### PR TITLE
Use copy when storing Nelder-Mead trace

### DIFF
--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -2,7 +2,7 @@ function trace!(tr, d, state, iteration, method::NelderMead, options)
     dt = Dict()
     if options.extended_trace
         dt["centroid"] = copy(state.x_centroid)
-        dt["step_type"] = copy(state.step_type)
+        dt["step_type"] = state.step_type
     end
     update!(tr,
     iteration,

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -1,8 +1,8 @@
 function trace!(tr, d, state, iteration, method::NelderMead, options)
     dt = Dict()
     if options.extended_trace
-        dt["centroid"] = state.x_centroid
-        dt["step_type"] = state.step_type
+        dt["centroid"] = copy(state.x_centroid)
+        dt["step_type"] = copy(state.step_type)
     end
     update!(tr,
     iteration,

--- a/src/utilities/update.jl
+++ b/src/utilities/update.jl
@@ -9,7 +9,7 @@ function update!{T}(tr::OptimizationTrace{T},
                  callback = nothing)
     os = OptimizationState{T}(iteration, f_x, grnorm, dt)
     if store_trace
-        push!(tr, os)
+        push!(tr, deepcopy(os))
     end
     if show_trace
         if iteration % show_every == 0

--- a/src/utilities/update.jl
+++ b/src/utilities/update.jl
@@ -9,7 +9,7 @@ function update!{T}(tr::OptimizationTrace{T},
                  callback = nothing)
     os = OptimizationState{T}(iteration, f_x, grnorm, dt)
     if store_trace
-        push!(tr, deepcopy(os))
+        push!(tr, os)
     end
     if show_trace
         if iteration % show_every == 0

--- a/test/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/test/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -7,6 +7,7 @@
 
     # Test if the trace is correctly stored.
     prob = Optim.UnconstrainedProblems.examples["Rosenbrock"]
-    res = Optim.optimize(prob.f, prob.initial_x, method = NelderMead(), store_trace = true)
+    res = Optim.optimize(prob.f, prob.initial_x, method = NelderMead(), store_trace = true, extended_trace=true)
     @test ( length(unique(Optim.g_norm_trace(res))) != 1 || length(unique(Optim.f_trace(res))) != 1 ) && issorted(Optim.f_trace(res)[end:1])
+    @test !(res.trace[1].metadata["centroid"] === res.trace[end].metadata["centroid"])
 end


### PR DESCRIPTION
I was using the Nelder-Mead solver and the trace was only storing the final value. This was because the solver was reusing memory. This small changes fixes the issue.