### PR TITLE
bump ForwardDiff version upper bound

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
 Calculus
-ForwardDiff 0.3.0 0.4.0
+ForwardDiff 0.3.0 0.5.0
 PositiveFactorizations
 Compat 0.18.0
 LineSearches 0.1.2


### PR DESCRIPTION
The latest version of ForwardDiff is needed to support Julia v0.6 without deprecation warnings, but it drops v0.4 support. Since bumping the lower bound here would mean dropping v0.4 support from Optim, I only bumped the upper bound.