### PR TITLE
keyword arguments for curve_fit, small fixes to levenberg_marquardt

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -1,4 +1,4 @@
-function curve_fit(model::Function, xpts, ydata, p0)
+function curve_fit(model::Function, xpts, ydata, p0; kwargs...)
 	# assumes model(xpts, params...) = ydata + noise
 	# minimizes F(p) = sum(ydata - f(xdata)).^2 using leastsq()
 	# returns p, f(p), g(p) where
@@ -12,7 +12,7 @@ function curve_fit(model::Function, xpts, ydata, p0)
 	# construct Jacobian function
 	g = Calculus.jacobian(f)
 
-	results = levenberg_marquardt(f, g, p0)
+	results = levenberg_marquardt(f, g, p0; kwargs...)
 	p = results.minimum
 	return p, f(p), g(p)
 end

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -39,7 +39,7 @@ function levenberg_marquardt(f::Function, g::Function, x0; tolX=1e-8, tolG=1e-12
 	tr = OptimizationTrace()
 	if show_trace
 		d = {"lambda" => lambda}
-		os = OptimizationState(x, sse(fcur), iterCt, d)
+		os = OptimizationState(iterCt, sse(fcur), NaN, d)
 		push!(tr, os)
 		println(os)
 	end
@@ -60,7 +60,7 @@ function levenberg_marquardt(f::Function, g::Function, x0; tolX=1e-8, tolG=1e-12
 		predicted_residual = sse(J*delta_x + fcur)
 		# check for numerical problems in solving for delta_x by ensuring that the predicted residual is smaller
 		# than the current residual
-		if predicted_residual > residual
+		if predicted_residual > residual + max(eps(predicted_residual),eps(residual))
 			error("Error solving for delta_x: predicted residual increase.")
 		end
 		# try the step and compute its quality
@@ -84,8 +84,9 @@ function levenberg_marquardt(f::Function, g::Function, x0; tolX=1e-8, tolG=1e-12
 
 		# show state
 		if show_trace
-			d = {"g(x)" => norm(J'*fcur, Inf), "dx" => delta_x, "lambda" => lambda}
-			os = OptimizationState(x, sse(fcur), iterCt, d)
+			gradnorm = norm(J'*fcur, Inf)
+			d = {"g(x)" => gradnorm, "dx" => delta_x, "lambda" => lambda}
+			os = OptimizationState(iterCt, sse(fcur), gradnorm, d)
 			push!(tr, os)
 			println(os)
 		end


### PR DESCRIPTION
The curve_fit change just makes it easy to set the levenberg-marquardt options.

The type definition of OptimizationState did not match the code here anymore, so setting show_trace = true would throw type errors.

Finally, after relaxing the check for decrease of residual a bit, some models which would throw an error previously, now converge to something close to what I'd expect theoretically.
