### PR TITLE
Clean trace for SimulatedAnnealing and ParticleSwarm.

### DIFF
--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -21,11 +21,10 @@ function trace!(tr, state, iteration, method::Union{ParticleSwarm, SimulatedAnne
     if options.extended_trace
         dt["x"] = copy(state.x)
     end
-    g_norm = NaN
     update!(tr,
             state.iteration,
             state.f_x,
-            g_norm,
+            NaN,
             dt,
             options.store_trace,
             options.show_trace,

--- a/test/particle_swarm.jl
+++ b/test/particle_swarm.jl
@@ -27,6 +27,7 @@
                              options)
     @test norm(Optim.minimizer(res) - [1.0, 1.0]) < 0.1
 
-    # Add UnconstrainedProblems here; currently they take too many iterations to be
-    # feasible
+    options = Optim.Options(iterations=300, show_trace=true, extended_trace=true, store_trace=true)
+    res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles),
+                             options)
 end

--- a/test/simulated_annealing.jl
+++ b/test/simulated_annealing.jl
@@ -14,4 +14,8 @@
     options = Optim.Options(iterations=100_000)
     results = Optim.optimize(rosenbrock_s, [0.0, 0.0], SimulatedAnnealing(), options)
     @test norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.1
+
+    # test special trace!
+    options = Optim.Options(iterations=10, show_trace=true, store_trace=true, extended_trace=true)
+    results = Optim.optimize(rosenbrock_s, [0.0, 0.0], SimulatedAnnealing(), options)
 end


### PR DESCRIPTION
In unrelated work I made mistake in renaming variable names, and the error didn't show up because we didn't run these two with tracing on at any point.