### PR TITLE
Constrained optimization episode 2: revenge of the slack variables

### DIFF
--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -19,6 +19,7 @@ module Optim
     export optimize,
            isfeasible,
            isinterior,
+           nconstraints,
            DifferentiableFunction,
            TwiceDifferentiableFunction,
            DifferentiableConstraintsFunction,
@@ -110,8 +111,9 @@ module Optim
     include("utilities/trace.jl")
 
     # Examples for testing
-    include(joinpath("problems", "unconstrained.jl"))
+    include(joinpath("problems", "multivariate.jl"))
     include(joinpath("problems", "univariate.jl"))
+    using .MultivariateProblems
 
     cgdescent(args...) = error("API has changed. Please use cg.")
 end

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -17,6 +17,8 @@ module Optim
            Base.setindex!
 
     export optimize,
+           isfeasible,
+           isinterior,
            DifferentiableFunction,
            TwiceDifferentiableFunction,
            DifferentiableConstraintsFunction,

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -34,6 +34,7 @@ module Optim
            Fminbox,
            GoldenSection,
            GradientDescent,
+           IPNewton,
            LBFGS,
            MomentumGradientDescent,
            NelderMead,

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -19,6 +19,8 @@ module Optim
     export optimize,
            DifferentiableFunction,
            TwiceDifferentiableFunction,
+           DifferentiableConstraintsFunction,
+           TwiceDifferentiableConstraintsFunction,
            OptimizationOptions,
            OptimizationState,
            OptimizationTrace,

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -78,9 +78,9 @@ module Optim
 
     # Constrained optimization
     include("fminbox.jl")
+    include("iplinesearch.jl")
     include("interior.jl")
     include("ipnewton.jl")
-    include("iplinesearch.jl")
 
     # trust region methods
     include("levenberg_marquardt.jl")

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -78,6 +78,7 @@ module Optim
 
     # Constrained optimization
     include("fminbox.jl")
+    include("interior.jl")
 
     # trust region methods
     include("levenberg_marquardt.jl")

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -80,6 +80,7 @@ module Optim
     include("fminbox.jl")
     include("interior.jl")
     include("ipnewton.jl")
+    include("iplinesearch.jl")
 
     # trust region methods
     include("levenberg_marquardt.jl")

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -79,6 +79,7 @@ module Optim
     # Constrained optimization
     include("fminbox.jl")
     include("interior.jl")
+    include("ipnewton.jl")
 
     # trust region methods
     include("levenberg_marquardt.jl")

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -23,3 +23,9 @@ end
 @deprecate interpolating_linesearch! LineSearches.strongwolfe!
 @deprecate backtracking_linesearch! LineSearches.backtracking!
 @deprecate interpbacktracking_linesearch! LineSearches.interpbacktracking!
+
+if VERSION >= v"0.5.0"
+    view5(A, i, j) = view(A, i, j)
+else
+    view5(A, i, j) = A[i,j]
+end

--- a/src/interior.jl
+++ b/src/interior.jl
@@ -69,7 +69,6 @@ Base.copy(bstate::BarrierStateVars) =
                      copy(bstate.λxE),
                      copy(bstate.λcE))
 
-
 function Base.fill!(b::BarrierStateVars, val)
     fill!(b.slack_x, val)
     fill!(b.slack_c, val)
@@ -79,6 +78,14 @@ function Base.fill!(b::BarrierStateVars, val)
     fill!(b.λcE, val)
     b
 end
+
+Base.convert{T}(::Type{BarrierStateVars{T}}, bstate::BarrierStateVars) =
+    BarrierStateVars(convert(Array{T}, bstate.slack_x),
+                     convert(Array{T}, bstate.slack_c),
+                     convert(Array{T}, bstate.λx),
+                     convert(Array{T}, bstate.λc),
+                     convert(Array{T}, bstate.λxE),
+                     convert(Array{T}, bstate.λcE))
 
 Base.eltype{T}(::Type{BarrierStateVars{T}}) = T
 Base.eltype(sv::BarrierStateVars) = eltype(typeof(sv))
@@ -127,6 +134,9 @@ immutable BarrierLineSearch{T}
     c::Vector{T}                  # value of constraints-functions at trial point
     bstate::BarrierStateVars{T}   # trial point for slack and λ variables
 end
+Base.convert{T}(::Type{BarrierLineSearch{T}}, bsl::BarrierLineSearch) =
+    BarrierLineSearch(convert(Vector{T}, bsl.c),
+                      convert(BarrierStateVars{T}, bsl.bstate))
 
 """
     BarrierLineSearchGrad{T}
@@ -139,6 +149,12 @@ immutable BarrierLineSearchGrad{T}
     bstate::BarrierStateVars{T}   # trial point for slack and λ variables
     bgrad::BarrierStateVars{T}    # trial point's gradient
 end
+Base.convert{T}(::Type{BarrierLineSearchGrad{T}}, bsl::BarrierLineSearchGrad) =
+    BarrierLineSearchGrad(convert(Vector{T}, bsl.c),
+                          convert(Matrix{T}, bsl.J),
+                          convert(BarrierStateVars{T}, bsl.bstate),
+                          convert(BarrierStateVars{T}, bsl.bgrad))
+
 
 function ls_update!(out::BarrierStateVars, base::BarrierStateVars, step::BarrierStateVars, α, αI)
     ls_update!(out.slack_x, base.slack_x, step.slack_x, α)

--- a/src/interior.jl
+++ b/src/interior.jl
@@ -61,6 +61,17 @@ Base.similar(bstate::BarrierStateVars) =
                      similar(bstate.λc),
                      similar(bstate.λcE))
 
+Base.copy(bstate::BarrierStateVars) =
+    BarrierStateVars(copy(bstate.slack_x),
+                     copy(bstate.slack_c),
+                     copy(bstate.active_x),
+                     copy(bstate.active_c),
+                     copy(bstate.λxE),
+                     copy(bstate.λx),
+                     copy(bstate.λc),
+                     copy(bstate.λcE))
+
+
 function Base.fill!(b::BarrierStateVars, val)
     fill!(b.slack_x, val)
     fill!(b.slack_c, val)
@@ -96,6 +107,14 @@ const bsv_seed = sizeof(UInt) == 64 ? 0x145b788192d1cde3 : 0x766a2810
 Base.hash(b::BarrierStateVars, u::UInt) =
     hash(b.λcE, hash(b.λc, hash(b.λx, hash(b.λxE, hash(b.slack_c, hash(b.slack_x, u+bsv_seed))))))
 
+function Base.dot(v::BarrierStateVars, w::BarrierStateVars)
+    dot(v.slack_x,w.slack_x) +
+        dot(v.slack_c, w.slack_c) +
+        dot(v.λxE, w.λxE) +
+        dot(v.λx, w.λx) +
+        dot(v.λc, w.λc) +
+        dot(v.λcE, w.λcE)
+end
 
 """
     BarrierLineSearch{T}

--- a/src/interior.jl
+++ b/src/interior.jl
@@ -668,7 +668,12 @@ function isfeasible(bounds::ConstraintBounds, x, c)
     isf
 end
 isfeasible(constraints, state::AbstractBarrierState) = isfeasible(constraints, state.x, state.constraints_c)
-isfeasible(constraints, x) = isfeasible(constraints, x, constraints.c!(x, Array{eltype(x)}(constraints.bounds.nc)))
+function isfeasible(constraints, x)
+    # don't assume c! returns c (which means this is a little more awkward)
+    c = Array{eltype(x)}(constraints.bounds.nc)
+    constraints.c!(x, c)
+    isfeasible(constraints, x, c)
+end
 isfeasible(constraints::AbstractConstraintsFunction, x, c) = isfeasible(constraints.bounds, x, c)
 
 """
@@ -700,7 +705,11 @@ function isinterior(bounds::ConstraintBounds, x, c)
     isi
 end
 isinterior(constraints, state::AbstractBarrierState) = isinterior(constraints, state.x, state.constraints_c)
-isinterior(constraints, x) = isinterior(constraints, x, constraints.c!(x, Array{eltype(x)}(constraints.bounds.nc)))
+function isinterior(constraints, x)
+    c = Array{eltype(x)}(constraints.bounds.nc)
+    constraints.c!(x, c)
+    isinterior(constraints, x, c)
+end
 isinterior(constraints::AbstractConstraintsFunction, x, c) = isinterior(constraints.bounds, x, c)
 
 ## Utilities for representing total state as single vector

--- a/src/interior.jl
+++ b/src/interior.jl
@@ -386,7 +386,7 @@ function _lagrangian_linefunc(α, d, constraints, state)
     b_ls = state.b_ls
     ls_update!(state.x_ls, state.x, state.s, α)
     ls_update!(b_ls.bstate, state.bstate, state.bstep, α)
-    constraints.c!(state.x, b_ls.c)
+    constraints.c!(state.x_ls, b_ls.c)
     lagrangian(d, constraints.bounds, state.x_ls, b_ls.c, b_ls.bstate, state.μ)
 end
 

--- a/src/interior.jl
+++ b/src/interior.jl
@@ -17,7 +17,7 @@ end
 # not matching the equality constraints.  So we allow them to
 # differ, and require that the algorithm can cope with it.
 
-function (::Type{BarrierStateVars{T}}){T}(bounds::ConstraintBounds)
+@compat function (::Type{BarrierStateVars{T}}){T}(bounds::ConstraintBounds)
     slack_x = Array{T}(length(bounds.ineqx))
     slack_c = Array{T}(length(bounds.ineqc))
     λxE = Array{T}(length(bounds.eqx))
@@ -278,7 +278,7 @@ end
 function equality_grad_var!(gs, gx, ineq, σ, λ, J)
     gs[:] = gs + λ
     if !isempty(ineq)
-        gx[:] = gx - view(J, ineq, :)'*(λ.*σ)
+        gx[:] = gx - view5(J, ineq, :)'*(λ.*σ)
     end
     nothing
 end
@@ -293,7 +293,7 @@ end
 # violations of v = target
 function equality_grad_var!(gx, idx, λ, J)
     if !isempty(idx)
-        gx[:] = gx - view(J, idx, :)'*λ
+        gx[:] = gx - view5(J, idx, :)'*λ
     end
     nothing
 end
@@ -342,4 +342,10 @@ function unpack_vec!(x, vec::Vector, k::Int)
         x[i] = vec[k+=1]
     end
     k
+end
+
+if VERSION >= v"0.5.0"
+    view5(A, i, j) = view(A, i, j)
+else
+    view5(A, i, j) = A[i,j]
 end

--- a/src/interior.jl
+++ b/src/interior.jl
@@ -1,0 +1,345 @@
+abstract AbstractBarrierState
+
+# These are used not only for the current state, but also for the step and the gradient
+immutable BarrierStateVars{T}
+    slack_x::Vector{T}    # values of slack variables for x
+    slack_c::Vector{T}    # values of slack variables for c
+    λxE::Vector{T}        # λ for equality constraints on x
+    λx::Vector{T}         # λ for equality constraints on slack_x
+    λc::Vector{T}         # λ for equality constraints on slack_c
+    λcE::Vector{T}        # λ for linear/nonlinear equality constraints
+end
+# Note on λxE:
+# We could just set equality-constrained variables to their
+# constraint values at the beginning of optimization, but this
+# might make the initial guess infeasible in terms of its
+# inequality constraints. This would be a much bigger problem than
+# not matching the equality constraints.  So we allow them to
+# differ, and require that the algorithm can cope with it.
+
+function (::Type{BarrierStateVars{T}}){T}(bounds::ConstraintBounds)
+    slack_x = Array{T}(length(bounds.ineqx))
+    slack_c = Array{T}(length(bounds.ineqc))
+    λxE = Array{T}(length(bounds.eqx))
+    λx = similar(slack_x)
+    λc = similar(slack_c)
+    λcE = Array{T}(length(bounds.eqc))
+    sv = BarrierStateVars{T}(slack_x, slack_c, λxE, λx, λc, λcE)
+end
+BarrierStateVars{T}(bounds::ConstraintBounds{T}) = BarrierStateVars{T}(bounds)
+
+function BarrierStateVars{T}(bounds::ConstraintBounds{T}, x)
+    sv = BarrierStateVars(bounds)
+    setslack!(sv.slack_x, x, bounds.ineqx, bounds.σx, bounds.bx)
+    sv
+end
+function BarrierStateVars{T}(bounds::ConstraintBounds{T}, x, c)
+    sv = BarrierStateVars(bounds)
+    setslack!(sv.slack_x, x, bounds.ineqx, bounds.σx, bounds.bx)
+    setslack!(sv.slack_c, c, bounds.ineqc, bounds.σc, bounds.bc)
+    sv
+end
+function setslack!(slack, v, ineq, σ, b)
+    for i = 1:length(ineq)
+        slack[i] = σ[i]*(v[ineq[i]]-b[i])
+    end
+    slack
+end
+
+Base.similar(bstate::BarrierStateVars) =
+    BarrierStateVars(similar(bstate.slack_x),
+                     similar(bstate.slack_c),
+                     similar(bstate.λxE),
+                     similar(bstate.λx),
+                     similar(bstate.λc),
+                     similar(bstate.λcE))
+
+function Base.fill!(b::BarrierStateVars, val)
+    fill!(b.slack_x, val)
+    fill!(b.slack_c, val)
+    fill!(b.λxE, val)
+    fill!(b.λx, val)
+    fill!(b.λc, val)
+    fill!(b.λcE, val)
+    b
+end
+
+Base.eltype{T}(::Type{BarrierStateVars{T}}) = T
+Base.eltype(sv::BarrierStateVars) = eltype(typeof(sv))
+
+function Base.show(io::IO, b::BarrierStateVars)
+    print(io, "BarrierStateVars{$(eltype(b))}:")
+    for fn in fieldnames(b)
+        print(io, "\n  $fn: ")
+        show(io, getfield(b, fn))
+    end
+end
+
+
+## Computation of the Lagrangian and its gradient
+# This is in a parametrization that is also useful during linesearch
+
+function lagrangian(d, bounds::ConstraintBounds, x, c, bstate::BarrierStateVars, μ, method)
+    f_x = d.f(x)
+    L_xsλ = f_x + barrier_value(bounds, x, bstate, μ) +
+            equality_violation(bounds, x, c, bstate)
+    f_x, L_xsλ
+end
+
+function lagrangian_g!(gx, bgrad, d, bounds::ConstraintBounds, x, c, J, bstate::BarrierStateVars, μ, method)
+    fill!(bgrad, 0)
+    d.g!(x, gx)
+    barrier_grad!(gx, bgrad, bounds, x, bstate, μ)
+    equality_grad!(gx, bgrad, bounds, x, c, J, bstate)
+    nothing
+end
+
+function lagrangian_fg!(gx, bgrad, d, bounds::ConstraintBounds, x, c, J, bstate::BarrierStateVars, μ, method)
+    fill!(bgrad, 0)
+    f_x = d.fg!(x, gx)
+    L_xsλ = f_x + barrier_value(bounds, x, bstate, μ) +
+        equality_violation(bounds, x, c, bstate)
+    barrier_grad!(gx, bgrad, bounds, x, bstate, μ)
+    equality_grad!(gx, bgrad, bounds, x, c, J, bstate)
+    f_x, L_xsλ
+end
+
+## Computation of Lagrangian and derivatives when passing all parameters as a single vector
+function lagrangian_vec(p, d, bounds::ConstraintBounds, x, c::AbstractArray, bstate::BarrierStateVars, μ, method)
+    unpack_vec!(x, bstate, p)
+    f_x, L_xsλ = lagrangian(d, bounds, x, c, bstate, μ, method)
+    L_xsλ
+end
+function lagrangian_vec(p, d, bounds::ConstraintBounds, x, c::Function, bstate::BarrierStateVars, μ, method)
+    # Use this version when using automatic differentiation
+    unpack_vec!(x, bstate, p)
+    f_x, L_xsλ = lagrangian(d, bounds, x, c(x), bstate, μ, method)
+    L_xsλ
+end
+function lagrangian_fgvec!(p, storage, gx, bgrad, d, bounds::ConstraintBounds, x, c, J, bstate::BarrierStateVars, μ, method)
+    unpack_vec!(x, bstate, p)
+    f_x, L_xsλ = lagrangian_fg!(gx, bgrad, d, bounds, x, c, J, bstate, μ, method)
+    pack_vec!(storage, gx, bgrad)
+    L_xsλ
+end
+
+## Computation of Lagrangian terms: barrier penalty
+"""
+    barrier_value(constraints, state) -> val
+    barrier_value(bounds, x, sx, sc, μ) -> val
+
+Compute the value of the barrier penalty at the current `state`, or at
+a position (`x`,`sx`,`sc`), where `x` is the current position, `sx`
+are the coordinate slack variables, and `sc` are the linear/nonlinear
+slack variables. `bounds` holds the parsed bounds.
+"""
+function barrier_value(bounds::ConstraintBounds, x, sx, sc, μ)
+    # bμ is the coefficient of μ in the barrier penalty
+    bμ = _bv(x, bounds.iz, bounds.σz) +      # coords constrained by 0
+         _bv(sx) +  # coords with other bounds
+         _bv(sc)    # linear/nonlinear constr.
+    μ*bμ
+end
+barrier_value(bounds::ConstraintBounds, x, bstate::BarrierStateVars, μ) =
+    barrier_value(bounds, x, bstate.slack_x, bstate.slack_c, μ)
+barrier_value(bounds::ConstraintBounds, state) =
+    barrier_value(bounds, state.x, state.bstate.slack_x, state.bstate.slack_c, state.μ)
+barrier_value(constraints::AbstractConstraintsFunction, state) =
+    barrier_value(constraints.bounds, state)
+
+# don't call this barrier_value because it lacks μ
+function _bv(v, idx, σ)
+    ret = loginf(one(eltype(σ))*one(eltype(v)))
+    for (i,iv) in enumerate(idx)
+        ret += loginf(σ[i]*v[iv])
+    end
+    -ret
+end
+
+_bv(v) = isempty(v) ? loginf(one(eltype(v))) : -sum(loginf, v)
+
+loginf(δ) = δ > 0 ? log(δ) : -oftype(δ, Inf)
+
+"""
+    barrier_grad!(gx, bgrad, bounds, x, bstate, μ)
+    barrier_grad!(gx, gsx, gsc, bounds, x, sx, sc, μ)
+
+Compute the gradient of the barrier penalty at (`x`,`sx`,`sc`), where
+`x` is the current position, `sx` are the coordinate slack variables,
+and `sc` are the linear/nonlinear slack
+variables. `bounds::ConstraintBounds` holds the parsed bounds.
+
+The result is *added* to `gx`, `gsx`, and `gsc`, so these vectors
+need to be initialized appropriately.
+"""
+function barrier_grad!(gx, gsx, gsc, bounds::ConstraintBounds, x, sx, sc, μ)
+    barrier_grad!(view(gx, bounds.iz), view(x, bounds.iz), μ)
+    barrier_grad!(gsx, sx, μ)
+    barrier_grad!(gsc, sc, μ)
+    nothing
+end
+barrier_grad!(gx, bgrad, bounds::ConstraintBounds, x, bstate, μ) =
+    barrier_grad!(gx, bgrad.slack_x, bgrad.slack_c, bounds, x, bstate.slack_x, bstate.slack_c, μ)
+
+function barrier_grad!(out, v, μ)
+    for i = 1:length(out)
+        out[i] -= μ/v[i]
+    end
+    nothing
+end
+
+
+## Computation of Lagrangian terms: equality constraints penalty
+
+"""
+    equality_violation([f=identity], bounds, x, c, bstate) -> val
+    equality_violation([f=identity], bounds, x, c, sx, sc, λxE, λx, λc, λcE) -> val
+
+Compute the sum of `f(v_i)`, where `v_i = λ_i*(target - observed)`
+measures the difference between the current state and the
+equality-constrained state. `bounds::ConstraintBounds` holds the
+parsed bounds. `x` is the current position, `sx` are the coordinate
+slack variables, and `sc` are the linear/nonlinear slack
+variables. `c` holds the values of the linear-nonlinear constraints,
+and the λ arguments hold the Lagrange multipliers for `x`, `sx`, `sc`, and
+`c` respectively.
+"""
+function equality_violation(f, bounds::ConstraintBounds, x, c, sx, sc, λxE, λx, λc, λcE)
+    ev = equality_violation(f, x, bounds.valx, bounds.eqx, λxE) +
+         equality_violation(f, sx, x, bounds.ineqx, bounds.σx, bounds.bx, λx) +
+         equality_violation(f, sc, c, bounds.ineqc, bounds.σc, bounds.bc, λc) +
+         equality_violation(f, c, bounds.valc, bounds.eqc, λcE)
+end
+equality_violation(bounds::ConstraintBounds, x, c, sx, sc, λxE, λx, λc, λcE) =
+    equality_violation(identity, bounds, x, c, sx, sc, λxE, λx, λc, λcE)
+function equality_violation(f, bounds::ConstraintBounds, x, c, bstate::BarrierStateVars)
+    equality_violation(f, bounds, x, c,
+                       bstate.slack_x, bstate.slack_c, bstate.λxE, bstate.λx, bstate.λc, bstate.λcE)
+end
+equality_violation(bounds::ConstraintBounds, x, c, bstate::BarrierStateVars) =
+    equality_violation(identity, bounds, x, c, bstate)
+equality_violation(f, bounds::ConstraintBounds, state::AbstractBarrierState) =
+    equality_violation(f, bounds, state.x, state.constr_c, state.bstate)
+equality_violation(bounds::ConstraintBounds, state::AbstractBarrierState) =
+    equality_violation(identity, bounds, state)
+equality_violation(f, constraints::AbstractConstraintsFunction, state::AbstractBarrierState) =
+    equality_violation(f, constraints.bounds, state)
+equality_violation(constraints::AbstractConstraintsFunction, state::AbstractBarrierState) =
+    equality_violation(constraints.bounds, state)
+
+# violations of s = σ*(v-b)
+function equality_violation(f, s, v, ineq, σ, b, λ)
+    ret = f(zero(eltype(λ))*(zero(eltype(s))-zero(eltype(σ))*(zero(eltype(v))-zero(eltype(b)))))
+    for (i,iv) in enumerate(ineq)
+        ret += f(λ[i]*(s[i] - σ[i]*(v[iv]-b[i])))
+    end
+    ret
+end
+
+# violations of v = target
+function equality_violation(f, v, target, idx, λ)
+    ret = f(zero(eltype(λ))*(zero(eltype(v))-zero(eltype(target))))
+    for (i,iv) in enumerate(idx)
+        ret += f(λ[i]*(target[i] - v[iv]))
+    end
+    ret
+end
+
+"""
+    equality_grad!(gx, gbstate, bounds, x, c, J, bstate)
+
+Compute the gradient of `equality_violation`, storing the result in `gx` (an array) and `gbstate::BarrierStateVars`.
+"""
+function equality_grad!(gx, gsx, gsc, gλxE, gλx, gλc, gλcE, bounds::ConstraintBounds, x, c, J, sx, sc, λxE, λx, λc, λcE)
+    gx[bounds.eqx] = gx[bounds.eqx] - λxE
+    equality_grad_var!(gsx, gx, bounds.ineqx, bounds.σx, λx)
+    equality_grad_var!(gsc, gx, bounds.ineqc, bounds.σc, λc, J)
+    equality_grad_var!(gx, bounds.eqc, λcE, J)
+    equality_grad_λ!(gλxE, x, bounds.valx, bounds.eqx)
+    equality_grad_λ!(gλx, sx, x, bounds.ineqx, bounds.σx, bounds.bx)
+    equality_grad_λ!(gλc, sc, c, bounds.ineqc, bounds.σc, bounds.bc)
+    equality_grad_λ!(gλcE, c, bounds.valc, bounds.eqc)
+end
+equality_grad!(gx, gb::BarrierStateVars, bounds::ConstraintBounds, x, c, J, b::BarrierStateVars) =
+    equality_grad!(gx, gb.slack_x, gb.slack_c, gb.λxE, gb.λx, gb.λc, gb.λcE,
+                   bounds, x, c, J,
+                   b.slack_x, b.slack_c, b.λxE, b.λx, b.λc, b.λcE)
+
+# violations of s = σ*(x-b)
+function equality_grad_var!(gs, gx, ineq, σ, λ)
+    for (i,ix) in enumerate(ineq)
+        λi = λ[i]
+        gs[i] += λi
+        gx[ix] -= λi*σ[i]
+    end
+    nothing
+end
+
+function equality_grad_var!(gs, gx, ineq, σ, λ, J)
+    gs[:] = gs + λ
+    if !isempty(ineq)
+        gx[:] = gx - view(J, ineq, :)'*(λ.*σ)
+    end
+    nothing
+end
+
+function equality_grad_λ!(gλ, s, v, ineq, σ, b)
+    for (i,iv) in enumerate(ineq)
+        gλ[i] += s[i] - σ[i]*(v[iv]-b[i])
+    end
+    nothing
+end
+
+# violations of v = target
+function equality_grad_var!(gx, idx, λ, J)
+    if !isempty(idx)
+        gx[:] = gx - view(J, idx, :)'*λ
+    end
+    nothing
+end
+
+function equality_grad_λ!(gλ, v, target, idx)
+    for (i,iv) in enumerate(idx)
+        gλ[i] += target[i] - v[iv]
+    end
+    nothing
+end
+
+## Utilities for representing total state as single vector
+function pack_vec(x, b::BarrierStateVars)
+    n = length(x)
+    for fn in fieldnames(b)
+        n += length(getfield(b, fn))
+    end
+    vec = Array{eltype(x)}(n)
+    pack_vec!(vec, x, b)
+end
+
+function pack_vec!(vec, x, b::BarrierStateVars)
+    k = pack_vec!(vec, x, 0)
+    for fn in fieldnames(b)
+        k = pack_vec!(vec, getfield(b, fn), k)
+    end
+    k == length(vec) || throw(DimensionMismatch("vec should have length $k, got $(length(vec))"))
+    vec
+end
+function pack_vec!(vec, x, k::Int)
+    for i = 1:length(x)
+        vec[k+=1] = x[i]
+    end
+    k
+end
+function unpack_vec!(x, b::BarrierStateVars, vec::Vector)
+    k = unpack_vec!(x, vec, 0)
+    for fn in fieldnames(b)
+        k = unpack_vec!(getfield(b, fn), vec, k)
+    end
+    k == length(vec) || throw(DimensionMismatch("vec should have length $k, got $(length(vec))"))
+    x, b
+end
+function unpack_vec!(x, vec::Vector, k::Int)
+    for i = 1:length(x)
+        x[i] = vec[k+=1]
+    end
+    k
+end

--- a/src/interior.jl
+++ b/src/interior.jl
@@ -201,7 +201,7 @@ function optimize{T, M<:ConstrainedOptimizer}(d::AbstractOptimFunction, constrai
         iteration += 1
         iterationμ += 1
 
-        update_state!(d, constraints, state, method) && break # it returns true if it's forced by something in update! to stop (eg dx_dg == 0.0 in BFGS)
+        update_state!(d, constraints, state, method, options) && break # it returns true if it's forced by something in update! to stop (eg dx_dg == 0.0 in BFGS)
         update_asneeded_fg!(d, constraints, state, method)
         x_converged, f_converged,
         g_converged, converged = assess_convergence(state, options)

--- a/src/interior.jl
+++ b/src/interior.jl
@@ -233,7 +233,9 @@ function optimize{T, M<:ConstrainedOptimizer}(d::AbstractOptimFunction, constrai
         end
 
         Δf = abs(state.f_x - state.f_x_previous)
-        Δfmax = max(Δfmax, abs(state.f_x - state.f_x_previous))
+        if iterationμ > 1
+            Δfmax = max(Δfmax, abs(state.f_x - state.f_x_previous))
+        end
 
         # Test whether we need to decrease the barrier penalty
         if iterationμ > 1 && (converged || 100*gnormnew < gnorm || 100*Δf < Δfmax)

--- a/src/iplinesearch.jl
+++ b/src/iplinesearch.jl
@@ -1,0 +1,15 @@
+function backtrack_constrained(ϕ, α, αmax, Lcoefsα,
+                               c1 = 0.5, ρ=oftype(α, 0.5), itermax = 100)
+    α = min(α, 0.999*αmax)
+    L0, L1, L2 = Lcoefsα
+    f_calls = 0
+    while f_calls < itermax
+        f_calls += 1
+        val = ϕ(α)
+        if abs(val - (L0 + L1*α + L2*α^2/2)) <= c1*abs(val-L0) + 100*eps(abs(val)+abs(L0))
+            return α, f_calls, 0
+        end
+        α *= ρ
+    end
+    error("failed to satisfy criterion after $f_calls iterations")
+end

--- a/src/iplinesearch.jl
+++ b/src/iplinesearch.jl
@@ -19,21 +19,28 @@ function backtrack_constrained(ϕ, α, αmax, αImax, Lcoefsα,
 end
 
 function backtrack_constrained_grad(ϕ, α, αmax, αImax, Lcoefsα,
-                                    c1 = 0.9, c2 = 0.9, ρ=oftype(α, 0.5), αminfrac = sqrt(eps(one(α))))
+                                    c1 = 0.9, c2 = 0.9, ρ=oftype(α, 0.5),
+                                    αminfrac = sqrt(eps(one(α))); show_linesearch::Bool=false)
     α, αI = min(α, 0.999*αmax), min(α, 0.999*αImax)
     αmin = αminfrac * α
     L0, L1, L2 = Lcoefsα
-    # @show L2
+    if show_linesearch
+        println("L0 = $L0, L1 = $L1, L2 = ")
+        Base.showarray(STDOUT, L2, false)
+    end
     f_calls = 0
     while α >= αmin
         f_calls += 1
         val, slopeα = ϕ((α, αI))
         δval = evalgrad(L1, α, αI) + evalhess(L2, α, αI)/2
         δslope = mulhess(L2, α, αI)
-        # r0, r1 = abs(val - (L0 + δval)) / (c1*abs(val-L0)), norm(slopeα - (L1 + δslope))/(c2*norm(slopeα-L1))
-        # @show val L0 L0+δval
-        # @show slopeα L1 L1+δslope
-        # @show (α, αI, r0, r1)
+        if show_linesearch
+            @show (α, αI)
+            @show val L0 L0+δval
+            @show slopeα L1 L1+δslope
+            r0, r1 = (val - (L0 + δval)) / (c1*abs(val-L0)), (slopeα - (L1 + δslope))./(c2*(slopeα-L1))
+            @show (r0, r1)
+        end
         if isfinite(val) && val - (L0 + δval) <= c1*abs(val-L0) &&
                             all(slopeα - (L1 + δslope) .<= c2*abs.(slopeα-L1))
             return α, αI, f_calls, f_calls

--- a/src/iplinesearch.jl
+++ b/src/iplinesearch.jl
@@ -1,15 +1,15 @@
 function backtrack_constrained(ϕ, α, αmax, Lcoefsα,
-                               c1 = 0.5, ρ=oftype(α, 0.5), itermax = 100)
+                               c1 = 0.5, ρ=oftype(α, 0.5), αmin = sqrt(eps(one(α))))
     α = min(α, 0.999*αmax)
     L0, L1, L2 = Lcoefsα
     f_calls = 0
-    while f_calls < itermax
+    while α >= αmin
         f_calls += 1
         val = ϕ(α)
-        if abs(val - (L0 + L1*α + L2*α^2/2)) <= c1*abs(val-L0) + 100*eps(abs(val)+abs(L0))
+        if isfinite(val) && abs(val - (L0 + L1*α + L2*α^2/2)) <= c1*abs(val-L0)
             return α, f_calls, 0
         end
         α *= ρ
     end
-    error("failed to satisfy criterion after $f_calls iterations")
+    return zero(α), f_calls, 0
 end

--- a/src/iplinesearch.jl
+++ b/src/iplinesearch.jl
@@ -23,6 +23,7 @@ function backtrack_constrained_grad(ϕ, α, αmax, αImax, Lcoefsα,
     α, αI = min(α, 0.999*αmax), min(α, 0.999*αImax)
     αmin = αminfrac * α
     L0, L1, L2 = Lcoefsα
+    # @show L2
     f_calls = 0
     while α >= αmin
         f_calls += 1
@@ -30,6 +31,8 @@ function backtrack_constrained_grad(ϕ, α, αmax, αImax, Lcoefsα,
         δval = evalgrad(L1, α, αI) + evalhess(L2, α, αI)/2
         δslope = mulhess(L2, α, αI)
         # r0, r1 = abs(val - (L0 + δval)) / (c1*abs(val-L0)), norm(slopeα - (L1 + δslope))/(c2*norm(slopeα-L1))
+        # @show val L0 L0+δval
+        # @show slopeα L1 L1+δslope
         # @show (α, αI, r0, r1)
         if isfinite(val) && abs(val - (L0 + δval)) <= c1*abs(val-L0) &&
                             norm(slopeα - (L1 + δslope)) <= c2*norm(slopeα-L1)

--- a/src/iplinesearch.jl
+++ b/src/iplinesearch.jl
@@ -1,15 +1,16 @@
-function backtrack_constrained(ϕ, α, αmax, Lcoefsα,
+function backtrack_constrained(ϕ, α, αmax, αImax, Lcoefsα,
                                c1 = 0.5, ρ=oftype(α, 0.5), αmin = sqrt(eps(one(α))))
-    α = min(α, 0.999*αmax)
+    α, αI = min(α, 0.999*αmax), min(α, 0.999*αImax)
     L0, L1, L2 = Lcoefsα
     f_calls = 0
     while α >= αmin
         f_calls += 1
-        val = ϕ(α)
+        val = ϕ(α, αI)
         if isfinite(val) && abs(val - (L0 + L1*α + L2*α^2/2)) <= c1*abs(val-L0)
-            return α, f_calls, 0
+            return α, αI, f_calls, 0
         end
         α *= ρ
+        αI *= ρ
     end
-    return zero(α), f_calls, 0
+    return zero(α), zero(αI), f_calls, 0
 end

--- a/src/iplinesearch.jl
+++ b/src/iplinesearch.jl
@@ -1,17 +1,57 @@
 function backtrack_constrained(ϕ, α, αmax, αImax, Lcoefsα,
-                               c1 = 0.5, ρ=oftype(α, 0.5), αmin = sqrt(eps(one(α))))
+                               c1 = 0.5, ρ=oftype(α, 0.5), αminfrac = sqrt(eps(one(α))))
     α, αI = min(α, 0.999*αmax), min(α, 0.999*αImax)
+    αmin = αminfrac * α
     L0, L1, L2 = Lcoefsα
     f_calls = 0
     while α >= αmin
         f_calls += 1
-        val = ϕ(α, αI)
-        if isfinite(val) && abs(val - (L0 + L1*α + L2*α^2/2)) <= c1*abs(val-L0)
+        val = ϕ((α, αI))
+        δ = evalgrad(L1, α, αI)
+        if isfinite(val) && abs(val - (L0 + δ)) <= c1*abs(val-L0)
             return α, αI, f_calls, 0
         end
         α *= ρ
         αI *= ρ
     end
-    ϕ(zero(α), zero(αI))  # to ensure that state gets set appropriately
+    ϕ((zero(α), zero(αI)))  # to ensure that state gets set appropriately
     return zero(α), zero(αI), f_calls, 0
+end
+
+function backtrack_constrained_grad(ϕ, α, αmax, αImax, Lcoefsα,
+                                    c1 = 0.9, c2 = 0.9, ρ=oftype(α, 0.5), αminfrac = sqrt(eps(one(α))))
+    α, αI = min(α, 0.999*αmax), min(α, 0.999*αImax)
+    αmin = αminfrac * α
+    L0, L1, L2 = Lcoefsα
+    f_calls = 0
+    while α >= αmin
+        f_calls += 1
+        val, slopeα = ϕ((α, αI))
+        δval = evalgrad(L1, α, αI) + evalhess(L2, α, αI)/2
+        δslope = mulhess(L2, α, αI)
+        # r0, r1 = abs(val - (L0 + δval)) / (c1*abs(val-L0)), norm(slopeα - (L1 + δslope))/(c2*norm(slopeα-L1))
+        # @show (α, αI, r0, r1)
+        if isfinite(val) && abs(val - (L0 + δval)) <= c1*abs(val-L0) &&
+                            norm(slopeα - (L1 + δslope)) <= c2*norm(slopeα-L1)
+            return α, αI, f_calls, f_calls
+        end
+        α *= ρ
+        αI *= ρ
+    end
+    ϕ((zero(α), zero(αI)))  # to ensure that state gets set appropriately
+    return zero(α), zero(αI), f_calls, f_calls
+end
+
+# Evaluate for a step parametrized as [α, α, αI, α]
+function evalgrad(slopeα, α, αI)
+    α*(slopeα[1] + slopeα[2] + slopeα[4]) + αI*slopeα[3]
+end
+
+function mulhess(Hα, α, αI)
+    αv = [α, α, αI, α]
+    Hα*αv
+end
+function evalhess(Hα, α, αI)
+    αv = [α, α, αI, α]
+    dot(αv, Hα*αv)
 end

--- a/src/iplinesearch.jl
+++ b/src/iplinesearch.jl
@@ -8,7 +8,7 @@ function backtrack_constrained(ϕ, α, αmax, αImax, Lcoefsα,
         f_calls += 1
         val = ϕ((α, αI))
         δ = evalgrad(L1, α, αI)
-        if isfinite(val) && abs(val - (L0 + δ)) <= c1*abs(val-L0)
+        if isfinite(val) && val - (L0 + δ) <= c1*abs(val-L0)
             return α, αI, f_calls, 0
         end
         α *= ρ
@@ -34,8 +34,8 @@ function backtrack_constrained_grad(ϕ, α, αmax, αImax, Lcoefsα,
         # @show val L0 L0+δval
         # @show slopeα L1 L1+δslope
         # @show (α, αI, r0, r1)
-        if isfinite(val) && abs(val - (L0 + δval)) <= c1*abs(val-L0) &&
-                            norm(slopeα - (L1 + δslope)) <= c2*norm(slopeα-L1)
+        if isfinite(val) && val - (L0 + δval) <= c1*abs(val-L0) &&
+                            all(slopeα - (L1 + δslope) .<= c2*abs.(slopeα-L1))
             return α, αI, f_calls, f_calls
         end
         α *= ρ

--- a/src/iplinesearch.jl
+++ b/src/iplinesearch.jl
@@ -12,5 +12,6 @@ function backtrack_constrained(ϕ, α, αmax, αImax, Lcoefsα,
         α *= ρ
         αI *= ρ
     end
+    ϕ(zero(α), zero(αI))  # to ensure that state gets set appropriately
     return zero(α), zero(αI), f_calls, 0
 end

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -1,0 +1,151 @@
+immutable IPNewton <: IPOptimizer
+    linesearch!::Function
+end
+
+IPNewton(; linesearch!::Function = backtrack_constrained!) =
+  IPNewton(linesearch!)
+
+type IPNewtonState{T,N} <: AbstractBarrierState
+    @add_generic_fields()
+    x_previous::Array{T,N}
+    g::Array{T,N}
+    f_x_previous::T
+    H::Matrix{T}
+    Hd::Vector{Int8}
+    s::Array{T,N}  # step for x
+    # Barrier penalty fields
+    μ::T                  # coefficient of the barrier penalty
+    bstate::BarrierStateVars{T}   # value of slack and λ variables (current "position")
+    bgrad::BarrierStateVars{T}    # gradient of slack and λ variables at current "position"
+    constr_c::Vector{T}   # value of the user-supplied constraints at x
+    constr_J::Matrix{T}   # value of the user-supplied Jacobian at x
+    @add_linesearch_fields()
+    b_ls::BarrierLineSearch{T}
+    gf::Vector{T}
+    Hf::Matrix{T}
+end
+
+function initial_state{T}(method::IPNewton, options, d::TwiceDifferentiableFunction, constraints::TwiceDifferentiableConstraintsFunction, initial_x::Array{T})
+    # Check feasibility of the initial state
+    mc = nconstraints(constraints)
+    constr_c = Array{T}(mc)
+    constraints.c!(initial_x, constr_c)
+#    isfeasible(constraints, initial_x, constr_c) || error("initial guess must be feasible")
+
+    # Allocate fields for the objective function
+    n = length(initial_x)
+    g = Array(T, n)
+    s = Array(T, n)
+    x_ls, g_ls = Array(T, n), Array(T, n)
+    f_x_previous, f_x = NaN, d.fg!(initial_x, g)
+    f_calls, g_calls = 1, 1
+    H = Array(T, n, n)
+    Hd = Array{Int8}(n)
+    d.h!(initial_x, H)
+    h_calls = 1
+
+    # More constraints
+    constr_J = Array{T}(mc, n)
+    constr_gtemp = Array{T}(n)
+    gf = Array{T}(0)    # will be replaced
+    Hf = Array{T}(0,0)  #   "
+    constraints.jacobian!(initial_x, constr_J)
+    μ = T(1)
+    bstate = BarrierStateVars(constraints.bounds, initial_x, constr_c)
+    bgrad = similar(bstate)
+    b_ls = BarrierLineSearch(similar(constr_c), similar(bstate))
+
+    state = IPNewtonState("Interior-point Newton's Method",
+        length(initial_x),
+        copy(initial_x), # Maintain current state in state.x
+        f_x, # Store current f in state.f_x
+        f_calls, # Track f calls in state.f_calls
+        g_calls, # Track g calls in state.g_calls
+        h_calls,
+        copy(initial_x), # Maintain current state in state.x_previous
+        g, # Store current gradient in state.g
+        T(NaN), # Store previous f in state.f_x_previous
+        H,
+        Hd,
+        similar(initial_x), # Maintain current x-search direction in state.s
+        μ,
+        bstate,
+        bgrad,
+        constr_c,
+        constr_J,
+        @initial_linesearch()..., # Maintain a cache for line search results in state.lsr
+        b_ls,
+        gf,
+        Hf)
+    #    μ = initialize_μ_λ!(λv, λc, constraints, initial_x, g, constr_c, constr_J)
+    update_g!(d, constraints, state, method)
+    update_h!(d, constraints, state, method)
+end
+
+function update_g!(d, constraints::TwiceDifferentiableConstraintsFunction, state, method::IPNewton)
+    lagrangian_g!(state.g, state.bgrad, d, constraints.bounds, state.x, state.constr_c, state.constr_J, state.bstate, state.μ, method)
+end
+
+function update_h!(d, constraints::TwiceDifferentiableConstraintsFunction, state, method::IPNewton)
+    μ, Hxx, J = state.μ, state.H, state.constr_J
+    d.h!(state.x, Hxx)
+    # Collect the values of the coefficients of the inequality constraints
+    bounds = constraints.bounds
+    ineqc, σc, λc = bounds.ineqc, bounds.σc, state.bstate.λc
+    m, n = size(J, 1), size(J, 2)
+    λ = zeros(eltype(bounds), m)
+    for i = 1:length(ineqc)
+        λ[ineqc[i]] -= λc[i]*σc[i]
+    end
+    # Add the weighted hessian terms from the nonlinear constraints
+    constraints.h!(state.x, λ, Hxx)
+    # Add the Jacobian terms
+    JI = view5(J, ineqc, :)
+    Sinv2 = Diagonal(1./state.bstate.slack_c.^2)
+    HJ = JI'*Sinv2*JI
+    for j = 1:n, i = 1:n
+        Hxx[i,j] += μ*HJ[i,j]
+    end
+    # Add the variable inequalities
+    iz, x = bounds.iz, state.x
+    for i in iz
+        Hxx[i,i] += μ/x[i]^2
+    end
+    ineqx, sx = bounds.ineqx, state.bstate.slack_x
+    for (i,j) in enumerate(ineqx)
+        Hxx[j,j] += μ/sx[i]^2
+    end
+    # Perform a positive factorization
+    Hpc, state.Hd = ldltfact(Positive, Hxx)
+    Hp = full(Hpc)
+    # Now add the equality constraint hessian terms
+    eqc, λcE = bounds.eqc, state.bstate.λcE
+    fill!(λ, 0)
+    for i = 1:length(eqc)
+        λ[eqc[i]] -= λcE[i]
+    end
+    constraints.h!(state.x, λ, Hp)
+    # Also add these to Hxx so we have the true Hessian (the one
+    # without forcing positive-definiteness)
+    constraints.h!(state.x, λ, Hxx)
+    # Form the total Hessian
+    JEx = zeros(eltype(bounds), length(bounds.eqx), length(state.x))
+    for (i,j) in enumerate(bounds.eqx)
+        JEx[i,j] = 1
+    end
+    JEc = view5(J, eqc, :)
+    Jod = zeros(eltype(JEx), size(JEc, 1), size(JEx, 1))
+    state.Hf = [Hp -JEx' -JEc';
+                -JEx zeros(eltype(JEx), size(JEx,1), size(JEx,1)) Jod';
+                -JEc Jod zeros(eltype(JEc), size(JEc,1), size(JEc,1))]
+    # Also form the total gradient
+    bgrad = state.bgrad
+    gI = state.g + JI'*Diagonal(σc)*(bgrad.slack_c - μ*Sinv2*bgrad.λc)
+    for (i,j) in enumerate(ineqx)
+        gI[j] += bounds.σx[i]*(bgrad.slack_x[i] - μ*bgrad.λx[i]/sx[i]^2)
+    end
+    state.gf = [gI;
+                bgrad.λxE;
+                bgrad.λcE]
+    state
+end

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -240,6 +240,13 @@ function solve_step!(state::IPNewtonState, constraints)
     MF = cholfact(Positive, M, Val{true})
     ΔλE = MF \ (gE + JE * (HxxF \ state.gtilde))
     Δx = HxxF \ (JE'*ΔλE - state.gtilde)
+    if norm(gE) < norm(gE - JE*Δx) # ||
+        # norm(state.gtilde) < norm(full(HxxF)*Δx - JE'*ΔλE + state.gtilde)
+        # Precision problems gave us a worse solution than the one we started with, abort
+        fill!(s, 0)
+        fill!(bstep, 0)
+        return state
+    end
     copy!(s, Δx)
     k = unpack_vec!(bstep.λxE, ΔλE, 0)
     k = unpack_vec!(bstep.λcE, ΔλE, k)

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -28,6 +28,39 @@ type IPNewtonState{T,N} <: AbstractBarrierState
     gtilde::Vector{T}
 end
 
+function Base.convert{T,S,N}(::Type{IPNewtonState{T,N}}, state::IPNewtonState{S,N})
+    IPNewtonState(state.method_string,
+                  state.n,
+                  convert(Array{T}, state.x),
+                  T(state.f_x),
+                  state.f_calls,
+                  state.g_calls,
+                  state.h_calls,
+                  convert(Array{T}, state.x_previous),
+                  convert(Array{T}, state.g),
+                  T(state.f_x_previous),
+                  convert(Array{T}, state.H),
+                  state.Hd,
+                  convert(Array{T}, state.s),
+                  T(state.μ),
+                  T(state.L),
+                  T(state.L_previous),
+                  convert(BarrierStateVars{T}, state.bstate),
+                  convert(BarrierStateVars{T}, state.bgrad),
+                  convert(BarrierStateVars{T}, state.bstep),
+                  convert(Array{T}, state.constr_c),
+                  convert(Array{T}, state.constr_J),
+                  T(state.ev),
+                  convert(Array{T}, state.x_ls),
+                  convert(Array{T}, state.g_ls),
+                  T(state.alpha),
+                  state.mayterminate,
+                  state.lsr,
+                  convert(BarrierLineSearchGrad{T}, state.b_ls),
+                  convert(Array{T}, state.gtilde)
+                  )
+end
+
 function initial_state{T}(method::IPNewton, options, d::TwiceDifferentiableFunction, constraints::TwiceDifferentiableConstraintsFunction, initial_x::Array{T})
     # Check feasibility of the initial state
     mc = nconstraints(constraints)

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -86,7 +86,7 @@ function initial_state{T}(method::IPNewton, options, d::TwiceDifferentiableFunct
         Hf,
         stepf)
 
-    #    μ = initialize_μ_λ!(λv, λc, constraints, initial_x, g, constr_c, constr_J)
+    state.μ = initialize_μ_λ!(bstate.λxE, bstate.λcE, constraints, initial_x, g, constr_c, constr_J)
     update_fg!(d, constraints, state, method)
     update_h!(d, constraints, state, method)
 end
@@ -94,11 +94,14 @@ end
 function update_fg!(d, constraints::TwiceDifferentiableConstraintsFunction, state, method::IPNewton)
     f_x, L = lagrangian_fg!(state.g, state.bgrad, d, constraints.bounds, state.x, state.constr_c, state.constr_J, state.bstate, state.μ)
     state.f_x, state.L = f_x, L
+    state.f_calls += 1
+    state.g_calls += 1
     state
 end
 
 function update_g!(d, constraints::TwiceDifferentiableConstraintsFunction, state, method::IPNewton)
     lagrangian_g!(state.g, state.bgrad, d, constraints.bounds, state.x, state.constr_c, state.constr_J, state.bstate, state.μ)
+    state.g_calls += 1
     state
 end
 

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -307,10 +307,11 @@ function quadratic_parameters(bounds::ConstraintBounds, state::IPNewtonState)
          dot(bstep.λxE, view(state.s, bounds.eqx))
     hss = dot(bstep.slack_c, HsscP*bstep.slack_c) + dot(bstep.slack_x, HssxP*bstep.slack_x)
     si = dot(bstep.slack_c, bstep.λc) + dot(bstep.slack_x, bstep.λx)
-    Hα = [state.s'*state.H*state.s - jHj 0    -ji   -je;
-          0                              hss  si    0;
-          -ji                            si   0     0;
-          -je                            0    0     0]
+    hxx = dot(state.s, state.H*state.s) - jHj
+    Hα = [hxx    0    -ji   -je;
+          0      hss  si    0;
+          -ji    si   0     0;
+          -je    0    0     0]
     state.L, slopeα, Hα
 end
 

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -86,9 +86,9 @@ function initial_state{T}(method::IPNewton, options, d::TwiceDifferentiableFunct
         Hf,
         stepf)
 
-    state.μ = initialize_μ_λ!(bstate.λxE, bstate.λcE, constraints, initial_x, g, constr_c, constr_J)
-    bstate.λx[:] = μ./bstate.slack_x
-    bstate.λc[:] = μ./bstate.slack_c
+    state.μ = initialize_μ_λ!(bstate.λxE, bstate.λcE, constraints, initial_x, g, constr_c, constr_J, options.μ0)
+    bstate.λx[:] = state.μ./bstate.slack_x
+    bstate.λc[:] = state.μ./bstate.slack_c
     update_fg!(d, constraints, state, method)
     update_h!(d, constraints, state, method)
 end

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -1,5 +1,5 @@
-immutable IPNewton <: IPOptimizer
-    linesearch!::Function
+immutable IPNewton{F} <: IPOptimizer{F}
+    linesearch!::F
 end
 
 IPNewton(; linesearch!::Function = backtrack_constrained) =
@@ -192,7 +192,7 @@ function update_state!{T}(d, constraints::TwiceDifferentiableConstraintsFunction
                             view(state.s, bounds.iz).*bounds.σz)
 
     # Determine the actual distance of movement along the search line
-    ϕ = α->lagrangian_linefunc(α, d, constraints, state)
+    ϕ = α->lagrangian_linefunc!(α, d, constraints, state, method)
     state.alpha, f_update, g_update =
         method.linesearch!(ϕ, T(1), αmax, qp)
     state.f_calls, state.g_calls = state.f_calls + f_update, state.g_calls + g_update

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -212,7 +212,7 @@ function update_state!{T}(d, constraints::TwiceDifferentiableConstraintsFunction
     constraints.jacobian!(state.x, state.constr_J)
 
     # Test for active inequalities, solve immediately for the corresponding s and λ
-    solve_active_inequalities!(d, constraints, state)
+    # solve_active_inequalities!(d, constraints, state)
 
     false
 end

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -87,6 +87,8 @@ function initial_state{T}(method::IPNewton, options, d::TwiceDifferentiableFunct
         stepf)
 
     state.μ = initialize_μ_λ!(bstate.λxE, bstate.λcE, constraints, initial_x, g, constr_c, constr_J)
+    bstate.λx[:] = μ./bstate.slack_x
+    bstate.λc[:] = μ./bstate.slack_c
     update_fg!(d, constraints, state, method)
     update_h!(d, constraints, state, method)
 end

--- a/src/ipnewton.jl
+++ b/src/ipnewton.jl
@@ -382,4 +382,10 @@ function Hf(bounds::ConstraintBounds, state)
           -JE zeros(eltype(JE), size(JE, 1), size(JE, 1))]
 end
 Hf(constraints, state) = Hf(constraints.bounds, state)
-gf(state) = [state.gtilde; state.bgrad.λxE; state.bgrad.λcE]
+function gf(bounds::ConstraintBounds, state)
+    bstate, μ = state.bstate, state.μ
+    μsinv = μ * [bounds.σx./bstate.slack_x; bounds.σc./bstate.slack_c]
+    gtildeμ = state.gtilde  - jacobianI(state, bounds)' * μsinv
+    [gtildeμ; state.bgrad.λxE; state.bgrad.λcE]
+end
+gf(constraints, state) = gf(constraints.bounds, state)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -9,6 +9,7 @@ function optimize(f::Function,
                   x_tol::Real = 1e-32,
                   f_tol::Real = 1e-32,
                   g_tol::Real = 1e-8,
+                  successive_f_tol::Integer = 2,
                   iterations::Integer = 1_000,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
@@ -17,7 +18,7 @@ function optimize(f::Function,
                   autodiff::Bool = false,
                   callback = nothing)
     options = OptimizationOptions(;
-        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol,
+        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol, successive_f_tol = successive_f_tol,
         iterations = iterations, store_trace = store_trace,
         show_trace = show_trace, extended_trace = extended_trace,
         callback = callback, show_every = show_every,
@@ -32,6 +33,7 @@ function optimize(f::Function,
                   x_tol::Real = 1e-32,
                   f_tol::Real = 1e-32,
                   g_tol::Real = 1e-8,
+                  successive_f_tol::Integer = 2,
                   iterations::Integer = 1_000,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
@@ -39,7 +41,7 @@ function optimize(f::Function,
                   show_every::Integer = 1,
                   callback = nothing)
     options = OptimizationOptions(;
-        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol,
+        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol, successive_f_tol = successive_f_tol,
         iterations = iterations, store_trace = store_trace,
         show_trace = show_trace, extended_trace = extended_trace,
         callback = callback, show_every = show_every)
@@ -54,6 +56,7 @@ function optimize(f::Function,
                   x_tol::Real = 1e-32,
                   f_tol::Real = 1e-32,
                   g_tol::Real = 1e-8,
+                  successive_f_tol::Integer = 2,
                   iterations::Integer = 1_000,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
@@ -61,7 +64,7 @@ function optimize(f::Function,
                   show_every::Integer = 1,
                   callback = nothing)
     options = OptimizationOptions(;
-        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol,
+        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol, successive_f_tol = successive_f_tol,
         iterations = iterations, store_trace = store_trace,
         show_trace = show_trace, extended_trace = extended_trace,
         callback = callback, show_every = show_every)
@@ -74,6 +77,7 @@ function optimize(d::DifferentiableFunction,
                   x_tol::Real = 1e-32,
                   f_tol::Real = 1e-32,
                   g_tol::Real = 1e-8,
+                  successive_f_tol::Integer = 2,
                   iterations::Integer = 1_000,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
@@ -81,7 +85,7 @@ function optimize(d::DifferentiableFunction,
                   show_every::Integer = 1,
                   callback = nothing)
     options = OptimizationOptions(;
-        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol,
+        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol, successive_f_tol = successive_f_tol,
         iterations = iterations, store_trace = store_trace,
         show_trace = show_trace, extended_trace = extended_trace,
         callback = callback, show_every = show_every)
@@ -94,6 +98,7 @@ function optimize(d::TwiceDifferentiableFunction,
                   x_tol::Real = 1e-32,
                   f_tol::Real = 1e-32,
                   g_tol::Real = 1e-8,
+                  successive_f_tol::Integer = 2,
                   iterations::Integer = 1_000,
                   store_trace::Bool = false,
                   show_trace::Bool = false,
@@ -101,7 +106,7 @@ function optimize(d::TwiceDifferentiableFunction,
                   show_every::Integer = 1,
                   callback = nothing)
     options = OptimizationOptions(;
-        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol,
+        x_tol = x_tol, f_tol = f_tol, g_tol = g_tol, successive_f_tol = successive_f_tol,
         iterations = iterations, store_trace = store_trace,
         show_trace = show_trace, extended_trace = extended_trace,
         callback = callback, show_every = show_every)
@@ -220,7 +225,7 @@ function optimize{T, M<:Optimizer}(d, initial_x::Array{T}, method::M, options::O
     tracing = options.store_trace || options.show_trace || options.extended_trace || options.callback != nothing
     stopped, stopped_by_callback, stopped_by_time_limit = false, false, false
 
-    x_converged, f_converged = false, false
+    x_converged, f_converged, counter_f_tol = false, false, 0
     g_converged = if typeof(method) <: NelderMead
         nmobjective(state.f_simplex, state.m, state.n) < options.g_tol
     elseif  typeof(method) <: ParticleSwarm || typeof(method) <: SimulatedAnnealing
@@ -242,6 +247,11 @@ function optimize{T, M<:Optimizer}(d, initial_x::Array{T}, method::M, options::O
         update_g!(d, state, method)
         x_converged, f_converged,
         g_converged, converged = assess_convergence(state, options)
+        # See optimize in interior.jl for an explanation of the next
+        # two lines (given the existence of the option, we'd better
+        # use it here too)
+        counter_f_tol = f_converged ? counter_f_tol+1 : 0
+        converged = x_converged | g_converged | (counter_f_tol > options.successive_f_tol)
         # We don't use the Hessian for anything if we have declared convergence,
         # so we might as well not make the (expensive) update if converged == true
         !converged && update_h!(d, state, method)

--- a/src/problems/constrained.jl
+++ b/src/problems/constrained.jl
@@ -1,0 +1,42 @@
+module ConstrainedProblems
+
+using ..OptimizationProblem, ...TwiceDifferentiableConstraintsFunction
+
+examples = Dict{AbstractString, OptimizationProblem}()
+
+hs9_obj(x::AbstractVector) = sin(π*x[1]/12) * cos(π*x[2]/16)
+hs9_c!(x::AbstractVector, c::AbstractVector) = (c[1] = 4*x[1]-3*x[2]; c)
+
+function hs9_obj_g!(x::AbstractVector, g::AbstractVector)
+    g[1] = π/12 * cos(π*x[1]/12) * cos(π*x[2]/16)
+    g[2] = -π/16 * sin(π*x[1]/12) * sin(π*x[2]/16)
+    g
+end
+function hs9_obj_h!(x::AbstractVector, h::AbstractMatrix)
+    v = hs9_obj(x)
+    h[1,1] = -π^2*v/144
+    h[2,2] = -π^2*v/256
+    h[1,2] = h[2,1] = -π^2 * cos(π*x[1]/12) * sin(π*x[2]/16) / 192
+    h
+end
+
+function hs9_jacobian!(x, J)
+    J[1,1] = 4
+    J[1,2] = -3
+    J
+end
+hs9_h!(x, λ, h) = h
+
+examples["HS9"] = OptimizationProblem("HS9",
+                                      hs9_obj,
+                                      hs9_obj_g!,
+                                      hs9_obj_h!,
+                                      TwiceDifferentiableConstraintsFunction(
+                                          hs9_c!, hs9_jacobian!, hs9_h!,
+                                          [], [], [0.0], [0.0]),
+                                      [0.0, 0.0],
+                                      [[12k-3, 16k-4] for k in (0, 1, -1)], # any integer k will do...
+                                      true,
+                                      true)
+
+end  # module

--- a/src/problems/multivariate.jl
+++ b/src/problems/multivariate.jl
@@ -1,0 +1,27 @@
+module MultivariateProblems
+
+export UnconstrainedProblems, ConstrainedProblems
+
+immutable OptimizationProblem
+    name::AbstractString
+    f::Function
+    g!::Function
+    h!::Function
+    constraints
+    initial_x::Vector{Float64}
+    solutions::Vector
+    isdifferentiable::Bool
+    istwicedifferentiable::Bool
+end
+
+function OptimizationProblem(name, f, g!, h!,
+                             initial_x::AbstractVector, solutions,
+                             isdifferentiable::Bool, istwicedifferentiable::Bool)
+    OptimizationProblem(name, f, g!, h!, nothing,
+                        initial_x, solutions, isdifferentiable, istwicedifferentiable)
+end
+
+include("unconstrained.jl")
+include("constrained.jl")
+
+end

--- a/src/problems/unconstrained.jl
+++ b/src/problems/unconstrained.jl
@@ -1,22 +1,13 @@
 module UnconstrainedProblems
 
+using ..OptimizationProblem
+
 ### Sources
 ###
 ### [1] Ali, Khompatraporn, & Zabinsky: A Numerical Evaluation of Several Stochastic Algorithms on Selected Continuous Global Optimization Test
 ### Link: www.researchgate.net/profile/Montaz_Ali/publication/226654862_A_Numerical_Evaluation_of_Several_Stochastic_Algorithms_on_Selected_Continuous_Global_Optimization_Test_Problems/links/00b4952bef133a1a6b000000.pdf
 ###
 ### [2] Fletcher & Powell: A rapidly convergent descent method for minimization,
-
-immutable OptimizationProblem
-    name::AbstractString
-    f::Function
-    g!::Function
-    h!::Function
-    initial_x::Vector{Float64}
-    solutions::Vector
-    isdifferentiable::Bool
-    istwicedifferentiable::Bool
-end
 
 examples = Dict{AbstractString, OptimizationProblem}()
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -310,6 +310,17 @@ end
 DifferentiableConstraintsFunction(c!, jacobian!, bounds::ConstraintBounds) =
     DifferentiableConstraintsFunction{typeof(c!), typeof(jacobian!), eltype(b)}(c!, jacobian!, b)
 
+function DifferentiableConstraintsFunction(lx::AbstractArray, ux::AbstractArray)
+    bounds = ConstraintBounds(lx, ux, [], [])
+    DifferentiableConstraintsFunction(bounds)
+end
+
+function DifferentiableConstraintsFunction(bounds::ConstraintBounds)
+    c! = (x,c)->nothing
+    J! = (x,J)->nothing
+    DifferentiableConstraintsFunction(c!, J!, bounds)
+end
+
 immutable TwiceDifferentiableConstraintsFunction{F,J,H,T} <: AbstractConstraintsFunction
     c!::F
     jacobian!::J
@@ -322,6 +333,19 @@ function TwiceDifferentiableConstraintsFunction(c!, jacobian!, h!, lx, ux, lc, u
 end
 TwiceDifferentiableConstraintsFunction(c!, jacobian!, h!, bounds::ConstraintBounds) =
     TwiceDifferentiableConstraintsFunction{typeof(c!), typeof(jacobian!), typeof(h!), eltype(b)}(c!, jacobian!, h!, b)
+
+function TwiceDifferentiableConstraintsFunction(lx::AbstractArray, ux::AbstractArray)
+    bounds = ConstraintBounds(lx, ux, [], [])
+    TwiceDifferentiableConstraintsFunction(bounds)
+end
+
+function TwiceDifferentiableConstraintsFunction(bounds::ConstraintBounds)
+    c! = (x,c)->nothing
+    J! = (x,J)->nothing
+    h! = (x,λ,h)->nothing
+    TwiceDifferentiableConstraintsFunction(c!, J!, h!, bounds)
+end
+
 
 ## Utilities
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -284,7 +284,7 @@ end
 # additional variables. See `parse_constraints` for details.
 
 immutable ConstraintBounds{T}
-    nc::Int          # Number of linear/nonlinear constraints
+    nc::Int          # Number of linear/nonlinear constraints supplied by user
     # Box-constraints on variables (i.e., directly on x)
     eqx::Vector{Int} # index-vector of equality-constrained x (not actually variable...)
     valx::Vector{T}  # value of equality-constrained x
@@ -312,7 +312,34 @@ end
 Base.eltype{T}(::Type{ConstraintBounds{T}}) = T
 Base.eltype(cb::ConstraintBounds) = eltype(typeof(cb))
 
+"""
+    nconstraints(bounds) -> nc
+
+The number of linear/nonlinear constraint functions supplied by the
+user. This does not include bounds-constraints on variables.
+
+See also: nconstraints_x.
+"""
 nconstraints(cb::ConstraintBounds) = cb.nc
+
+"""
+    nconstraints_x(bounds) -> nx
+
+The number of "meaningful" constraints (not `±Inf`) on the x coordinates.
+
+See also: nconstraints.
+"""
+function nconstraints_x(cb::ConstraintBounds)
+    mz = isempty(cb.iz) ? 0 : maximum(cb.iz)
+    mi = isempty(cb.ineqx) ? 0 : maximum(cb.ineqx)
+    me = isempty(cb.eqx) ? 0 : maximum(cb.eqx)
+    nmax = max(mz, mi, me)
+    hasconstraint = falses(nmax)
+    hasconstraint[cb.iz] = true
+    hasconstraint[cb.ineqx] = true
+    hasconstraint[cb.eqx] = true
+    sum(hasconstraint)
+end
 
 function Base.show(io::IO, cb::ConstraintBounds)
     indent = "    "

--- a/src/types.jl
+++ b/src/types.jl
@@ -13,6 +13,7 @@ immutable OptimizationOptions{TCallback <: Union{Void, Function}}
     store_trace::Bool
     show_trace::Bool
     extended_trace::Bool
+    show_linesearch::Bool
     autodiff::Bool
     show_every::Int
     callback::TCallback
@@ -30,6 +31,7 @@ function OptimizationOptions(;
         store_trace::Bool = false,
         show_trace::Bool = false,
         extended_trace::Bool = false,
+        show_linesearch::Bool = false,
         autodiff::Bool = false,
         show_every::Integer = 1,
         callback = nothing,
@@ -42,8 +44,8 @@ function OptimizationOptions(;
     end
     OptimizationOptions{typeof(callback)}(
         Float64(x_tol), Float64(f_tol), Float64(g_tol), Int(successive_f_tol),
-        Int(iterations), store_trace, show_trace, extended_trace, autodiff,
-        Int(show_every), callback, time_limit, μfactor, μ0)
+        Int(iterations), store_trace, show_trace, extended_trace, show_linesearch,
+        autodiff, Int(show_every), callback, time_limit, μfactor, μ0)
 end
 
 function print_header(options::OptimizationOptions)

--- a/src/types.jl
+++ b/src/types.jl
@@ -8,6 +8,7 @@ immutable OptimizationOptions{TCallback <: Union{Void, Function}}
     x_tol::Float64
     f_tol::Float64
     g_tol::Float64
+    successive_f_tol::Int
     iterations::Int
     store_trace::Bool
     show_trace::Bool
@@ -23,6 +24,7 @@ function OptimizationOptions(;
         x_tol::Real = 1e-32,
         f_tol::Real = 1e-32,
         g_tol::Real = 1e-8,
+        successive_f_tol::Integer = 2,
         iterations::Integer = 1_000,
         store_trace::Bool = false,
         show_trace::Bool = false,
@@ -37,9 +39,9 @@ function OptimizationOptions(;
         show_trace = true
     end
     OptimizationOptions{typeof(callback)}(
-        Float64(x_tol), Float64(f_tol), Float64(g_tol), Int(iterations),
-        store_trace, show_trace, extended_trace, autodiff, Int(show_every),
-        callback, time_limit, μfactor)
+        Float64(x_tol), Float64(f_tol), Float64(g_tol), Int(successive_f_tol),
+        Int(iterations), store_trace, show_trace, extended_trace, autodiff,
+        Int(show_every), callback, time_limit, μfactor)
 end
 
 function print_header(options::OptimizationOptions)

--- a/src/types.jl
+++ b/src/types.jl
@@ -428,6 +428,10 @@ Base.show(io::IO, uqstr::UnquotedString) = print(io, uqstr.str)
 
 Base.array_eltype_show_how(a::Vector{UnquotedString}) = false, ""
 
+if !isdefined(Base, :IOContext)
+    IOContext(io; kwargs...) = io
+end
+
 function showeq(io, indent, eq, val, chr, style)
     if !isempty(eq)
         print(io, '\n', indent)

--- a/src/types.jl
+++ b/src/types.jl
@@ -18,6 +18,7 @@ immutable OptimizationOptions{TCallback <: Union{Void, Function}}
     callback::TCallback
     time_limit::Float64
     μfactor::Float64
+    μ0
 end
 
 function OptimizationOptions(;
@@ -33,7 +34,8 @@ function OptimizationOptions(;
         show_every::Integer = 1,
         callback = nothing,
         time_limit = NaN,
-        μfactor = 0.1)
+        μfactor = 0.1,
+        μ0 = :auto)
     show_every = show_every > 0 ? show_every: 1
     if extended_trace && callback == nothing
         show_trace = true
@@ -41,7 +43,7 @@ function OptimizationOptions(;
     OptimizationOptions{typeof(callback)}(
         Float64(x_tol), Float64(f_tol), Float64(g_tol), Int(successive_f_tol),
         Int(iterations), store_trace, show_trace, extended_trace, autodiff,
-        Int(show_every), callback, time_limit, μfactor)
+        Int(show_every), callback, time_limit, μfactor, μ0)
 end
 
 function print_header(options::OptimizationOptions)

--- a/src/types.jl
+++ b/src/types.jl
@@ -57,7 +57,7 @@ function print_header(method::Optimizer)
 end
 
 function print_header(method::IPOptimizer)
-        @printf "Iter     Lagrangian value Function value   Gradient norm    μ\n"
+        @printf "Iter     Lagrangian value Function value   Gradient norm    |==constr.|      μ\n"
 end
 
 immutable OptimizationState{T <: Optimizer}
@@ -134,10 +134,10 @@ end
 
 function Base.show{M<:IPOptimizer}(io::IO, t::OptimizationState{M})
     md = t.metadata
-    @printf io "%6d   %-14e   %-14e   %-14e   %-6.2e\n" t.iteration md["Lagrangian"] t.value t.g_norm md["μ"]
+    @printf io "%6d   %-14e   %-14e   %-14e   %-14e   %-6.2e\n" t.iteration md["Lagrangian"] t.value t.g_norm md["ev"] md["μ"]
     if !isempty(t.metadata)
         for (key, value) in md
-            key ∈ ("Lagrangian", "μ") && continue
+            key ∈ ("Lagrangian", "μ", "ev") && continue
             @printf io " * %s: %s\n" key value
         end
     end
@@ -154,8 +154,8 @@ function Base.show(io::IO, tr::OptimizationTrace)
 end
 
 function Base.show{M<:IPOptimizer}(io::IO, tr::OptimizationTrace{M})
-    @printf io "Iter     Lagrangian value Function value   Gradient norm    μ\n"
-    @printf io "------   ---------------- --------------   --------------   --------\n"
+    @printf io "Iter     Lagrangian value Function value   Gradient norm    |==constr.|      μ\n"
+    @printf io "------   ---------------- --------------   --------------   --------------   --------\n"
     for state in tr
         show(io, state)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,9 @@
 abstract Optimizer
-abstract ConstrainedOptimizer <: Optimizer
-abstract IPOptimizer <: ConstrainedOptimizer
+abstract ConstrainedOptimizer{T} <: Optimizer
+abstract IPOptimizer{T} <: ConstrainedOptimizer  # interior point methods
+
+abstract AbstractOptimFunction
+
 immutable OptimizationOptions{TCallback <: Union{Void, Function}}
     x_tol::Float64
     f_tol::Float64
@@ -13,6 +16,7 @@ immutable OptimizationOptions{TCallback <: Union{Void, Function}}
     show_every::Int
     callback::TCallback
     time_limit::Float64
+    μfactor::Float64
 end
 
 function OptimizationOptions(;
@@ -26,7 +30,8 @@ function OptimizationOptions(;
         autodiff::Bool = false,
         show_every::Integer = 1,
         callback = nothing,
-        time_limit = NaN)
+        time_limit = NaN,
+        μfactor = 0.1)
     show_every = show_every > 0 ? show_every: 1
     if extended_trace && callback == nothing
         show_trace = true
@@ -34,7 +39,7 @@ function OptimizationOptions(;
     OptimizationOptions{typeof(callback)}(
         Float64(x_tol), Float64(f_tol), Float64(g_tol), Int(iterations),
         store_trace, show_trace, extended_trace, autodiff, Int(show_every),
-        callback, time_limit)
+        callback, time_limit, μfactor)
 end
 
 function print_header(options::OptimizationOptions)
@@ -45,6 +50,10 @@ end
 
 function print_header(method::Optimizer)
         @printf "Iter     Function value   Gradient norm \n"
+end
+
+function print_header(method::IPOptimizer)
+        @printf "Iter     Lagrangian value Function value   Gradient norm    μ\n"
 end
 
 immutable OptimizationState{T <: Optimizer}
@@ -92,17 +101,17 @@ type UnivariateOptimizationResults{T,M} <: OptimizationResults
     f_calls::Int
 end
 
-immutable NonDifferentiableFunction
+immutable NonDifferentiableFunction <: AbstractOptimFunction
     f::Function
 end
 
-immutable DifferentiableFunction
+immutable DifferentiableFunction <: AbstractOptimFunction
     f::Function
     g!::Function
     fg!::Function
 end
 
-immutable TwiceDifferentiableFunction
+immutable TwiceDifferentiableFunction <: AbstractOptimFunction
     f::Function
     g!::Function
     fg!::Function
@@ -119,9 +128,30 @@ function Base.show(io::IO, t::OptimizationState)
     return
 end
 
+function Base.show{M<:IPOptimizer}(io::IO, t::OptimizationState{M})
+    md = t.metadata
+    @printf io "%6d   %-14e   %-14e   %-14e   %-6.2e\n" t.iteration md["Lagrangian"] t.value t.g_norm md["μ"]
+    if !isempty(t.metadata)
+        for (key, value) in md
+            key ∈ ("Lagrangian", "μ") && continue
+            @printf io " * %s: %s\n" key value
+        end
+    end
+    return
+end
+
 function Base.show(io::IO, tr::OptimizationTrace)
     @printf io "Iter     Function value   Gradient norm \n"
     @printf io "------   --------------   --------------\n"
+    for state in tr
+        show(io, state)
+    end
+    return
+end
+
+function Base.show{M<:IPOptimizer}(io::IO, tr::OptimizationTrace{M})
+    @printf io "Iter     Lagrangian value Function value   Gradient norm    μ\n"
+    @printf io "------   ---------------- --------------   --------------   --------\n"
     for state in tr
         show(io, state)
     end

--- a/src/utilities/assess_convergence.jl
+++ b/src/utilities/assess_convergence.jl
@@ -85,6 +85,17 @@ function assess_convergence(state::NewtonTrustRegionState, options)
     x_converged, f_converged, g_converged, converged
 end
 
+function assess_convergence(state::IPNewtonState, options)
+    assess_convergence(state.x,
+                       state.x_previous,
+                       state.L,
+                       state.L_previous,
+                       state.gf,
+                       options.x_tol,
+                       options.f_tol,
+                       options.g_tol)
+end
+
 # For monotonic-decreasing problems
 fconverged(state) = nextfloat(state.f_x) >= state.f_x_previous
 # Constrained problems are not monotonic, so we can't add a one-sided criterion

--- a/src/utilities/assess_convergence.jl
+++ b/src/utilities/assess_convergence.jl
@@ -15,7 +15,7 @@ function assess_convergence(x::Array,
     # Absolute Tolerance
     # if abs(f_x - f_x_previous) < f_tol
     # Relative Tolerance
-    if abs(f_x - f_x_previous) / (abs(f_x) + f_tol) < f_tol || nextfloat(f_x) >= f_x_previous
+    if abs(f_x - f_x_previous) < min(f_tol * (abs(f_x) + f_tol), eps(abs(f_x)+abs(f_x_previous)))
         f_converged = true
     end
 
@@ -39,7 +39,7 @@ function assess_convergence(state, options)
     # Absolute Tolerance
     # if abs(f_x - f_x_previous) < f_tol
     # Relative Tolerance
-    if abs(state.f_x - state.f_x_previous) / (abs(state.f_x) + options.f_tol) < options.f_tol || nextfloat(state.f_x) >= state.f_x_previous
+    if abs(state.f_x - state.f_x_previous) < min(options.f_tol * (abs(state.f_x) + options.f_tol), eps(abs(state.f_x)+abs(state.f_x_previous))) || fconverged(state)
         f_converged = true
     end
 
@@ -79,6 +79,13 @@ function assess_convergence(state::NewtonTrustRegionState, options)
                                        options.x_tol,
                                        options.f_tol,
                                        options.g_tol)
+        f_converged = fconverged(state)
+        converged |= f_converged
     end
     x_converged, f_converged, g_converged, converged
 end
+
+# For monotonic-decreasing problems
+fconverged(state) = nextfloat(state.f_x) >= state.f_x_previous
+# Constrained problems are not monotonic, so we can't add a one-sided criterion
+fconverged(state::IPNewtonState) = false

--- a/src/utilities/assess_convergence.jl
+++ b/src/utilities/assess_convergence.jl
@@ -86,11 +86,13 @@ function assess_convergence(state::NewtonTrustRegionState, options)
 end
 
 function assess_convergence(state::IPNewtonState, options)
+    # We use the whole bstate-gradient `bgrad`
+    bgrad = state.bgrad
     assess_convergence(state.x,
                        state.x_previous,
                        state.L,
                        state.L_previous,
-                       state.gf,
+                       [state.g; bgrad.slack_x; bgrad.slack_c; bgrad.λx; bgrad.λc; bgrad.λxE; bgrad.λcE],
                        options.x_tol,
                        options.f_tol,
                        options.g_tol)

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -120,6 +120,7 @@ function trace!(tr, state, iteration, method::IPOptimizer, options)
     dt["Lagrangian"] = state.L
     dt["μ"] = state.μ
     if options.extended_trace
+        dt["α"] = state.alpha
         dt["x"] = copy(state.x)
         dt["g(x)"] = copy(state.g)
         dt["h(x)"] = copy(state.H)

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -119,6 +119,7 @@ function trace!(tr, state, iteration, method::IPOptimizer, options)
     dt = Dict()
     dt["Lagrangian"] = state.L
     dt["μ"] = state.μ
+    dt["ev"] = state.ev
     if options.extended_trace
         dt["α"] = state.alpha
         dt["x"] = copy(state.x)
@@ -130,7 +131,7 @@ function trace!(tr, state, iteration, method::IPOptimizer, options)
         dt["bgrad"] = copy(state.bgrad)
         dt["c"] = copy(state.constr_c)
     end
-    g_norm = vecnorm(state.gf, Inf)
+    g_norm = vecnorm(state.g, Inf) + vecnorm(state.bgrad, Inf)
     update!(tr,
             iteration,
             state.f_x,

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -123,6 +123,9 @@ function trace!(tr, state, iteration, method::IPOptimizer, options)
         dt["x"] = copy(state.x)
         dt["g(x)"] = copy(state.g)
         dt["h(x)"] = copy(state.H)
+        dt["bstate"] = copy(state.bstate)
+        dt["bgrad"] = copy(state.bgrad)
+        dt["c"] = copy(state.constr_c)
     end
     g_norm = vecnorm(state.g, Inf)
     update!(tr,

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -114,3 +114,24 @@ function trace!(tr, state, iteration, method::NewtonTrustRegion, options)
             options.show_every,
             options.callback)
 end
+
+function trace!(tr, state, iteration, method::IPOptimizer, options)
+    dt = Dict()
+    dt["Lagrangian"] = state.L
+    dt["μ"] = state.μ
+    if options.extended_trace
+        dt["x"] = copy(state.x)
+        dt["g(x)"] = copy(state.g)
+        dt["h(x)"] = copy(state.H)
+    end
+    g_norm = vecnorm(state.g, Inf)
+    update!(tr,
+            iteration,
+            state.f_x,
+            g_norm,
+            dt,
+            options.store_trace,
+            options.show_trace,
+            options.show_every,
+            options.callback)
+end

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -123,12 +123,14 @@ function trace!(tr, state, iteration, method::IPOptimizer, options)
         dt["α"] = state.alpha
         dt["x"] = copy(state.x)
         dt["g(x)"] = copy(state.g)
+        dt["gf(x)"] = copy(state.gf)
         dt["h(x)"] = copy(state.H)
+        dt["hf(x)"] = copy(state.Hf)
         dt["bstate"] = copy(state.bstate)
         dt["bgrad"] = copy(state.bgrad)
         dt["c"] = copy(state.constr_c)
     end
-    g_norm = vecnorm(state.g, Inf)
+    g_norm = vecnorm(state.gf, Inf)
     update!(tr,
             iteration,
             state.f_x,

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -119,14 +119,13 @@ function trace!(tr, state, iteration, method::IPOptimizer, options)
     dt = Dict()
     dt["Lagrangian"] = state.L
     dt["μ"] = state.μ
-    dt["ev"] = state.ev
+    dt["ev"] = abs(state.ev)
     if options.extended_trace
         dt["α"] = state.alpha
         dt["x"] = copy(state.x)
         dt["g(x)"] = copy(state.g)
-        dt["gf(x)"] = copy(state.gf)
+        dt["gtilde(x)"] = copy(state.gtilde)
         dt["h(x)"] = copy(state.H)
-        dt["hf(x)"] = copy(state.Hf)
         dt["bstate"] = copy(state.bstate)
         dt["bgrad"] = copy(state.bgrad)
         dt["c"] = copy(state.constr_c)

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -124,11 +124,13 @@ function trace!(tr, state, iteration, method::IPOptimizer, options)
         dt["α"] = state.alpha
         dt["x"] = copy(state.x)
         dt["g(x)"] = copy(state.g)
-        dt["gtilde(x)"] = copy(state.gtilde)
         dt["h(x)"] = copy(state.H)
-        dt["bstate"] = copy(state.bstate)
-        dt["bgrad"] = copy(state.bgrad)
-        dt["c"] = copy(state.constr_c)
+        if !isempty(state.bstate)
+            dt["gtilde(x)"] = copy(state.gtilde)
+            dt["bstate"] = copy(state.bstate)
+            dt["bgrad"] = copy(state.bgrad)
+            dt["c"] = copy(state.constr_c)
+        end
     end
     g_norm = vecnorm(state.g, Inf) + vecnorm(state.bgrad, Inf)
     update!(tr,

--- a/src/utilities/update.jl
+++ b/src/utilities/update.jl
@@ -27,3 +27,10 @@ function update!{T}(tr::OptimizationTrace{T},
     end
     stopped
 end
+
+function ls_update!(out::AbstractArray, base::AbstractArray, step::AbstractArray, α)
+    length(out) == length(base) == length(step) || throw(DimensionMismatch("all arrays must have the same length, got $(length(out)), $(length(base)), $(length(step))"))
+    for i = 1:length(base)
+        out[i] = base[i]+α*step[i]
+    end
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -322,7 +322,7 @@ ConstraintBounds:
         Optim.update_fg!(d, constraints, state, method)
         J = zeros(2,4)
         constraints.jacobian!(x, J)
-        eqnormal = J[1,:]; eqnormal = eqnormal/norm(eqnormal)
+        eqnormal = vec(J[1,:]); eqnormal = eqnormal/norm(eqnormal)
         @test abs(dot(state.g, eqnormal)) < 1e-12  # orthogonal to equality constraint
         Pfg = f_g - dot(f_g, eqnormal)*eqnormal
         Pg = state.g - dot(state.g, eqnormal)*eqnormal
@@ -362,7 +362,7 @@ ConstraintBounds:
         Optim.update_fg!(d, constraints, state, method)
         J = zeros(2,4)
         constraints.jacobian!(x, J)
-        eqnormal = J[1,:]; eqnormal = eqnormal/norm(eqnormal)
+        eqnormal = vec(J[1,:]); eqnormal = eqnormal/norm(eqnormal)
         @test abs(dot(state.g, eqnormal)) < 1e-12  # orthogonal to equality constraint
         Pgx = gx - dot(gx, eqnormal)*eqnormal
         @test abs(dot(Pgx, state.g)/dot(Pgx,Pgx) - 1) <= 0.011
@@ -404,7 +404,7 @@ ConstraintBounds:
         αmax = Optim.estimate_maxstep(Inf, state.x[bounds.ineqx].*bounds.σx,
                                            state.s[bounds.ineqx].*bounds.σx)
         ϕ = Optim.linesearch_anon(d, constraints, state, method)
-        val0 = ϕ((0,0))
+        val0 = ϕ(0.0)
         val0 = isa(val0, Tuple) ? val0[1] : val0
         @test val0 ≈ qp[1]
         α, nf, ng = method.linesearch!(ϕ, 1.0, αmax, qp)

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -1,8 +1,24 @@
-using Optim, Base.Test
+using Optim
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
+if VERSION >= v"0.5.0-dev+2396"
+    macro inferred5(ex)
+        Expr(:macrocall, Symbol("@inferred"), esc(ex))
+    end
+else
+    macro inferred5(ex)
+        esc(ex)
+    end
+end
 
 @testset "Constraints" begin
     @testset "Bounds parsing" begin
-        b = @inferred(Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0, 2.0], [5.0, 3.8], [5.0, 4.0]))
+        b = @inferred5(Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0, 2.0], [5.0, 3.8], [5.0, 4.0]))
         @test b.eqx == [3]
         @test b.valx == [2.0]
         @test b.ineqx == [1,2,2]
@@ -27,7 +43,7 @@ ConstraintBounds:
     c_1=5.0
     c_2≥3.8,c_2≤4.0"""
 
-        b = @inferred(Optim.ConstraintBounds(Float64[], Float64[], [5.0, 3.8], [5.0, 4.0]))
+        b = @inferred5(Optim.ConstraintBounds(Float64[], Float64[], [5.0, 3.8], [5.0, 4.0]))
         for fn in (:eqx, :valx, :ineqx, :σx, :bx, :iz, :σz)
             @test isempty(getfield(b, fn))
         end
@@ -67,7 +83,7 @@ ConstraintBounds:
         μ = 0.2345678
         A = randn(3,3); H = A'*A
         d = DifferentiableFunction(x->(x'*H*x)[1]/2, (x,storage)->(storage[:] = H*x))
-        x = clamp.(randn(3), -0.99, 0.99)
+        x = broadcast(clamp, randn(3), -0.99, 0.99)
         gx = similar(x)
         cfun = x->Float64[]
         c = Float64[]

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -430,7 +430,7 @@ ConstraintBounds:
             constraints = TwiceDifferentiableConstraintsFunction(σswap(σ, [0.0], [])...)
             state = Optim.initial_state(method, options, d, constraints, [μ/F*10])
             for i = 1:10
-                Optim.update_state!(d, constraints, state, method)
+                Optim.update_state!(d, constraints, state, method, options)
                 Optim.update_fg!(d, constraints, state, method)
                 Optim.update_h!(d, constraints, state, method)
             end
@@ -440,7 +440,7 @@ ConstraintBounds:
             constraints = TwiceDifferentiableConstraintsFunction(σswap(σ, [Float64(σ)], [])...)
             state = Optim.initial_state(method, options, d, constraints, [(1+eps(1.0))*σ])
             for i = 1:10
-                Optim.update_state!(d, constraints, state, method)
+                Optim.update_state!(d, constraints, state, method, options)
                 Optim.update_fg!(d, constraints, state, method)
                 Optim.update_h!(d, constraints, state, method)
             end
@@ -455,7 +455,7 @@ ConstraintBounds:
                 [], [], σswap(σ, [Float64(σ)], [])...)
             state = Optim.initial_state(method, options, d, constraints, [(1+eps(1.0))*σ])
             for i = 1:10
-                Optim.update_state!(d, constraints, state, method)
+                Optim.update_state!(d, constraints, state, method, options)
                 Optim.update_fg!(d, constraints, state, method)
                 Optim.update_h!(d, constraints, state, method)
             end

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -299,7 +299,7 @@ ConstraintBounds:
         bstate, bstep, bounds = state.bstate, state.bstep, constraints.bounds
         αmax = Optim.estimate_maxstep(Inf, state.x[bounds.iz].*bounds.σz,
                                       state.s[bounds.iz].*bounds.σz)
-        ϕ = α->Optim.lagrangian_linefunc(α, d, constraints, state)
+        ϕ = α->Optim.lagrangian_linefunc(α, d, constraints, state, Float64[])
         @test ϕ(0) ≈ qp[1]
         α, nf, ng = method.linesearch!(ϕ, 1.0, αmax, qp)
         @test α > 1e-3

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -342,7 +342,7 @@ ConstraintBounds:
                 Optim.update_h!(d, constraints, state, method)
             end
             @test state.x[1] == σ
-            @test state.bstate.slack_x[1] ≈ μ/abs(F)
+            @test state.bstate.slack_x[1] < eps(float(σ))
             # x >= 1 using the linear/nonlinear constraints
             d = TwiceDifferentiableFunction(x->F*(x[1]-σ), (x,g) -> (g[1] = F), (x,h) -> (h[1,1] = 0))
             constraints = TwiceDifferentiableConstraintsFunction(
@@ -358,7 +358,7 @@ ConstraintBounds:
                 Optim.update_h!(d, constraints, state, method)
             end
             @test state.x[1] == σ
-            @test state.bstate.slack_c[1] ≈ μ/abs(F)
+            @test state.bstate.slack_c[1] < eps(float(σ))
         end
     end
 end

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -43,6 +43,113 @@ ConstraintBounds:
         @test_throws ArgumentError Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0, 2.0], [5.0, 4.8], [5.0, 4.0])
         @test_throws DimensionMismatch Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0], [5.0, 4.8], [5.0, 4.0])
     end
+
+    @testset "Lagrangian val/grad" begin
+        function check_autodiff(d, bounds, x, cfun::Function, bstate, μ)
+            c = cfun(x)
+            J = ForwardDiff.jacobian(cfun, x)
+            # Using real-valued inputs
+            p = Optim.pack_vec(x, bstate)
+            ftot! = (p,storage)->Optim.lagrangian_fgvec!(p, storage, gx, bgrad, d, bounds, x, c, J, bstate, μ, nothing)
+            pgrad = similar(p)
+            ftot!(p, pgrad)
+            # Compute with ForwardDiff
+            chunksize = min(8, length(p))
+            TD = ForwardDiff.Dual{chunksize,eltype(p)}
+            xd = Array{TD}(length(x))
+            bstated = Optim.BarrierStateVars{TD}(bounds)
+            pcmp = similar(p)
+            ftot = p->Optim.lagrangian_vec(p, d, bounds, xd, cfun, bstated, μ, nothing)
+            ForwardDiff.gradient!(pcmp, ftot, p, ForwardDiff.Chunk{chunksize}())
+            @test pcmp ≈ pgrad
+        end
+        # Basic setup
+        μ = 0.2345678
+        A = randn(3,3); H = A'*A
+        d = DifferentiableFunction(x->(x'*H*x)[1]/2, (x,storage)->(storage[:] = H*x))
+        x = clamp.(randn(3), -0.99, 0.99)
+        gx = similar(x)
+        cfun = x->Float64[]
+        c = Float64[]
+        J = Array{Float64}(0,0)
+        ## No constraints
+        bounds = Optim.ConstraintBounds(Float64[], Float64[], Float64[], Float64[])
+        bstate = Optim.BarrierStateVars(bounds, x)
+        bgrad = similar(bstate)
+        f_x, L = Optim.lagrangian_fg!(gx, bgrad, d, bounds, x, Float64[], Array{Float64}(0,0), bstate, μ, nothing)
+        @test f_x == L == d.f(x)
+        @test gx == H*x
+        ## Pure equality constraints on variables
+        d = DifferentiableFunction(x->0.0, (x,storage)->fill!(storage, 0))
+        xbar = fill(0.2, length(x))
+        bounds = Optim.ConstraintBounds(xbar, xbar, [], [])
+        bstate = Optim.BarrierStateVars(bounds)
+        rand!(bstate.λxE)
+        bgrad = similar(bstate)
+        f_x, L = Optim.lagrangian_fg!(gx, bgrad, d, bounds, x, c, J, bstate, μ, nothing)
+        @test f_x == 0
+        @test L ≈ dot(bstate.λxE, xbar-x)
+        @test gx == -bstate.λxE
+        @test bgrad.λxE == xbar-x
+        check_autodiff(d, bounds, x, cfun, bstate, μ)
+        ## Nonnegativity constraints
+        bounds = Optim.ConstraintBounds(zeros(length(x)), fill(Inf,length(x)), [], [])
+        y = rand(length(x))
+        bstate = Optim.BarrierStateVars(bounds, y)
+        bgrad = similar(bstate)
+        f_x, L = Optim.lagrangian_fg!(gx, bgrad, d, bounds, y, Float64[], Array{Float64}(0,0), bstate, μ, nothing)
+        @test f_x == 0
+        @test L ≈ -μ*sum(log, y)
+        @test gx == -μ./y
+        check_autodiff(d, bounds, y, cfun, bstate, μ)
+        ## General inequality constraints on variables
+        bounds = Optim.ConstraintBounds(rand(length(x))-2, rand(length(x))+1, [], [])
+        bstate = Optim.BarrierStateVars(bounds, x)
+        rand!(bstate.slack_x)  # intentionally displace from the correct value
+        rand!(bstate.λx)
+        bgrad = similar(bstate)
+        f_x, L = Optim.lagrangian_fg!(gx, bgrad, d, bounds, x, Float64[], Array{Float64}(0,0), bstate, μ, nothing)
+        @test f_x == 0
+        Ltarget = -μ*sum(log, bstate.slack_x) +
+            dot(bstate.λx, bstate.slack_x - bounds.σx.*(x[bounds.ineqx]-bounds.bx))
+        @test L ≈ Ltarget
+        dx = similar(gx); fill!(dx, 0)
+        for (i,j) in enumerate(bounds.ineqx)
+            dx[j] -= bounds.σx[i]*bstate.λx[i]
+        end
+        @test gx ≈ dx
+        @test bgrad.slack_x == -μ./bstate.slack_x + bstate.λx
+        check_autodiff(d, bounds, x, cfun, bstate, μ)
+        ## Nonlinear equality constraints
+        cfun = x->[x[1]^2+x[2]^2, x[2]*x[3]^2]
+        c = cfun(x)
+        J = ForwardDiff.jacobian(cfun, x)
+        cbar = rand(length(c))
+        bounds = Optim.ConstraintBounds([], [], cbar, cbar)
+        bstate = Optim.BarrierStateVars(bounds, x, c)
+        rand!(bstate.λcE)
+        bgrad = similar(bstate)
+        f_x, L = Optim.lagrangian_fg!(gx, bgrad, d, bounds, x, c, J, bstate, μ, nothing)
+        @test f_x == 0
+        @test L ≈ dot(bstate.λcE, cbar-c)
+        @test gx ≈ -J'*bstate.λcE
+        @test bgrad.λcE == cbar-c
+        check_autodiff(d, bounds, x, cfun, bstate, μ)
+        ## Nonlinear inequality constraints
+        bounds = Optim.ConstraintBounds([], [], rand(length(c))-1, rand(length(c))+1)
+        bstate = Optim.BarrierStateVars(bounds, x, c)
+        rand!(bstate.slack_c)  # intentionally displace from the correct value
+        rand!(bstate.λc)
+        bgrad = similar(bstate)
+        f_x, L = Optim.lagrangian_fg!(gx, bgrad, d, bounds, x, c, J, bstate, μ, nothing)
+        @test f_x == 0
+        Ltarget = -μ*sum(log, bstate.slack_c) +
+            dot(bstate.λc, bstate.slack_c - bounds.σc.*(c[bounds.ineqc]-bounds.bc))
+        @test L ≈ Ltarget
+        @test gx ≈ -J[bounds.ineqc,:]'*(bstate.λc.*bounds.σc)
+        @test bgrad.slack_c == -μ./bstate.slack_c + bstate.λc
+        check_autodiff(d, bounds, x, cfun, bstate, μ)
+    end
 end
 
 nothing

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -1,33 +1,48 @@
 using Optim, Base.Test
 
-b = @inferred(Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0, 2.0], [5.0, 3.8], [5.0, 4.0]))
-@test b.eqx == [3]
-@test b.valx == [2.0]
-@test b.ineqx == [1,2,2]
-@test b.σx == [-1,1,-1]
-@test b.bx == [1.0,0.5,1.0]
-@test b.iz == [1]
-@test b.σz == [1]
-@test b.eqc == [1]
-@test b.valc == [5]
-@test b.ineqc == [2,2]
-@test b.σc == [1,-1]
-@test b.bc == [3.8,4.0]
+@testset "Constraints" begin
+    @testset "Bounds parsing" begin
+        b = @inferred(Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0, 2.0], [5.0, 3.8], [5.0, 4.0]))
+        @test b.eqx == [3]
+        @test b.valx == [2.0]
+        @test b.ineqx == [1,2,2]
+        @test b.σx == [-1,1,-1]
+        @test b.bx == [1.0,0.5,1.0]
+        @test b.iz == [1]
+        @test b.σz == [1]
+        @test b.eqc == [1]
+        @test b.valc == [5]
+        @test b.ineqc == [2,2]
+        @test b.σc == [1,-1]
+        @test b.bc == [3.8,4.0]
+        io = IOBuffer()
+        show(io, b)
+        @test takebuf_string(io) == """
+ConstraintBounds:
+  Variables:
+    x[3]=2.0
+    x[1]≤1.0,x[2]≥0.5,x[2]≤1.0
+    x[1]≥0.0
+  Linear/nonlinear constraints:
+    c_1=5.0
+    c_2≥3.8,c_2≤4.0"""
 
-b = @inferred(Optim.ConstraintBounds(Float64[], Float64[], [5.0, 3.8], [5.0, 4.0]))
-for fn in (:eqx, :valx, :ineqx, :σx, :bx, :iz, :σz)
-    @test isempty(getfield(b, fn))
+        b = @inferred(Optim.ConstraintBounds(Float64[], Float64[], [5.0, 3.8], [5.0, 4.0]))
+        for fn in (:eqx, :valx, :ineqx, :σx, :bx, :iz, :σz)
+            @test isempty(getfield(b, fn))
+        end
+        @test b.eqc == [1]
+        @test b.valc == [5]
+        @test b.ineqc == [2,2]
+        @test b.σc == [1,-1]
+        @test b.bc == [3.8,4.0]
+
+        ba = Optim.ConstraintBounds([], [], [5.0, 3.8], [5.0, 4.0])
+        @test eltype(ba) == Float64
+
+        @test_throws ArgumentError Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0, 2.0], [5.0, 4.8], [5.0, 4.0])
+        @test_throws DimensionMismatch Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0], [5.0, 4.8], [5.0, 4.0])
+    end
 end
-@test b.eqc == [1]
-@test b.valc == [5]
-@test b.ineqc == [2,2]
-@test b.σc == [1,-1]
-@test b.bc == [3.8,4.0]
-
-ba = Optim.ConstraintBounds([], [], [5.0, 3.8], [5.0, 4.0])
-@test eltype(ba) == Float64
-
-@test_throws ArgumentError Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0, 2.0], [5.0, 4.8], [5.0, 4.0])
-@test_throws DimensionMismatch Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0], [5.0, 4.8], [5.0, 4.0])
 
 nothing

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -1,0 +1,33 @@
+using Optim, Base.Test
+
+b = @inferred(Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0, 2.0], [5.0, 3.8], [5.0, 4.0]))
+@test b.eqx == [3]
+@test b.valx == [2.0]
+@test b.ineqx == [1,2,2]
+@test b.σx == [-1,1,-1]
+@test b.bx == [1.0,0.5,1.0]
+@test b.iz == [1]
+@test b.σz == [1]
+@test b.eqc == [1]
+@test b.valc == [5]
+@test b.ineqc == [2,2]
+@test b.σc == [1,-1]
+@test b.bc == [3.8,4.0]
+
+b = @inferred(Optim.ConstraintBounds(Float64[], Float64[], [5.0, 3.8], [5.0, 4.0]))
+for fn in (:eqx, :valx, :ineqx, :σx, :bx, :iz, :σz)
+    @test isempty(getfield(b, fn))
+end
+@test b.eqc == [1]
+@test b.valc == [5]
+@test b.ineqc == [2,2]
+@test b.σc == [1,-1]
+@test b.bc == [3.8,4.0]
+
+ba = Optim.ConstraintBounds([], [], [5.0, 3.8], [5.0, 4.0])
+@test eltype(ba) == Float64
+
+@test_throws ArgumentError Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0, 2.0], [5.0, 4.8], [5.0, 4.0])
+@test_throws DimensionMismatch Optim.ConstraintBounds([0.0, 0.5, 2.0], [1.0, 1.0], [5.0, 4.8], [5.0, 4.0])
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ my_tests = [
     "brent.jl",
     "type_stability.jl",
     "array.jl",
+    "constraints.jl",
     "constrained.jl",
     "callbacks.jl",
     "precon.jl",


### PR DESCRIPTION
No matter how the American election turns out, today we have something to celebrate: the beginning of what I hope will be a merge-worthy native Julia constrained optimization framework.

Long ago said that I would not work on hard-core optimization without a debugger (errors triggered 1 hour into an optimization run are too painful to fix otherwise), but @Keno has delivered, so now it's time for me to pony up. Besides, I've grown tired of maintaining my own fork of Optim and want access to all the goodies and cleanups (*especially* the cleanups) that others have contributed.

Rather than implementing the whole framework at once, I decided to try to keep things "simple" (if a ~~1600~~2000 line diff can be called simple) by implementing just one method. I picked the interior-point Newton method, since that seems to be the mostly widely-used and/or described method, and for which the iteration is relatively simple. There are also many, many bells and whistles one could add. But I want to get a basic implementation of *something* merged before going on to other things.

Compared to #50, there are almost too many differences to mention, as this was a clean start. A few of the highlights:
- it's more in line with the MathProgBase interface (still not a perfect match, but pretty close), for example in [how the bounds are specified](https://github.com/JuliaOpt/Optim.jl/pull/50#issuecomment-37338779) and [how the constraint hessian is requested](https://github.com/JuliaOpt/Optim.jl/pull/50#issuecomment-37261452).
- it supports both equality and inequality constraints
- it should exhibit far greater numerical stability near the edges of the feasible region (this has been a big problem with the approach in #50)

It's also worth briefly mentioning that this might have some nice features, though it needs real-world testing for us to know whether these will materialize. For example, unlike Ipopt this is guaranteed to roughly preserve the descent direction of the user's objective function (it will not choose such a high barrier coefficient that it pushes the solution into a different basin).  

Testing are a mixed bag: there's quite a few tests for the low-level mathematics, but any overall tests (e.g., ones that involve a call to `optimize`) are a work in progress. I'm hoping to make use of CUTEst (https://github.com/JuliaSmoothOptimizers/CUTEst.jl/issues/43#issuecomment-256709346) and do a fairly thorough job, but that will take some time.

It's worth noting a few details:
- argument order may be somewhat confused; in some places I adopt mutated-first, in others (where I'm trying to match some preexisting API) it's last. It's my understanding that Optim will eventually migrate to mutated-first, but perhaps this is too inconsistent now
- I needed to customize the line search algorithm to account for constraints, so this goes against the migration to [LineSearches.jl](https://github.com/anriseth/LineSearches.jl) and reintroduces a linesearch method to Optim. Aside from simplicity in making updates (I don't want to be bothered with tagging another package just to make tests for a RFC pass), I kept this here because I was also trying to move towards a more sane linesearch API and so it doesn't fit with our classic functions. (It's based on the fact that anonymous functions are fast with julia 0.5 and higher---if people are unhappy with the overhead this causes on 0.4, tough. We have to write code for the future, not the past.)

CC @Cody-G, @dpo, @abelsiqueira.
