### PR TITLE
No upper bound on ForwardDiff

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,5 @@ Compat 0.18.0
 LineSearches 2.1.0
 Calculus
 NLSolversBase
-ForwardDiff 0.3.0 0.5.0
+ForwardDiff 0.3.0 
 ReverseDiff 0.0.3


### PR DESCRIPTION
We were constraining ForwardDiff to 0.4, but 0.5 should work as well.
Do we want to have upper bounds on packages in anticipating breakages? I think we should either have it on all, or none