### PR TITLE
added optional initial bfgs inverse hessian

### DIFF
--- a/src/bfgs.jl
+++ b/src/bfgs.jl
@@ -106,7 +106,6 @@ function bfgs{T}(d::Union(DifferentiableFunction,
 
         # Refresh the line search cache
         dphi0 = dot(gr, s)
-        
         # If invH is not positive definite, reset it to I
         if dphi0 > 0.0
             copy!(invH, I)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -1,5 +1,5 @@
 function optimize(d::TwiceDifferentiableFunction,
-                  initial_x::Array;
+                  initial_x::Vector;
                   method::Symbol = :l_bfgs,
                   xtol::Real = 1e-32,
                   ftol::Real = 1e-8,
@@ -92,7 +92,7 @@ function optimize(d::TwiceDifferentiableFunction,
 end
 
 function optimize(d::DifferentiableFunction,
-                  initial_x::Array;
+                  initial_x::Vector;
                   method::Symbol = :l_bfgs,
                   xtol::Real = 1e-32,
                   ftol::Real = 1e-8,
@@ -176,7 +176,7 @@ end
 function optimize(f::Function,
                   g!::Function,
                   h!::Function,
-                  initial_x::Array;
+                  initial_x::Vector;
                   method::Symbol = :newton,
                   xtol::Real = 1e-32,
                   ftol::Real = 1e-8,
@@ -291,7 +291,7 @@ end
 
 function optimize(f::Function,
                   g!::Function,
-                  initial_x::Array;
+                  initial_x::Vector;
                   method::Symbol = :l_bfgs,
                   xtol::Real = 1e-32,
                   ftol::Real = 1e-8,
@@ -393,7 +393,7 @@ function optimize(f::Function,
 end
 
 function optimize(f::Function,
-                  initial_x::Array;
+                  initial_x::Vector;
                   method::Symbol = :nelder_mead,
                   xtol::Real = 1e-32,
                   ftol::Real = 1e-8,


### PR DESCRIPTION
This is my first attempt at a pull-request - a really simple additional option for the BFGS method to accept an initial inverse hessian.  I need this feature for a problem in which the standard identity matrix generates errors in the line search routine. 
