### PR TITLE
RFC: Various changes to BFGSs

### DIFF
--- a/src/backtracking_line_search.jl
+++ b/src/backtracking_line_search.jl
@@ -3,9 +3,10 @@ using Base
 function backtracking_line_search(f::Function,
                                   g::Function,
                                   x::Vector,
-                                  dx::Vector,
-                                  alpha::Float64,
-                                  beta::Float64,
+                                  p::Vector,
+                                  c1::Float64,
+                                  c2::Float64,
+                                  rho::Float64,
                                   max_iterations::Int64)
   
   # Keep track of the number of iterations.
@@ -14,38 +15,28 @@ function backtracking_line_search(f::Function,
   # Store a copy of the function and gradient evaluted at x.
   f_x = f(x)
   g_x = g(x)
-  angle = (g_x' * dx)[1]
+  gxp = dot(g_x,p)
   
   # The default step-size is always 1.
-  t = 1
+  alpha = 1.0
   
+  while (dot(g(x + alpha*p),p) < c2 * gxp) & (alpha < 65536)
+    alpha *= 2
+  end
+
   # Keep coming closer to x until we find a point that is as good
   # as the gradient suggests we can do.
-  while f(x + t * dx) > f_x + alpha * t * angle
-    t = beta * t
-    
-    i = i + 1
-    
+  while f(x + alpha*p) > f_x + c1*alpha*gxp
+    alpha *= rho
+    i += 1    
     if i > max_iterations
-      error("Too many iterations in backtracking_line_search(alpha: $alpha, beta: $beta)")
+      error("Too many iterations in backtracking_line_search.")
     end
   end
-  
-  t
+  return alpha
 end
 
-function backtracking_line_search(f::Function,
-                                  g::Function,
-                                  x::Vector,
-                                  dx::Vector,
-                                  alpha::Float64,
-                                  beta::Float64)
-  backtracking_line_search(f, g, x, dx, alpha, beta, 1000)
-end
-
-function backtracking_line_search(f::Function,
-                                  g::Function,
-                                  x::Vector,
-                                  dx::Vector)
-  backtracking_line_search(f, g, x, dx, 0.1, 0.8, 1000)
-end
+backtracking_line_search(f::Function,
+                         g::Function,
+                         x::Vector,
+                         p::Vector) = backtracking_line_search(f, g, x, p, 1e-6, 0.9, 0.9, 1000)

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -7,20 +7,13 @@ function newton(f::Function,
                 tolerance::Float64,
                 max_iterations::Int64,
                 show_trace::Bool)
-  
+    
   # Maintain a record of the state.
   x = initial_x
-  
-  # Select a stepsize.
-  dx = -inv(h(x)) * g(x)
-  l2 = (g(x)' * inv(h(x)) * g(x))[1]
-  
+
   # Don't run forever.
   i = 0
-  
-  # Track convergence.
-  converged = false
-  
+
   # Show state of the system.
   if show_trace
     println("Iteration: $(i)")
@@ -31,24 +24,22 @@ function newton(f::Function,
     println()
   end
   
+  # Track convergence.
+  converged = false
+
+  # Select a stepsize.
+  dx = -h(x)\g(x)
+  l2 = dot(g(x), -dx)
+
   while !converged && i < max_iterations
     # Update the iteration counter.
-    i = i + 1
-    
-    # Select a search direction.
-    dx = -inv(h(x)) * g(x)
-    
+    i += 1
+
     # Select a step size.
     step_size = backtracking_line_search(f, g, x, dx)
-    
+
     # Update our position.
-    x = x + step_size * dx
-    
-    # Assess converged convergence.
-    l2 = (g(x)' * inv(h(x)) * g(x))[1]
-    if l2 / 2 <= tolerance
-      converged = true
-    end
+    x += step_size * dx
     
     # Show state of the system.
     if show_trace
@@ -59,14 +50,27 @@ function newton(f::Function,
       println("h(x): $(h(x))")
       println()
     end
+
+    # Select a search direction.
+    dx = -h(x)\g(x)
+
+    # Assess convergence.
+    l2 = dot(g(x),-dx)
+    if l2 / 2 <= tolerance
+      converged = true
+    end
   end
   
   OptimizationResults("Newton's Method", initial_x, x, f(x), i, converged)
 end
 
-function newton(f::Function,
-                g::Function,
-                h::Function,
-                initial_x::Vector)
-  newton(f, g, h, initial_x, 10e-16, 1000, false)
-end
+newton(f::Function,
+       g::Function,
+       h::Function,
+       initial_x::Vector,
+       show_trace::Bool) = newton(f, g, h, initial_x, 10e-16, 1000, show_trace)
+newton(f::Function,
+       g::Function,
+       h::Function,
+       initial_x::Vector) = newton(f, g, h, initial_x, false)
+


### PR DESCRIPTION
The backtracking line search now also checks the curvature condition and extends the search step if necessary. The first Wolfe's conditions now uses a much smaller value in the evaluation. This avoids many terminations due to no improvement in line search. No improvement in the line search now terminates the algorithm without nan freakout message. Some changes that should improve performance. E.g. use of \ instead of inv()\* in Newton's method. Change of convergence criteria in the BFGS algorithms to use Inf norm. Some cosmetic changes to the code and naming in line with Nocedal. Finally, changed trace to be more like Matlab by printing step size and convergence criteria.
