### PR TITLE
Adds Levenberg-Marquardt search method.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,2 @@
+Distributions
+Options

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -1,37 +1,41 @@
 module Optim
   using Base
 
-  export optimize
+  export optimize, curve_fit, estimate_errors
 
   # Types
-  load("Optim/src/types.jl")
+  include(find_in_path("Optim/src/types.jl"))
 
   # RNG Sources
-  load("Optim/src/rng.jl")
+  include(find_in_path("Optim/src/rng.jl"))
 
   # Grid Search
-  load("Optim/src/grid_search.jl")
+  include(find_in_path("Optim/src/grid_search.jl"))
 
   # Line Search Methods
-  load("Optim/src/backtracking_line_search.jl")
+  include(find_in_path("Optim/src/backtracking_line_search.jl"))
 
   # Gradient Descent Methods
-  load("Optim/src/naive_gradient_descent.jl")
-  load("Optim/src/gradient_descent.jl")
+  include(find_in_path("Optim/src/naive_gradient_descent.jl"))
+  include(find_in_path("Optim/src/gradient_descent.jl"))
 
   # Newton and Quasi-Newton Methods
-  load("Optim/src/newton.jl")
-  load("Optim/src/bfgs.jl")
-  load("Optim/src/l_bfgs.jl")
+  include(find_in_path("Optim/src/newton.jl"))
+  include(find_in_path("Optim/src/bfgs.jl"))
+  include(find_in_path("Optim/src/l_bfgs.jl"))
+
+  # trust region methods
+  include(find_in_path("Optim/src/levenberg_marquardt.jl"))
 
   # Heuristic Optimization Methods
-  load("Optim/src/nelder_mead.jl")
-  load("Optim/src/simulated_annealing.jl")
+  include(find_in_path("Optim/src/nelder_mead.jl"))
+  include(find_in_path("Optim/src/simulated_annealing.jl"))
 
   # End-User Facing Wrapper Functions
-  load("Optim/src/optimize.jl")
+  include(find_in_path("Optim/src/optimize.jl"))
+  include(find_in_path("Optim/src/curve_fit.jl"))
 
   # Finite-Difference Methods
-  load("Optim/src/estimate_gradient.jl")
-  load("Optim/src/derivative.jl")
+  include(find_in_path("Optim/src/estimate_gradient.jl"))
+  include(find_in_path("Optim/src/derivative.jl"))
 end

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -1,0 +1,47 @@
+require("Distributions")
+
+using Base
+using Distributions
+
+function curve_fit(model::Function, xpts, ydata, p0)
+	# assumes model(xpts, params...) = ydata + noise
+	# minimizes sum(ydata - f(xdata)).^2 using leastsq()
+
+	# construct the cost function
+	f(p) = model(xpts, p) - ydata
+	
+	# construct Jacobian function
+	g = estimate_jacobian(f)
+
+	results = levenberg_marquardt(f, g, p0)
+	p = results.minimum
+	residuals = model(xpts, p) - ydata
+	J = g(p)
+	return p, residuals, J
+end
+
+estimate_errors(p, residuals, J) = estimate_errors(p, residuals, J, .95)
+
+function estimate_errors(p, residuals, J, alpha)
+	# estimate_errors(p, residuals, J, alpha) computes (1-alpha) error estimates for the parameters from leastsq
+	#   p - parameters
+	#   residuals - vector of residuals
+	#   J - Jacobian
+	#   alpha - compute alpha percent confidence interval, (e.g. alpha=0.95 for 95% CI)
+
+	# mean square error is: standard square error / degrees of freedom
+	n, p = size(J)
+	mse = sse(residuals)/(n-p)
+
+	# compute the covariance matrix from the QR decomposition
+	Q,R = qr(J)
+	Rinv = inv(R)
+	covar = Rinv*Rinv*mse
+
+	# then the standard errors are given by the sqrt of the diagonal
+	std_error = sqrt(diag(covar))
+
+	# scale by quantile of the student-t distribution
+	dist = TDist(n-p)
+	std_error *= quantile(dist, alpha)
+end

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -1,8 +1,13 @@
 using Base
 
-# Functions for calculating numerical derivates. By exploiting Taylor series expansions higher order approximations of derivatives are calculated.
+# Functions for calculating numerical derivates. By exploiting Taylor series
+# expansions higher order approximations of derivatives are calculated.
 
-# The function "derivative" is the workhorse function for calculation fo derivatives. The function f must be of the form Float64->Float64 and hence x0 must also be a Float64. The argument h is the step size. Step sizes around 0.0001 seem to be optimal. The estimate can be either single sided or double sided where there latter is preferred but not always feasible.
+# The function "derivative" is the workhorse function for calculation of
+# derivatives. The function f must be of the form Float64->Float64 and hence
+# x0 must also be a Float64. The argument h is the step size. Step sizes
+# around 0.0001 seem to be optimal. The estimate can be either single sided
+# or double sided where there latter is preferred but not always feasible.
 function derivative(f::Function, x0::Float64, h::Float64, twoside::Bool)
 	if twoside
 		d = 4^5*(2^3*(f(x0+h) - f(x0-h)) - (f(x0+2h) - f(x0-2h))) - (2^3*(f(x0+4h) - f(x0-4h)) - (f(x0+8h) - f(x0-8h)))
@@ -18,20 +23,25 @@ derivative(f::Function, x0::Float64, h::Float64) = derivative(f, x0, h, true)
 derivative(f::Function, x0::Float64) = derivative(f, x0, 0.0001)
 derivative(f::Function) = x -> derivative(f, x)
 
-# The function "dirderivative" calculates directional derivatives in the direction v. The function supplied must have the form Array{Float64, 1} -> Float64
+# The function "dirderivative" calculates directional derivatives in the
+# direction v. The function supplied must have the form
+# Array{Float64, 1} -> Float64
 dirderivative(f::Function, v::Array{Float64, 1}, x0::Array{Float64, 1}, h::Float64, twoside::Bool) = derivative(t::Float64 -> f(x0 + v*t) / norm(v), 0.0, h, twoside)
 dirderivative(f::Function, v::Array{Float64, 1}, x0::Array{Float64, 1}, h::Float64) = dirderivative(f, v, x0, h, true)
 dirderivative(f::Function, v::Array{Float64, 1}, x0::Array{Float64, 1}, ) = derivative(f, v, x0, 0.0001)
 dirderivative(f::Function, v::Array{Float64, 1}) = x -> dirderivative(f, v, x)
 
-# Function for calculation of second order derivatives. This seem not more precise than applying derivative twice but it is more efficient. Eventually single sided option but will wait to see how often problems arise.
+# Function for calculation of second order derivatives. This seem not more
+# precise than applying derivative twice but it is more efficient. Eventually
+# single sided option but will wait to see how often problems arise.
 function derivative2(f::Function, x0::Float64, h::Float64)
 	f0 = f(x0)
 	d = 4^6*(2^4*(f(x0+h) + f(x0-h) - 2f0) - (f(x0+2h) + f(x0-2h) - 2f0)) - (2^4*(f(x0+4h) + f(x0-4h) - 2f0) - (f(x0+8h) + f(x0-8h) - 2f0))
 	return d / (3*2^6*(2^8-1)*h^2)
 end 
 
-# Function for calculation of a gradient. The function supplied must be of the form Array{Float64, 1} -> Float64
+# Function for calculation of a gradient. The function supplied must be of the
+# form Array{Float64, 1} -> Float64
 function gradient(f::Function, x::Array{Float64, 1}, h::Float64, twoside::Bool)
 	k = length(x)
 	ans = Array(Float64, k)
@@ -47,7 +57,9 @@ gradient(f::Function, x::Array{Float64, 1}) = gradient(f, x, 0.0001)
 gradient(f::Function, x::Array{Int64, 1}) = gradient(f, float(x))
 gradient(f::Function) = x::Array -> gradient(f, x)
 
-# Function for calculation of Jacobians. One method for functions of the form Float64 -> Array{Float64, 1} and one method for function of the form Array{Float64, 1} -> Array{Float64, 1}.
+# Function for calculation of Jacobians. One method for functions of the form
+# Float64 -> Array{Float64, 1} and one method for function of the form
+# Array{Float64, 1} -> Array{Float64, 1}.
 function jacobian(f::Function, x::Float64, h::Float64)
 	l = length(f(x))
 	ans = Array(Float64, l)
@@ -67,7 +79,8 @@ function jacobian(f::Function, x::Array{Float64, 1}, h::Float64)
 end
 jacobian(f::Function, x) = jacobian(f, x, 0.0001)
 
-# Function for calculation of the Hessian. Function argument must be of the form Array{Float64, 1} -> Float64
+# Function for calculation of the Hessian. Function argument must be of the
+# form Array{Float64, 1} -> Float64
 hessian(f::Function, x, h::Float64) = jacobian(gradient(f), x, h)
 hessian(f::Function, x) = hessian(f, x, 0.0001)
 hessian(f::Function) = x -> hessian(f, x)

--- a/src/estimate_gradient.jl
+++ b/src/estimate_gradient.jl
@@ -14,7 +14,7 @@ function estimate_gradient(f::Function)
   function g(x::Vector)    
     # How far do we move in each direction?
     # See Nodedal and Wright for motivation.
-    epsilon = sqrt(10e-16)
+    epsilon = sqrt(eps())
     
     # What is the dimension of x?
     n = length(x)
@@ -45,7 +45,7 @@ function estimate_gradient2(f::Function)
   function g(x::Vector)    
     # How far do we move in each direction?
     # See Nodedal and Wright for motivation.
-    epsilon = sqrt(10e-16)
+    epsilon = sqrt(eps())
     
     # What is the dimension of x?
     n = length(x)
@@ -63,6 +63,36 @@ function estimate_gradient2(f::Function)
     
     # Return the estimated gradient.
     diff
+  end
+  g
+end
+
+# Forward-differencing Jacobian
+function estimate_jacobian(f::Function)
+  # Construct and return a closure.
+  function g(x::Vector)    
+    # How far do we move in each direction?
+    # See Nodedal and Wright for motivation.
+    epsilon = sqrt(eps())
+    
+    # What is the dimension of x?
+    n = length(x)
+    
+    # Establish a baseline value of f(x).
+    f_x = f(x)
+
+	# initialize Jacobian matrix
+	J = zeros(length(f_x), n)
+    
+    # Iterate over each dimension of the gradient separately.
+    for j = 1:n
+      dx = zeros(n)
+      dx[j] = epsilon
+      J[:,j] = (f(x + dx) - f_x) / epsilon
+    end
+    
+    # Return the estimated Jacobian.
+    J
   end
   g
 end

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -1,0 +1,116 @@
+require("Options")
+using Base
+using OptionsMod
+
+# sse(x) gives the L2 norm of x
+sse(x) = (x'*x)[1]
+
+levenberg_marquardt(f::Function, g::Function, x0) = levenberg_marquardt(f::Function, g::Function, x0, @options)
+
+function levenberg_marquardt(f::Function, g::Function, x0, opts::Options)
+	# finds argmin sum(f(x).^2) using the Levenberg-Marquardt algorithm
+	#          x
+	# The function f should take an input vector of length n and return an output vector of length m
+	# The function g is the Jacobian of f, and should be an m x n matrix
+	# x0 is an initial guess for the solution
+	# fargs is a tuple of additional arguments to pass to f
+	# available options:
+	#   tolX - search tolerance in x
+	#   tolG - search tolerance in gradient
+	#   maxIter - maximum number of iterations
+	#   lambda - (inverse of) initial trust region radius
+	#   show_trace - print a status summary on each iteration if true
+	# returns: x, J
+	#   x - least squares solution for x
+	#   J - estimate of the Jacobian of f at x
+	n = size(x0,1)
+	@defaults opts tolX=1e-8 tolG=1e-12 maxIter=100*n lambda=100.0 show_trace=false
+
+	# other constants
+	const MAX_LAMBDA = 1e16 # maximum trust region radius
+	const MIN_LAMBDA = 1e-16 # minimum trust region radius
+	const MIN_STEP_QUALITY = 1e-3
+	const MIN_DIAGONAL = 1e-6 # lower bound on values of diagonal matrix used to regularize the trust region step
+
+	converged = false
+	iterCt = 0
+	x = x0
+	delta_x = copy(x0)
+
+	fcur = f(x)
+	residual = sse(fcur)
+	
+	# show state
+	if show_trace
+		println("Iteration: $(iterCt)")
+	    println("x: $(x)")
+	    println("||f(x)||^2: $(sse(fcur))")
+		println("lambda: $(lambda)")
+	    println()
+	end
+
+	while ( ~converged && iterCt < maxIter )
+		J = g(x)
+		# we want to solve:
+		#    argmin 0.5*||J(x)*delta_x + f(x)||^2 + lambda*||diagm(J'*J)*delta_x||^2
+		# Solving for the minimum gives:
+		#    (J'*J + lambda*DtD) * delta_x == -J^T * f(x), where DtD = diagm(sum(J.^2,1))
+		# Where we have used the equivalence: diagm(J'*J) = diagm(sum(J.^2, 1))
+		# It is additionally useful to bound the elements of DtD below to help
+		# prevent "parameter evaporation".
+		DtD = convert(Array{Float64,2}, diagm([max(x, MIN_DIAGONAL) for x in sum(J.^2,1)]))
+		delta_x = ( J'*J + sqrt(lambda)*DtD ) \ -J'*fcur
+		# if the linear assumption is valid, our new residual should be:
+		predicted_residual = sse(J*delta_x + fcur)
+		# check for numerical problems in solving for delta_x by ensuring that the predicted residual is smaller
+		# than the current residual
+		if predicted_residual > residual
+			error("Error solving for delta_x: predicted residual increase.")
+		end
+		# try the step and compute its quality
+		trial_f = f(x + delta_x)
+		trial_residual = sse(trial_f)
+		# step quality = residual change / predicted residual change
+		rho = (trial_residual - residual) / (predicted_residual - residual)
+
+		if rho > MIN_STEP_QUALITY
+			x += delta_x
+			fcur = trial_f
+			residual = trial_residual
+			# increase trust region radius
+			lambda = max(0.1*lambda, MIN_LAMBDA)
+		else
+			# decrease trust region radius
+			lambda = min(10*lambda, MAX_LAMBDA)
+		end
+		iterCt += 1
+
+		# show state
+		if show_trace
+			println("Iteration: $(iterCt)")
+		    println("x: $(x)")
+		    println("||f(x)||^2: $(sse(fcur))")
+		    println("g(x): $(J'*fcur)")
+			println("lambda: $(lambda)")
+		    println()
+		end
+
+		# check convergence criteria:
+		# 1. Small gradient: norm(J^T * fcur, Inf) < tolG
+		# 2. Small step size: norm(delta_x) < tolX
+		if norm(J' * fcur, Inf) < tolG
+			converged = true
+			println("Converged: gradient smaller than tolerance.")
+		elseif norm(delta_x) < tolX*(tolX + norm(x))
+			converged = true
+			println("Converged: Step size smaller than tolerance")
+		end
+	end
+
+	# give the user info about the stopping condition
+	if ~converged
+		println("Exceeded maximum number of iterations")
+	end
+
+	OptimizationResults("Levenberg-Marquardt", x0, x, sse(fcur), iterCt, converged)
+end

--- a/tests/curve_fit.jl
+++ b/tests/curve_fit.jl
@@ -1,0 +1,19 @@
+require("Optim")
+using Optim
+
+# fitting noisy data to an exponential model
+model(xpts, p) = p[1]*exp(-xpts.*p[2])
+
+# some example data
+srand(12345)
+xpts = linspace(0,10,20)
+data = model(xpts, [1.0 2.0]) + 0.01*randn(length(xpts))
+
+beta, r, J = curve_fit(model, xpts, data, [0.5, 0.5])
+println("Found beta: $beta")
+@assert norm(beta - [1.0, 2.0]) < 0.05
+
+# can also get error estimates on the fit parameters
+errors = estimate_errors(beta, r, J)
+
+println("Estimated errors: $errors")

--- a/tests/levenberg_marquardt.jl
+++ b/tests/levenberg_marquardt.jl
@@ -1,0 +1,14 @@
+require("Optim")
+using Optim
+
+function f(x)
+  [x[1], 2.0 - x[2]]
+end
+function g(x)
+  [1.0 0.0; 0.0 -1.0]
+end
+
+initial_x = [100.0, 100.0]
+
+results = Optim.levenberg_marquardt(f, g, initial_x)
+@assert norm(results.minimum - [0.0, 2.0]) < 0.01


### PR DESCRIPTION
Also adds top-level curve_fit() and estimate_errors() methods. Addresses issue #7.

Still need to make some decisions about how to integrate this into the
optimize() method. My main concern is that the Levenberg-Marquardt method
expects a different form for the function F(x). With the other methods you
direclty pass the cost function to mimize, e.g.:
   F(x) = Sum_i |f_i(x)|^2
For this minimizer, you instead pass the vector [f_i(x)..].

For this reason, I wonder if there ought to be a separate leastsq(...) interface
for optimizers that expect this sort of signature.
