### PR TITLE
Relax checks on residuals in curve fitting

### DIFF
--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -105,7 +105,7 @@ function levenberg_marquardt(f::Function, g::Function, x0; tolX=1e-8, tolG=1e-12
 
 	# give the user info about the stopping condition
 	if ~converged
-		println("Exceeded maximum number of iterations")
+		warn("Exceeded maximum number of iterations ($maxIter) without converging")
 	end
 
 	MultivariateOptimizationResults("Levenberg-Marquardt", x0, x, sse(fcur), iterCt, !converged, false, 0.0, false, 0.0, converged, tolG, tr, f_calls, g_calls)


### PR DESCRIPTION
When running a large number of curve fits, often one of them would trigger this error.  Changed to a warning instead, to allow the fits to run to completion.

Not sure if the factor of two is desired-- I split the commits so you can always cherry-pick the first one.
