### PR TITLE
RFC: Support ReverseDiff

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.4
 Calculus
 ForwardDiff 0.3.0 0.4.0
-ReverseDiff 0.0.4
+ReverseDiff 0.0.3
 PositiveFactorizations
 Compat 0.8.4
 LineSearches 0.1.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,7 @@
 julia 0.4
 Calculus
 ForwardDiff 0.3.0 0.4.0
+ReverseDiff 0.0.4
 PositiveFactorizations
 Compat 0.8.4
 LineSearches 0.1.2

--- a/docs/src/algo/autodiff.md
+++ b/docs/src/algo/autodiff.md
@@ -49,24 +49,27 @@ julia> Optim.minimizer(optimize(f, g!, h!, initial_x, Newton()))
 ```
 This is indeed the case. Now let us use finite differences for BFGS (we cannot
     get finite difference Hessians in Optim).
-```jlcon    
+```jlcon
 julia> Optim.minimizer(optimize(f, initial_x, BFGS()))
 2-element Array{Float64,1}:
  1.0
  1.0
 ```
 Still looks good. Returning to automatic differentiation, let us try both solvers using this
-method. We enable automatic differentiation by adding `autodiff = true` to our
+method. We enable [forward mode](https://github.com/JuliaDiff/ForwardDiff.jl) automatic differentiation by adding `autodiff = :forward` to our
 `Optim.Options`.
 ```jlcon
-julia> Optim.minimizer(optimize(f, initial_x, BFGS(), Optim.Options(autodiff = true)))
+julia> Optim.minimizer(optimize(f, initial_x, BFGS(), Optim.Options(autodiff = :forward)))
 2-element Array{Float64,1}:
  1.0
  1.0
 
-julia> Optim.minimizer(optimize(f, initial_x, Newton(), Optim.Options(autodiff = true)))
+julia> Optim.minimizer(optimize(f, initial_x, Newton(), Optim.Options(autodiff = :forward)))
 2-element Array{Float64,1}:
  1.0
  1.0
 ```
 Indeed, the minimizer was found, without providing any gradients or Hessians.
+
+Optim also supports
+[reverse mode](https://github.com/JuliaDiff/ReverseDiff.jl) automatic differentiation, which is enabled by adding `autodiff = :reverse` to `Optim.Options`.

--- a/docs/src/user/config.md
+++ b/docs/src/user/config.md
@@ -44,7 +44,7 @@ In addition to the solver, you can alter the behavior of the Optim package by us
 * `store_trace`: Should a trace of the optimization algorithm's state be stored? Defaults to `false`.
 * `show_trace`: Should a trace of the optimization algorithm's state be shown on `STDOUT`? Defaults to `false`.
 * `extended_trace`: Save additional information. Solver dependent.
-* `autodiff`: When only an objective function is provided, use automatic differentiation to compute exact numerical gradients. If not, finite differencing will be used. This functionality is experimental. Defaults to `false`.
+* `autodiff`: When only an objective function is provided, use automatic differentiation to compute exact numerical gradients. Two methods are available: [forward mode](https://github.com/JuliaDiff/ForwardDiff.jl) (`:forward`), and [reverse mode](https://github.com/JuliaDiff/ReverseDiff.jl) (`:reverse`). If not, finite differencing will be used (`:finite`). This functionality is experimental. Defaults to `:finite`.
 * `show_every`: Trace output is printed every `show_every`th iteration.
 
 We currently recommend the statically dispatched interface by using the `Optim.Options`

--- a/docs/src/user/minimization.md
+++ b/docs/src/user/minimization.md
@@ -26,9 +26,10 @@ using central finite differencing:
 optimize(f, [0.0, 0.0], LBFGS())
 ```
 Alternatively, the `autodiff` keyword will use atomatic differentiation to construct
-the gradient.
+the gradient. Two types of automatic differentiation is supported:
+[forward mode](https://github.com/JuliaDiff/ForwardDiff.jl) (`:forward`), and [reverse mode](https://github.com/JuliaDiff/ReverseDiff.jl) (`:reverse`).
 ```jl
-optimize(f, [0.0, 0.0], LBFGS(), Optim.Options(autodiff = true))
+optimize(f, [0.0, 0.0], LBFGS(), Optim.Options(autodiff = :forward))
 ```
 For better performance and greater precision, you can pass your own gradient function. For the Rosenbrock example, the analytical gradient can be shown to be:
 ```jl
@@ -129,7 +130,7 @@ which will return `"Nelder Mead"`. A bit more useful information is the minimize
 julia> Optim.minimizer(res)
 3-element Array{Float64,1}:
  -0.499921
- -0.3333  
+ -0.3333
  -1.49994
 
 julia> Optim.minimum(res)

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -5,6 +5,7 @@ module Optim
     using PositiveFactorizations
     using Compat
     using ForwardDiff
+    using ReverseDiff
     using LineSearches
 
     import Compat.String

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -134,7 +134,7 @@ function optimize{F<:Function, T, M <: Union{FirstOrderSolver, SecondOrderSolver
         error("The autodiff value $(options.autodiff) is not supported. Use :finite, :forward or :reverse.")
     end
 
-    optimize(d, initial_x, method, options).
+    optimize(d, initial_x, method, options)
 end
 
 function optimize{M<:Union{Newton,NewtonTrustRegion}}(d::OnceDifferentiable,

--- a/src/problems/unconstrained.jl
+++ b/src/problems/unconstrained.jl
@@ -13,7 +13,7 @@ immutable OptimizationProblem
     g!::Function
     h!::Function
     initial_x::Vector{Float64}
-    solutions::Vector
+    solutions
     isdifferentiable::Bool
     istwicedifferentiable::Bool
 end
@@ -26,16 +26,16 @@ examples = Dict{AbstractString, OptimizationProblem}()
 ###
 ##########################################################################
 
-function exponential(x::Vector)
+function exponential(x)
     return exp((2.0 - x[1])^2) + exp((3.0 - x[2])^2)
 end
 
-function exponential_gradient!(x::Vector, storage::Vector)
+function exponential_gradient!(x, storage)
     storage[1] = -2.0 * (2.0 - x[1]) * exp((2.0 - x[1])^2)
     storage[2] = -2.0 * (3.0 - x[2]) * exp((3.0 - x[2])^2)
 end
 
-function exponential_hessian!(x::Vector, storage::Matrix)
+function exponential_hessian!(x, storage)
     storage[1, 1] = 2.0 * exp((2.0 - x[1])^2) * (2.0 * x[1]^2 - 8.0 * x[1] + 9)
     storage[1, 2] = 0.0
     storage[2, 1] = 0.0
@@ -60,8 +60,8 @@ examples["Exponential"] = OptimizationProblem("Exponential",
 ###         Fletcher & Powell
 ##########################################################################
 
-function fletcher_powell(x::Vector)
-    function theta(x::Vector)
+function fletcher_powell(x)
+    function theta(x)
         if x[1] > 0
             return atan(x[2] / x[1]) / (2.0 * pi)
         else
@@ -74,12 +74,12 @@ function fletcher_powell(x::Vector)
 end
 
 # TODO: Implement
-function fletcher_powell_gradient!(x::Vector, storage::Vector)
+function fletcher_powell_gradient!(x, storage)
     return
 end
 
 # TODO: Implement
-function fletcher_powell_hessian!(x::Vector, storage::Matrix)
+function fletcher_powell_hessian!(x, storage)
     return
 end
 
@@ -98,18 +98,18 @@ examples["Fletcher-Powell"] = OptimizationProblem("Fletcher-Powell",
 ###
 ##########################################################################
 
-function himmelblau(x::Vector)
+function himmelblau(x)
     return (x[1]^2 + x[2] - 11)^2 + (x[1] + x[2]^2 - 7)^2
 end
 
-function himmelblau_gradient!(x::Vector, storage::Vector)
+function himmelblau_gradient!(x, storage)
     storage[1] = 4.0 * x[1]^3 + 4.0 * x[1] * x[2] -
                   44.0 * x[1] + 2.0 * x[1] + 2.0 * x[2]^2 - 14.0
     storage[2] = 2.0 * x[1]^2 + 2.0 * x[2] - 22.0 +
                   4.0 * x[1] * x[2] + 4.0 * x[2]^3 - 28.0 * x[2]
 end
 
-function himmelblau_hessian!(x::Vector, storage::Matrix)
+function himmelblau_hessian!(x, storage)
     storage[1, 1] = 12.0 * x[1]^2 + 4.0 * x[2] - 42.0
     storage[1, 2] = 4.0 * x[1] + 4.0 * x[2]
     storage[2, 1] = 4.0 * x[1] + 4.0 * x[2]
@@ -131,17 +131,17 @@ examples["Himmelblau"] = OptimizationProblem("Himmelblau",
 ### Problem 20 in [1]
 ##########################################################################
 
-function hosaki(x::Vector)
+function hosaki(x)
     a = (1.0 - 8.0 * x[1] + 7.0 * x[1]^2 - (7.0 / 3.0) * x[1]^3 + (1.0 / 4.0) * x[1]^4)
     return a * x[2]^2 * exp(-x[2])
 end
 
-function hosaki_gradient!(x::Vector, storage::Vector)
+function hosaki_gradient!(x, storage)
     storage[1] = (x[1]^3 - 7.0 * x[1]^2 + 14.0 * x[1] - 8)* x[2]^2 * exp(-x[2])
     storage[2] = 2.0 * (1.0 - 8.0 * x[1] + 7.0 * x[1]^2 - (7.0 / 3.0) * x[1]^3 + (1.0 / 4.0) * x[1]^4) * x[2] * exp(-x[2]) - (1.0 - 8.0 * x[1] + 7.0 * x[1]^2 - (7.0 / 3.0) * x[1]^3 + (1.0 / 4.0) * x[1]^4) * x[2]^2 * exp(-x[2])
 end
 
-function hosaki_hessian!(x::Vector, storage::Matrix)
+function hosaki_hessian!(x, storage)
     storage[1, 1] = (3.0 * x[1]^2 - 14.0 * x[1] + 14.0) * x[2]^2 * exp(-x[2])
     storage[1, 2] = 2.0 * (x[1]^3 - 7.0 * x[1]^2 + 14.0 * x[1] - 8.0) * x[2] * exp(-x[2])  - (x[1]^3 - 7.0 * x[1]^2 + 14.0 * x[1] - 8.0) * x[2]^2 * exp(-x[2])
     storage[2, 1] =  2.0 * (x[1]^3 - 7.0 * x[1]^2 + 14.0 * x[1] - 8.0) * x[2] * exp(-x[2])  - (x[1]^3 - 7.0 * x[1]^2 + 14.0 * x[1] - 8.0) * x[2]^2 * exp(-x[2])
@@ -163,7 +163,7 @@ examples["Hosaki"] = OptimizationProblem("Hosaki",
 ###
 ##########################################################################
 
-function large_polynomial(x::Vector)
+function large_polynomial(x)
     res = zero(x[1])
     for i in 1:250
         res += (i - x[i])^2
@@ -171,13 +171,13 @@ function large_polynomial(x::Vector)
     return res
 end
 
-function large_polynomial_gradient!(x::Vector, storage::Vector)
+function large_polynomial_gradient!(x, storage)
     for i in 1:250
         storage[i] = -2.0 * (i - x[i])
     end
 end
 
-function large_polynomial_hessian!(x::Vector, storage::Matrix)
+function large_polynomial_hessian!(x, storage)
     for i in 1:250
         for j in i:250
             if i == j
@@ -205,12 +205,12 @@ examples["Large Polynomial"] = OptimizationProblem("Large Polynomial",
 ###
 ##########################################################################
 
-function parabola(x::Vector)
+function parabola(x)
     return (1.0 - x[1])^2 + (2.0 - x[2])^2 + (3.0 - x[3])^2 +
             (5.0 - x[4])^2 + (8.0 - x[5])^2
 end
 
-function parabola_gradient!(x::Vector, storage::Vector)
+function parabola_gradient!(x, storage)
     storage[1] = -2.0 * (1.0 - x[1])
     storage[2] = -2.0 * (2.0 - x[2])
     storage[3] = -2.0 * (3.0 - x[3])
@@ -218,7 +218,7 @@ function parabola_gradient!(x::Vector, storage::Vector)
     storage[5] = -2.0 * (8.0 - x[5])
 end
 
-function parabola_hessian!(x::Vector, storage::Matrix)
+function parabola_hessian!(x, storage)
     for i in 1:5
         for j in 1:5
             if i == j
@@ -245,17 +245,17 @@ examples["Parabola"] = OptimizationProblem("Parabola",
 ###
 ##########################################################################
 
-function polynomial(x::Vector)
+function polynomial(x)
     return (10.0 - x[1])^2 + (7.0 - x[2])^4 + (108.0 - x[3])^4
 end
 
-function polynomial_gradient!(x::Vector, storage::Vector)
+function polynomial_gradient!(x, storage)
     storage[1] = -2.0 * (10.0 - x[1])
     storage[2] = -4.0 * (7.0 - x[2])^3
     storage[3] = -4.0 * (108.0 - x[3])^3
 end
 
-function polynomial_hessian!(x::Vector, storage::Matrix)
+function polynomial_hessian!(x, storage)
     storage[1, 1] = 2.0
     storage[1, 2] = 0.0
     storage[1, 3] = 0.0
@@ -284,19 +284,19 @@ examples["Polynomial"] = OptimizationProblem("Polynomial",
 ### Difficult since the hessian is singular at the optimum
 ##########################################################################
 
-function powell(x::Vector)
+function powell(x)
     return (x[1] + 10.0 * x[2])^2 + 5.0 * (x[3] - x[4])^2 +
             (x[2] - 2.0 * x[3])^4 + 10.0 * (x[1] - x[4])^4
 end
 
-function powell_gradient!(x::Vector, storage::Vector)
+function powell_gradient!(x, storage)
     storage[1] = 2.0 * (x[1] + 10.0 * x[2]) + 40.0 * (x[1] - x[4])^3
     storage[2] = 20.0 * (x[1] + 10.0 * x[2]) + 4.0 * (x[2] - 2.0 * x[3])^3
     storage[3] = 10.0 * (x[3] - x[4]) - 8.0 * (x[2] - 2.0 * x[3])^3
     storage[4] = -10.0 * (x[3] - x[4]) - 40.0 * (x[1] - x[4])^3
 end
 
-function powell_hessian!(x::Vector, storage::Matrix)
+function powell_hessian!(x, storage)
     storage[1, 1] = 2.0 + 120.0 * (x[1] - x[4])^2
     storage[1, 2] = 20.0
     storage[1, 3] = 0.0
@@ -333,16 +333,16 @@ examples["Powell"] = OptimizationProblem("Powell",
 ### Saddle point makes optimization difficult
 ##########################################################################
 
-function rosenbrock(x::Vector)
+function rosenbrock(x)
     return (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
 end
 
-function rosenbrock_gradient!(x::Vector, storage::Vector)
+function rosenbrock_gradient!(x, storage)
     storage[1] = -2.0 * (1.0 - x[1]) - 400.0 * (x[2] - x[1]^2) * x[1]
     storage[2] = 200.0 * (x[2] - x[1]^2)
 end
 
-function rosenbrock_hessian!(x::Vector, storage::Matrix)
+function rosenbrock_hessian!(x, storage)
     storage[1, 1] = 2.0 - 400.0 * x[2] + 1200.0 * x[1]^2
     storage[1, 2] = -400.0 * x[1]
     storage[2, 1] = -400.0 * x[1]

--- a/src/types.jl
+++ b/src/types.jl
@@ -8,7 +8,7 @@ immutable Options{TCallback <: Union{Void, Function}}
     store_trace::Bool
     show_trace::Bool
     extended_trace::Bool
-    autodiff::Bool
+    autodiff::Symbol
     show_every::Int
     callback::TCallback
     time_limit::Float64
@@ -23,7 +23,7 @@ function Options(;
         store_trace::Bool = false,
         show_trace::Bool = false,
         extended_trace::Bool = false,
-        autodiff::Bool = false,
+        autodiff::Symbol = :finite,
         show_every::Integer = 1,
         callback = nothing,
         time_limit = NaN)

--- a/test/bfgs.jl
+++ b/test/bfgs.jl
@@ -1,5 +1,5 @@
 @testset "BFGS" begin
-    for use_autodiff in (false, true)
+    for use_autodiff in (:finite, :forward, :reverse)
         for (name, prob) in Optim.UnconstrainedProblems.examples
             if prob.isdifferentiable
                 f_prob = prob.f

--- a/test/gradient_descent.jl
+++ b/test/gradient_descent.jl
@@ -1,5 +1,5 @@
 @testset "Gradient Descent" begin
-    for use_autodiff in (false, true)
+    for use_autodiff in (:finite, :forward, :reverse)
         for (name, prob) in Optim.UnconstrainedProblems.examples
             if prob.isdifferentiable
                 f_prob = prob.f

--- a/test/l_bfgs.jl
+++ b/test/l_bfgs.jl
@@ -1,5 +1,5 @@
 @testset "L-BFGS" begin
-    for use_autodiff in (false, true)
+    for use_autodiff in (:finite, :forward, :reverse)
         for (name, prob) in Optim.UnconstrainedProblems.examples
             if prob.isdifferentiable
                 f_prob = prob.f

--- a/test/lsthrow.jl
+++ b/test/lsthrow.jl
@@ -9,7 +9,7 @@
         println("Testing $(string(optimizer))")
         prob = Optim.UnconstrainedProblems.examples["Exponential"]
         optimize(prob.f, prob.initial_x, optimizer(linesearch = ls),
-                 Optim.Options(autodiff = true))
+                 Optim.Options(autodiff = :forward))
         # TODO: How can I verify that the call to optimize gives a warning?
     end
 end

--- a/test/momentum_gradient_descent.jl
+++ b/test/momentum_gradient_descent.jl
@@ -1,5 +1,5 @@
 @testset "Momentum Gradient Descent" begin
-    for use_autodiff in (false, true)
+    for use_autodiff in (:finite, :forward, :reverse)
         for (name, prob) in Optim.UnconstrainedProblems.examples
             if prob.isdifferentiable && !(name in ("Polynomial", "Large Polynomial", "Himmelblau")) # it goes in a direction of ascent -> f_converged == true
                 f_prob = prob.f

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -15,7 +15,7 @@
 
     # Need to specify autodiff!
     @test_throws ErrorException Optim.optimize(OnceDifferentiable(f_1, g!_1), [0.0], Newton())
-    Optim.optimize(OnceDifferentiable(f_1, g!_1), [0.0], Newton(), Optim.Options(autodiff = true))
+    Optim.optimize(OnceDifferentiable(f_1, g!_1), [0.0], Newton(), Optim.Options(autodiff = :forward))
 
     results = Optim.optimize(d, [0.0], Newton())
     @test_throws ErrorException Optim.x_trace(results)
@@ -25,19 +25,19 @@
     eta = 0.9
 
     function f_2(x::Vector)
-      (1.0 / 2.0) * (x[1]^2 + eta * x[2]^2)
+        (1.0 / 2.0) * (x[1]^2 + eta * x[2]^2)
     end
 
     function g!_2(x::Vector, storage::Vector)
-      storage[1] = x[1]
-      storage[2] = eta * x[2]
+        storage[1] = x[1]
+        storage[2] = eta * x[2]
     end
 
     function h!_2(x::Vector, storage::Matrix)
-      storage[1, 1] = 1.0
-      storage[1, 2] = 0.0
-      storage[2, 1] = 0.0
-      storage[2, 2] = eta
+        storage[1, 1] = 1.0
+        storage[1, 2] = 0.0
+        storage[2, 1] = 0.0
+        storage[2, 2] = eta
     end
 
     d = TwiceDifferentiable(f_2, g!_2, h!_2)
@@ -49,11 +49,11 @@
     # Test Optim.newton for all twice differentiable functions in Optim.UnconstrainedProblems.examples
     @testset "Optim problems" begin
         for (name, prob) in Optim.UnconstrainedProblems.examples
-        	if prob.istwicedifferentiable
-        		ddf = TwiceDifferentiable(prob.f, prob.g!,prob.h!)
-        		res = Optim.optimize(ddf, prob.initial_x, Newton())
-        		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-        	end
+            if prob.istwicedifferentiable
+                ddf = TwiceDifferentiable(prob.f, prob.g!,prob.h!)
+                res = Optim.optimize(ddf, prob.initial_x, Newton())
+                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+            end
         end
     end
 
@@ -66,15 +66,16 @@
 
     @testset "Optim problems (ForwardDiff)" begin
         for (name, prob) in Optim.UnconstrainedProblems.examples
-        	if prob.istwicedifferentiable
-        		ddf = OnceDifferentiable(prob.f, prob.g!)
-        		res = Optim.optimize(ddf, prob.initial_x, Newton(), Optim.Options(autodiff = true))
-        		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-        		res = Optim.optimize(ddf.f, prob.initial_x, Newton(), Optim.Options(autodiff = true))
-        		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-                res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, Newton(), Optim.Options(autodiff = true))
-        		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-        	end
+            if prob.istwicedifferentiable
+                opts = Optim.Options(autodiff = :forward)
+                ddf = OnceDifferentiable(prob.f, prob.g!)
+                res = Optim.optimize(ddf, prob.initial_x, Newton(), opts)
+                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                res = Optim.optimize(ddf.f, prob.initial_x, Newton(), opts)
+                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, Newton(), opts)
+                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+            end
         end
     end
 end

--- a/test/newton.jl
+++ b/test/newton.jl
@@ -67,14 +67,16 @@
     @testset "Optim problems (ForwardDiff)" begin
         for (name, prob) in Optim.UnconstrainedProblems.examples
             if prob.istwicedifferentiable
-                opts = Optim.Options(autodiff = :forward)
-                ddf = OnceDifferentiable(prob.f, prob.g!)
-                res = Optim.optimize(ddf, prob.initial_x, Newton(), opts)
-                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-                res = Optim.optimize(ddf.f, prob.initial_x, Newton(), opts)
-                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-                res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, Newton(), opts)
-                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                for use_autodiff in (:forward, :reverse)
+                    opts = Optim.Options(autodiff = use_autodiff)
+                    ddf = OnceDifferentiable(prob.f, prob.g!)
+                    res = Optim.optimize(ddf, prob.initial_x, Newton(), opts)
+                    @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                    res = Optim.optimize(ddf.f, prob.initial_x, Newton(), opts)
+                    @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                    res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, Newton(), opts)
+                    @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                end
             end
         end
     end

--- a/test/newton_trust_region.jl
+++ b/test/newton_trust_region.jl
@@ -183,14 +183,16 @@ end
     # Optim.UnconstrainedProblems.examples
     for (name, prob) in Optim.UnconstrainedProblems.examples
         if prob.istwicedifferentiable
-            opts = Optim.Options(autodiff = :forward)
-            ddf = OnceDifferentiable(prob.f, prob.g!)
-            res = Optim.optimize(ddf, prob.initial_x, NewtonTrustRegion(), opts)
-            @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-            res = Optim.optimize(ddf.f, prob.initial_x, NewtonTrustRegion(), opts)
-            @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-            res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, NewtonTrustRegion(), opts)
-            @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+            for use_autodiff in (:forward, :reverse)
+                opts = Optim.Options(autodiff = use_autodiff)
+                ddf = OnceDifferentiable(prob.f, prob.g!)
+                res = Optim.optimize(ddf, prob.initial_x, NewtonTrustRegion(), opts)
+                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                res = Optim.optimize(ddf.f, prob.initial_x, NewtonTrustRegion(), opts)
+                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+                res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, NewtonTrustRegion(), opts)
+                @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+            end
         end
     end
 end

--- a/test/newton_trust_region.jl
+++ b/test/newton_trust_region.jl
@@ -182,15 +182,16 @@ end
     # Test Optim.newton for all twice differentiable functions in
     # Optim.UnconstrainedProblems.examples
     for (name, prob) in Optim.UnconstrainedProblems.examples
-    	if prob.istwicedifferentiable
-    		ddf = OnceDifferentiable(prob.f, prob.g!)
-    		res = Optim.optimize(ddf, prob.initial_x, NewtonTrustRegion(), Optim.Options(autodiff = true))
-    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-    		res = Optim.optimize(ddf.f, prob.initial_x, NewtonTrustRegion(), Optim.Options(autodiff = true))
-    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-            res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, NewtonTrustRegion(), Optim.Options(autodiff = true))
-    		@test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
-    	end
+        if prob.istwicedifferentiable
+            opts = Optim.Options(autodiff = :forward)
+            ddf = OnceDifferentiable(prob.f, prob.g!)
+            res = Optim.optimize(ddf, prob.initial_x, NewtonTrustRegion(), opts)
+            @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+            res = Optim.optimize(ddf.f, prob.initial_x, NewtonTrustRegion(), opts)
+            @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+            res = Optim.optimize(ddf.f, ddf.g!, prob.initial_x, NewtonTrustRegion(), opts)
+            @test norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+        end
     end
 end
 

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -29,7 +29,7 @@
     @test Optim.g_converged(results)
     @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 
-    results = optimize(f1, [127.0, 921.0], Optim.Options(autodiff = true))
+    results = optimize(f1, [127.0, 921.0], Optim.Options(autodiff = :forward))
     @test Optim.g_converged(results)
     @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
 


### PR DESCRIPTION
This adds ReverseDiff automatic differentiation support.

I am not sure whether I have set it up in the most robust way, some feedback on how I call ReverseDiff will be appreciated ( @jrevels ?) 

I have chosen to change `autodiff::Bool` to be a symbol, and allow the options `autodiff == :finite`, `:forward` or `:reverse`. Anybody opposed to this approach?

TODO:
- [ ] Deprecate `autodiff::Bool` keywords

 @jeff-regier