### PR TITLE
Prepare for a Switching LineSearches.jl to dispatch

### DIFF
--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -6,7 +6,8 @@
 # If converged, return y_{t}
 # x_{t} = y_{t} + (t - 1.0) / (t + 2.0) * (y_{t} - y_{t - 1})
 
-immutable AcceleratedGradientDescent{L<:Function} <: Optimizer
+# L should be function or any other callable
+immutable AcceleratedGradientDescent{L} <: Optimizer
     linesearch!::L
 end
 

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -1,7 +1,9 @@
 # Translation from our variables to Nocedal and Wright's
 # JMW's dx <=> NW's s
 # JMW's dg <=> NW' y
-immutable BFGS{L<:Function, H<:Function} <: Optimizer
+
+# L should be function or any other callable 
+immutable BFGS{L, H<:Function} <: Optimizer
     linesearch!::L
     initial_invH::H
     resetalpha::Bool

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -53,7 +53,8 @@
 #   for cgdescent and alphamax for linesearch_hz.
 
 
-immutable ConjugateGradient{T, Tprep<:Union{Function, Void}, L<:Function} <: Optimizer
+# L should be function or any other callable 
+immutable ConjugateGradient{T, Tprep<:Union{Function, Void}, L} <: Optimizer
     eta::Float64
     P::T
     precondprep!::Tprep

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -1,4 +1,5 @@
-immutable GradientDescent{L<:Function, T, Tprep<:Union{Function, Void}} <: Optimizer
+# L should be function or any other callable
+immutable GradientDescent{L, T, Tprep<:Union{Function, Void}} <: Optimizer
     linesearch!::L
     P::T
     precondprep!::Tprep

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -60,7 +60,8 @@ function twoloop!(s::Vector,
     return
 end
 
-immutable LBFGS{T, L<:Function, Tprep<:Union{Function, Void}} <: Optimizer
+# L should be function or any other callable 
+immutable LBFGS{T, L, Tprep<:Union{Function, Void}} <: Optimizer
     m::Int
     linesearch!::L
     P::T

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -1,7 +1,8 @@
 # See p. 280 of Murphy's Machine Learning
 # x_k1 = x_k - alpha * gr + mu * (x - x_previous)
 
-immutable MomentumGradientDescent{L<:Function} <: Optimizer
+# L should be function or any other callable
+immutable MomentumGradientDescent{L} <: Optimizer
     mu::Float64
     linesearch!::L
 end


### PR DESCRIPTION
In all the first order methods I've simply removed the requirement that a `linesearch!` must be a function. This allows to plug in a type, which can be made callable. That will allow for a smooth transition from line search functions to line search types. 

In a second step, one can introduce a type `AbstractLinesearch` in `Linesearches.jl`, and then `linesearch!` could be made a `Union{Function, AbstractLinesearch}`. But I'd leave this as a second step, or even remove the possibility of it being a function altogether.

CC @pkofod  , @anriseth 