### PR TITLE
Support complex optimization

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -1,5 +1,5 @@
 Base.summary(r::OptimizationResults) = summary(r.method) # might want to do more here than just return summary of the method used
-minimizer(r::OptimizationResults) = r.minimizer
+minimizer(r::OptimizationResults) = iscomplex(r) ? real_to_complex(r.minimizer) : r.minimizer
 minimum(r::OptimizationResults) = r.minimum
 iterations(r::OptimizationResults) = r.iterations
 iteration_limit_reached(r::OptimizationResults) = r.iteration_converged

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -12,9 +12,13 @@ update_h!(d, state, method::SecondOrderSolver) = hessian!(d, state.x)
 after_while!(d, state, method, options) = nothing
 
 function optimize{D<:AbstractObjective, M<:Optimizer}(d::D, initial_x::AbstractArray, method::M,
-    options::Options = Options(), state = initial_state(method, options, d, initial_x))
+    options::Options = Options(), state = initial_state(method, options, d, NLSolversBase.iscomplex(d) ? NLSolversBase.complex_to_real(initial_x) : initial_x))
 
     t0 = time() # Initial time stamp used to control early stopping by options.time_limit
+
+    if NLSolversBase.iscomplex(d)
+        initial_x = NLSolversBase.complex_to_real(initial_x)
+    end
 
     if length(initial_x) == 1 && typeof(method) <: NelderMead
         error("Use optimize(f, scalar, scalar) for 1D problems")
@@ -70,6 +74,7 @@ function optimize{D<:AbstractObjective, M<:Optimizer}(d::D, initial_x::AbstractA
 
     try
     return MultivariateOptimizationResults(method,
+                                            NLSolversBase.iscomplex(d),
                                             initial_x,
                                             f_increased ? state.x_previous : state.x,
                                             f_increased ? state.f_x_previous : value(d),
@@ -91,6 +96,7 @@ function optimize{D<:AbstractObjective, M<:Optimizer}(d::D, initial_x::AbstractA
                                             h_calls(d))
     catch
       return MultivariateOptimizationResults(method,
+                                              NLSolversBase.iscomplex(d),
                                               initial_x,
                                               f_increased ? state.x_previous : state.x,
                                               f_increased ? state.f_x_previous : value(d),

--- a/src/multivariate/solvers/constrained/fminbox.jl
+++ b/src/multivariate/solvers/constrained/fminbox.jl
@@ -232,7 +232,7 @@ function optimize{T<:AbstractFloat,O<:Optimizer}(
         results.x_converged, results.f_converged, results.g_converged, converged, f_increased = assess_convergence(x, xold, minimum(results), fval0, g, x_tol, f_tol, g_tol)
         f_increased && !allow_f_increases && break
     end
-    return MultivariateOptimizationResults(Fminbox{O}(), initial_x, minimizer(results), df.f(minimizer(results)),
+    return MultivariateOptimizationResults(Fminbox{O}(), false, initial_x, minimizer(results), df.f(minimizer(results)),
             iteration, results.iteration_converged,
             results.x_converged, results.x_tol, vecnorm(x - xold),
             results.f_converged, results.f_tol, f_residual(minimum(results), fval0, f_tol),

--- a/src/types.jl
+++ b/src/types.jl
@@ -64,6 +64,7 @@ abstract type OptimizationResults end
 
 mutable struct MultivariateOptimizationResults{O<:Optimizer,T,N,M} <: OptimizationResults
     method::O
+    iscomplex::Bool
     initial_x::Array{T,N}
     minimizer::Array{T,N}
     minimum::T
@@ -84,6 +85,7 @@ mutable struct MultivariateOptimizationResults{O<:Optimizer,T,N,M} <: Optimizati
     g_calls::Int
     h_calls::Int
 end
+iscomplex(r::MultivariateOptimizationResults) = r.iscomplex
 
 function Base.show(io::IO, t::OptimizationState)
     @printf io "%6d   %14e   %14e\n" t.iteration t.value t.g_norm

--- a/src/univariate/types.jl
+++ b/src/univariate/types.jl
@@ -12,3 +12,4 @@ mutable struct UnivariateOptimizationResults{Tb,Tt,Tf, Tx,M,O<:Optimizer} <: Opt
     trace::OptimizationTrace{M}
     f_calls::Int
 end
+iscomplex(r::UnivariateOptimizationResults) = false

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -1,0 +1,15 @@
+srand(0)
+
+# Test case: solve Ax=b with A and b complex
+n = 4
+A = randn(n,n) + im*randn(n,n)
+A = A'A + I
+b = randn(4) + im*randn(4)
+
+fcomplex(x) = real(vecdot(x,A*x)/2 - vecdot(b,x))
+gcomplex(x) = A*x-b
+gcomplex!(stor,x) = copy!(stor,gcomplex(x))
+x0 = randn(n)+im*randn(n)
+res = Optim.optimize(fcomplex, gcomplex!, x0, Optim.ConjugateGradient())
+@test Optim.converged(res)
+@test Optim.minimizer(res) ≈ A\b rtol=1e-2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,7 @@ multivariate_tests = [
     "extrapolate",
     "lsthrow",
     "precon",
+    "complex",
 ]
 multivariate_tests = map(s->"./multivariate/"*s*".jl", multivariate_tests)
 


### PR DESCRIPTION
See https://github.com/JuliaNLSolvers/Optim.jl/issues/438. It implements the lazy option: solvers don't have to know they're solving a complex problem. It needs a separate PR in NLSolversBase. Comments very welcome!

(it's not compatible yet with the manifold stuff, so please don't merge the manifolds yet!)