### PR TITLE
Move assess_convergence and trace! methods from utilities to solvers

### DIFF
--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -73,3 +73,12 @@ function update_state!{T}(d, state::AcceleratedGradientDescentState{T}, method::
 
     lssuccess == false # break on linesearch error
 end
+
+function assess_convergence(state::AcceleratedGradientDescentState, d, options)
+  default_convergence_assessment(state, d, options)
+end
+
+
+function trace!(tr, d, state, iteration, method::AcceleratedGradientDescent, options)
+  common_1order_trace!(tr, d, state, iteration, method, options)
+end

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -74,7 +74,7 @@ function update_state!{T}(d, state::BFGSState{T}, method::BFGS)
     # Update current position
     state.dx .= state.alpha.*state.s
     state.x .= state.x .+ state.dx
-#  
+#
     lssuccess == false # break on linesearch error
 end
 
@@ -101,4 +101,28 @@ function update_h!(d, state, method::BFGS)
             @inbounds state.invH[i, j] += c1 * state.dx[i] * state.dx[j] - c2 * (state.u[i] * state.dx[j] + state.u[j] * state.dx[i])
         end
     end
+end
+
+function assess_convergence(state::BFGSState, d, options)
+  default_convergence_assessment(state, d, options)
+end
+
+function trace!(tr, d, state, iteration, method::BFGS, options)
+    dt = Dict()
+    if options.extended_trace
+        dt["x"] = copy(state.x)
+        dt["g(x)"] = copy(gradient(d))
+        dt["~inv(H)"] = copy(state.invH)
+        dt["Current step size"] = state.alpha
+    end
+    g_norm = vecnorm(gradient(d), Inf)
+    update!(tr,
+    iteration,
+    value(d),
+    g_norm,
+    dt,
+    options.store_trace,
+    options.show_trace,
+    options.show_every,
+    options.callback)
 end

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -183,3 +183,11 @@ function update_state!{T}(d, state::ConjugateGradientState{T}, method::Conjugate
 end
 
 update_g!(d, state, method::ConjugateGradient) = nothing
+
+function assess_convergence(state::ConjugateGradientState, d, options)
+  default_convergence_assessment(state, d, options)
+end
+
+function trace!(tr, d, state, iteration, method::ConjugateGradient, options)
+  common_1order_trace!(tr, d, state, iteration, method, options)
+end

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -56,3 +56,11 @@ function update_state!{T}(d, state::GradientDescentState{T}, method::GradientDes
     LinAlg.axpy!(state.alpha, state.s, state.x)
     lssuccess == false # break on linesearch error
 end
+
+function assess_convergence(state::GradientDescentState, d, options)
+  default_convergence_assessment(state, d, options)
+end
+
+function trace!(tr, d, state, iteration, method::GradientDescent, options)
+  common_1order_trace!(tr, d, state, iteration, method, options)
+end

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -177,3 +177,12 @@ function update_h!(d, state, method::LBFGS)
     state.rho[mod1(state.pseudo_iteration, method.m)] = rho_iteration
 
 end
+
+function assess_convergence(state::LBFGSState, d, options)
+  default_convergence_assessment(state, d, options)
+end
+
+
+function trace!(tr, d, state, iteration, method::LBFGS, options)
+  common_1order_trace!(tr, d, state, iteration, method, options)
+end

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -55,3 +55,11 @@ function update_state!{T}(d, state::MomentumGradientDescentState{T}, method::Mom
     end
     lssuccess == false # break on linesearch error
 end
+
+function assess_convergence(state::MomentumGradientDescentState, d, options)
+  default_convergence_assessment(state, d, options)
+end
+
+function trace!(tr, d, state, iteration, method::MomentumGradientDescent, options)
+  common_1order_trace!(tr, d, state, iteration, method, options)
+end

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -56,3 +56,26 @@ function update_state!{T}(d, state::NewtonState{T}, method::Newton)
     LinAlg.axpy!(state.alpha, state.s, state.x)
     lssuccess == false # break on linesearch error
 end
+
+function assess_convergence(state::NewtonState, d, options)
+  default_convergence_assessment(state, d, options)
+end
+
+function trace!(tr, d, state, iteration, method::Newton, options)
+    dt = Dict()
+    if options.extended_trace
+        dt["x"] = copy(state.x)
+        dt["g(x)"] = copy(gradient(d))
+        dt["h(x)"] = copy(NLSolversBase.hessian(d))
+    end
+    g_norm = vecnorm(gradient(d), Inf)
+    update!(tr,
+            iteration,
+            value(d),
+            g_norm,
+            dt,
+            options.store_trace,
+            options.show_trace,
+            options.show_every,
+            options.callback)
+end

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -316,3 +316,47 @@ function update_state!{T}(d, state::NewtonTrustRegionState{T}, method::NewtonTru
 
     false
 end
+
+function assess_convergence(state::NewtonTrustRegionState, d, options)
+    x_converged, f_converged, g_converged, converged, f_increased = false, false, false, false, false
+    if state.rho > state.eta
+        # Accept the point and check convergence
+        x_converged,
+        f_converged,
+        g_converged,
+        converged,
+        f_increased = assess_convergence(state.x,
+                                       state.x_previous,
+                                       value(d),
+                                       state.f_x_previous,
+                                       gradient(d),
+                                       options.x_tol,
+                                       options.f_tol,
+                                       options.g_tol)
+    end
+    x_converged, f_converged, g_converged, converged, f_increased
+end
+
+function trace!(tr, d, state, iteration, method::NewtonTrustRegion, options)
+    dt = Dict()
+    if options.extended_trace
+        dt["x"] = copy(state.x)
+        dt["g(x)"] = copy(gradient(d))
+        dt["h(x)"] = copy(NLSolversBase.hessian(H))
+        dt["delta"] = copy(state.delta)
+        dt["interior"] = state.interior
+        dt["hard case"] = state.hard_case
+        dt["reached_subproblem_solution"] = state.reached_subproblem_solution
+        dt["lambda"] = state.lambda
+    end
+    g_norm = norm(gradient(d), Inf)
+    update!(tr,
+            iteration,
+            value(d),
+            g_norm,
+            dt,
+            options.store_trace,
+            options.show_trace,
+            options.show_every,
+            options.callback)
+end

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -342,7 +342,7 @@ function trace!(tr, d, state, iteration, method::NewtonTrustRegion, options)
     if options.extended_trace
         dt["x"] = copy(state.x)
         dt["g(x)"] = copy(gradient(d))
-        dt["h(x)"] = copy(NLSolversBase.hessian(H))
+        dt["h(x)"] = copy(NLSolversBase.hessian(d))
         dt["delta"] = copy(state.delta)
         dt["interior"] = state.interior
         dt["hard case"] = state.hard_case

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -268,3 +268,25 @@ function after_while!{F}(f::F, state, method::NelderMead, options)
     f.f_x = f_min
     state.x[:] = x_min
 end
+
+function assess_convergence(state::NelderMeadState, d, options)
+    g_converged = state.nm_x <= options.g_tol # Hijact g_converged for NM stopping criterior
+    return false, false, g_converged, g_converged, false
+end
+
+function trace!(tr, d, state, iteration, method::NelderMead, options)
+    dt = Dict()
+    if options.extended_trace
+        dt["centroid"] = copy(state.x_centroid)
+        dt["step_type"] = state.step_type
+    end
+    update!(tr,
+    iteration,
+    state.f_lowest,
+    state.nm_x,
+    dt,
+    options.store_trace,
+    options.show_trace,
+    options.show_every,
+    options.callback)
+end

--- a/src/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/src/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -443,3 +443,23 @@ function compute_cost!(f,
     end
     nothing
 end
+
+function assess_convergence(state::ParticleSwarmState, d, options)
+  false, false, false, false, false
+end
+
+function trace!(tr, d, state, iteration, method::ParticleSwarm, options)
+    dt = Dict()
+    if options.extended_trace
+        dt["x"] = copy(state.x)
+    end
+    update!(tr,
+            state.iteration,
+            d.f_x,
+            NaN,
+            dt,
+            options.store_trace,
+            options.show_trace,
+            options.show_every,
+            options.callback)
+end

--- a/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
+++ b/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
@@ -75,3 +75,23 @@ function update_state!{T}(nd, state::SimulatedAnnealingState{T}, method::Simulat
     state.iteration += 1
     false
 end
+
+function assess_convergence(state::SimulatedAnnealingState, d, options)
+    false, false, false, false, false
+end
+
+function trace!(tr, d, state, iteration, method::SimulatedAnnealing, options)
+    dt = Dict()
+    if options.extended_trace
+        dt["x"] = copy(state.x)
+    end
+    update!(tr,
+            state.iteration,
+            d.f_x,
+            NaN,
+            dt,
+            options.store_trace,
+            options.show_trace,
+            options.show_every,
+            options.callback)
+end

--- a/src/utilities/assess_convergence.jl
+++ b/src/utilities/assess_convergence.jl
@@ -2,6 +2,7 @@ f_residual(f_x, f_x_previous, f_tol) = abs(f_x - f_x_previous) / (abs(f_x) + f_t
 x_residual(x, x_previous) = maxdiff(x, x_previous)
 g_residual(g) = vecnorm(g, Inf)
 
+# Used by fminbox
 function assess_convergence(x::Array,
                             x_previous::Array,
                             f_x::Real,
@@ -37,8 +38,10 @@ function assess_convergence(x::Array,
     return x_converged, f_converged, g_converged, converged, f_increased
 end
 
-
-function assess_convergence(state, d, options)
+# Default function for convergence assessment used by
+# AcceleratedGradientDescentState, BFGSState, ConjugateGradientState,
+# GradientDescentState, LBFGSState, MomentumGradientDescentState and NewtonState
+function default_convergence_assessment(state::Union{AcceleratedGradientDescentState, BFGSState, ConjugateGradientState, GradientDescentState, LBFGSState, MomentumGradientDescentState, NewtonState}, d, options)
     x_converged, f_converged, f_increased, g_converged = false, false, false, false
 
     if x_residual(state.x, state.x_previous) < options.x_tol
@@ -65,36 +68,4 @@ function assess_convergence(state, d, options)
     converged = x_converged || f_converged || g_converged
 
     return x_converged, f_converged, g_converged, converged, f_increased
-end
-
-function assess_convergence(state::NelderMeadState, d, options)
-    g_converged = state.nm_x <= options.g_tol # Hijact g_converged for NM stopping criterior
-    return false, false, g_converged, g_converged, false
-end
-
-
-function assess_convergence(state::Union{ParticleSwarmState, SimulatedAnnealingState}, d, options)
-    false, false, false, false, false
-end
-
-
-
-function assess_convergence(state::NewtonTrustRegionState, d, options)
-    x_converged, f_converged, g_converged, converged, f_increased = false, false, false, false, false
-    if state.rho > state.eta
-        # Accept the point and check convergence
-        x_converged,
-        f_converged,
-        g_converged,
-        converged,
-        f_increased = assess_convergence(state.x,
-                                       state.x_previous,
-                                       value(d),
-                                       state.f_x_previous,
-                                       gradient(d),
-                                       options.x_tol,
-                                       options.f_tol,
-                                       options.g_tol)
-    end
-    x_converged, f_converged, g_converged, converged, f_increased
 end

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -1,58 +1,6 @@
-function trace!(tr, d, state, iteration, method::NelderMead, options)
-    dt = Dict()
-    if options.extended_trace
-        dt["centroid"] = copy(state.x_centroid)
-        dt["step_type"] = state.step_type
-    end
-    update!(tr,
-    iteration,
-    state.f_lowest,
-    state.nm_x,
-    dt,
-    options.store_trace,
-    options.show_trace,
-    options.show_every,
-    options.callback)
-end
-
-
-function trace!(tr, d, state, iteration, method::Union{ParticleSwarm, SimulatedAnnealing}, options)
-    dt = Dict()
-    if options.extended_trace
-        dt["x"] = copy(state.x)
-    end
-    update!(tr,
-            state.iteration,
-            d.f_x,
-            NaN,
-            dt,
-            options.store_trace,
-            options.show_trace,
-            options.show_every,
-            options.callback)
-end
-
-function trace!(tr, d, state, iteration, method::BFGS, options)
-    dt = Dict()
-    if options.extended_trace
-        dt["x"] = copy(state.x)
-        dt["g(x)"] = copy(gradient(d))
-        dt["~inv(H)"] = copy(state.invH)
-        dt["Current step size"] = state.alpha
-    end
-    g_norm = vecnorm(gradient(d), Inf)
-    update!(tr,
-    iteration,
-    value(d),
-    g_norm,
-    dt,
-    options.store_trace,
-    options.show_trace,
-    options.show_every,
-    options.callback)
-end
-
-function trace!(tr, d, state, iteration, method::Union{LBFGS, AcceleratedGradientDescent, GradientDescent, MomentumGradientDescent, ConjugateGradient}, options)
+# First order methods trace, used by AcceleratedGradientDescent,
+# ConjugateGradient, GradientDescent, LBFGS and MomentumGradientDescent
+function common_1order_trace!(tr, d, state, iteration, method::Union{LBFGS, AcceleratedGradientDescent, GradientDescent, MomentumGradientDescent, ConjugateGradient}, options)
     dt = Dict()
     if options.extended_trace
         dt["x"] = copy(state.x)
@@ -60,49 +8,6 @@ function trace!(tr, d, state, iteration, method::Union{LBFGS, AcceleratedGradien
         dt["Current step size"] = state.alpha
     end
     g_norm = vecnorm(gradient(d), Inf)
-    update!(tr,
-            iteration,
-            value(d),
-            g_norm,
-            dt,
-            options.store_trace,
-            options.show_trace,
-            options.show_every,
-            options.callback)
-end
-
-function trace!(tr, d, state, iteration, method::Newton, options)
-    dt = Dict()
-    if options.extended_trace
-        dt["x"] = copy(state.x)
-        dt["g(x)"] = copy(gradient(d))
-        dt["h(x)"] = copy(NLSolversBase.hessian(d))
-    end
-    g_norm = vecnorm(gradient(d), Inf)
-    update!(tr,
-            iteration,
-            value(d),
-            g_norm,
-            dt,
-            options.store_trace,
-            options.show_trace,
-            options.show_every,
-            options.callback)
-end
-
-function trace!(tr, d, state, iteration, method::NewtonTrustRegion, options)
-    dt = Dict()
-    if options.extended_trace
-        dt["x"] = copy(state.x)
-        dt["g(x)"] = copy(gradient(d))
-        dt["h(x)"] = copy(NLSolversBase.hessian(H))
-        dt["delta"] = copy(state.delta)
-        dt["interior"] = state.interior
-        dt["hard case"] = state.hard_case
-        dt["reached_subproblem_solution"] = state.reached_subproblem_solution
-        dt["lambda"] = state.lambda
-    end
-    g_norm = norm(gradient(d), Inf)
     update!(tr,
             iteration,
             value(d),

--- a/test/multivariate/solvers/second_order/newton.jl
+++ b/test/multivariate/solvers/second_order/newton.jl
@@ -15,7 +15,9 @@
     Optim.optimize(NonDifferentiable(f_1, initial_x), [0.0], Newton())
     Optim.optimize(OnceDifferentiable(f_1, g!_1, initial_x), [0.0], Newton())
 
-    results = Optim.optimize(f_1, g!_1, h!_1, [0.0], Newton())
+    options = Optim.Options(store_trace = true, show_trace = false,
+                            extended_trace = true)
+    results = Optim.optimize(f_1, g!_1, h!_1, [0.0], Newton(), options)
 
     @test_throws ErrorException Optim.x_trace(results)
     @test Optim.g_converged(results)

--- a/test/multivariate/solvers/second_order/newton.jl
+++ b/test/multivariate/solvers/second_order/newton.jl
@@ -18,8 +18,7 @@
     options = Optim.Options(store_trace = true, show_trace = false,
                             extended_trace = true)
     results = Optim.optimize(f_1, g!_1, h!_1, [0.0], Newton(), options)
-
-    @test_throws ErrorException Optim.x_trace(results)
+    #@test_throws ErrorException Optim.x_trace(results)
     @test Optim.g_converged(results)
     @test norm(Optim.minimizer(results) - [5.0]) < 0.01
 

--- a/test/multivariate/solvers/second_order/newton.jl
+++ b/test/multivariate/solvers/second_order/newton.jl
@@ -15,10 +15,10 @@
     Optim.optimize(NonDifferentiable(f_1, initial_x), [0.0], Newton())
     Optim.optimize(OnceDifferentiable(f_1, g!_1, initial_x), [0.0], Newton())
 
-    options = Optim.Options(store_trace = true, show_trace = false,
+    options = Optim.Options(store_trace = false, show_trace = false,
                             extended_trace = true)
     results = Optim.optimize(f_1, g!_1, h!_1, [0.0], Newton(), options)
-    #@test_throws ErrorException Optim.x_trace(results)
+    @test_throws ErrorException Optim.x_trace(results)
     @test Optim.g_converged(results)
     @test norm(Optim.minimizer(results) - [5.0]) < 0.01
 

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -153,6 +153,7 @@ end
     options = Optim.Options(store_trace = false, show_trace = false,
                             extended_trace = true)
     results = Optim.optimize(d, [0.0], NewtonTrustRegion(), options)
+    @test_throws ErrorException Optim.x_trace(results)
     @test length(results.trace) == 0
     @test results.g_converged
     @test norm(Optim.minimizer(results) - [5.0]) < 0.01

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -150,7 +150,9 @@ end
 
     d = TwiceDifferentiable(f, g!, h!, [0.0])
 
-    results = Optim.optimize(d, [0.0], NewtonTrustRegion())
+    options = Optim.Options(store_trace = true, show_trace = false,
+                            extended_trace = true)
+    results = Optim.optimize(d, [0.0], NewtonTrustRegion(), options)
     @test length(results.trace) == 0
     @test results.g_converged
     @test norm(Optim.minimizer(results) - [5.0]) < 0.01

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -150,7 +150,7 @@ end
 
     d = TwiceDifferentiable(f, g!, h!, [0.0])
 
-    options = Optim.Options(store_trace = true, show_trace = false,
+    options = Optim.Options(store_trace = false, show_trace = false,
                             extended_trace = true)
     results = Optim.optimize(d, [0.0], NewtonTrustRegion(), options)
     @test length(results.trace) == 0


### PR DESCRIPTION
Considering that the convergence assessment and the trace update are specific to each solver, I suggest to move those methods from utilities to solver files.

I noticed that a trace method was used for almost all 1st order solver, also a convergence assessment method. So I keep them in utilities with another name and they are called by the `trace!` or `assess_convergence` specific to the solver.