### PR TITLE
Fix math formatting in docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(
 )
 
 deploydocs(
+    deps = Deps.pip("pygments", "mkdocs", "python-markdown-math"),
     repo = "github.com/JuliaNLSolvers/Optim.jl.git",
     julia = "0.6"
 )

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -16,9 +16,10 @@ markdown_extensions:
   - extra
   - tables
   - fenced_code
+  - mdx_math
 
 extra_javascript:
-  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+  - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML
   - assets/mathjaxhelper.js
 
 docs_dir: 'build'

--- a/docs/src/algo/gradientdescent.md
+++ b/docs/src/algo/gradientdescent.md
@@ -9,20 +9,24 @@ GradientDescent(; linesearch = LineSearches.HagerZhang(),
 Gradient Descent a common name for a quasi-Newton solver. This means that it takes
 steps according to
 
-$ x_{n+1} = x_n - P^{-1}\nabla f(x_n)$
+```math
+x_{n+1} = x_n - P^{-1}\nabla f(x_n)
+```
 
-where $P$ is a positive definite matrix. If $P$ is the Hessian, we get Newton's method.
-In Gradient Descent, $P$ is simply an appropriately dimensioned identity matrix,
+where ``P`` is a positive definite matrix. If ``P`` is the Hessian, we get Newton's method.
+In Gradient Descent, ``P`` is simply an appropriately dimensioned identity matrix,
 such that we go in the exact opposite direction of the gradient. This means
 that we do not use the curvature information from the Hessian, or an approximation
 of it. While it does seem quite logical to go in the opposite direction of the fastest
 increase in objective value, the procedure can be very slow if the problem is ill-conditioned.
 See the section on preconditioners for ways to remedy this when using Gradient Descent.
 
-As with the other quasi-Newton solvers in this package, a scalar $\alpha$ is introduced
+As with the other quasi-Newton solvers in this package, a scalar ``\alpha`` is introduced
 as follows
 
-$ x_{n+1} = x_n - \alpha P^{-1}\nabla f(x_n)$
+```math
+x_{n+1} = x_n - \alpha P^{-1}\nabla f(x_n)
+```
 
 and is chosen by a linesearch algorithm such that each step gives sufficient descent.
 ## Example

--- a/docs/src/algo/lbfgs.md
+++ b/docs/src/algo/lbfgs.md
@@ -17,9 +17,11 @@ LBFGS(; m = 10,
 ## Description
 This means that it takes steps according to
 
-$ x_{n+1} = x_n - P^{-1}\nabla f(x_n)$
+```math
+x_{n+1} = x_n - P^{-1}\nabla f(x_n)
+```
 
-where $P$ is a positive definite matrix. If $P$ is the Hessian, we get Newton's method.
+where ``P`` is a positive definite matrix. If ``P`` is the Hessian, we get Newton's method.
 In (L-)BFGS, the matrix is an approximation to the Hessian built using differences
 in the gradient across iterations. As long as the initial matrix is positive definite
  it is possible to show that all the follow matrices will be as well. The starting
@@ -28,19 +30,21 @@ to the Gradient Descent algorithm, or even the actual Hessian.
 
 There are two versions of BFGS in the package: BFGS, and L-BFGS. The latter is different
 from the former because it doesn't use a complete history of the iterative procedure to
-construct $P$, but rather only the latest $m$ steps. It doesn't actually build the Hessian
+construct ``P``, but rather only the latest ``m`` steps. It doesn't actually build the Hessian
 approximation matrix either, but computes the direction directly. This makes more suitable for
 large scale problems, as the memory requirement to store the relevant vectors will
 grow quickly in large problems.
 
-As with the other quasi-Newton solvers in this package, a scalar $\alpha$ is introduced
+As with the other quasi-Newton solvers in this package, a scalar ``\alpha`` is introduced
 as follows
 
-$ x_{n+1} = x_n - \alpha P^{-1}\nabla f(x_n)$
+```math
+x_{n+1} = x_n - \alpha P^{-1}\nabla f(x_n)
+```
 
 and is chosen by a linesearch algorithm such that each step gives sufficient descent.
 
-**For BFGS only**: If `resetalpha = true`, the linesearch algorithm starts with the initial value $ \alpha = 1.0 $ for each new BFGS iteration. Otherwise, it will use the terminating value of $ \alpha $ from the previous BFGS iteration.
+**For BFGS only**: If `resetalpha = true`, the linesearch algorithm starts with the initial value ``alpha = 1.0`` for each new BFGS iteration. Otherwise, it will use the terminating value of ``\alpha`` from the previous BFGS iteration.
 
 ## Example
 ## References

--- a/docs/src/algo/nelder_mead.md
+++ b/docs/src/algo/nelder_mead.md
@@ -43,18 +43,20 @@ run-time of the algorithm.
 
 ### Specifying the initial simplex
 The default choice of `initial_simplex` is `AffineSimplexer()`. A simplex is represented
-by an $n+1$ dimensional vector of $n$ dimensional vectors. It is used together
+by an ``(n+1)``-dimensional vector of ``n``-dimensional vectors. It is used together
  with the initial `x` to create the initial simplex. To
-construct the $i$th vertex, it simply multiplies entry $i$ in the initial vector with
-a constant `b`, and adds a constant `a`. This means that the $i$th of the $n$ additional
+construct the ``i``th vertex, it simply multiplies entry ``i`` in the initial vector with
+a constant `b`, and adds a constant `a`. This means that the ``i``th of the ``n`` additional
 vertices is of the form
 
-$ (x_0^1, x_0^2, \ldots, x_0^i, \ldots, 0,0) + (0, 0, \ldots, x_0^i\cdot b+a,\ldots, 0,0) $
+```math
+(x_0^1, x_0^2, \ldots, x_0^i, \ldots, 0,0) + (0, 0, \ldots, x_0^i\cdot b+a,\ldots, 0,0)
+```
 
-If an $x_0^i$ is zero, we need the $a$ to make sure all vertices are unique. Generally,
+If an ``x_0^i`` is zero, we need the ``a`` to make sure all vertices are unique. Generally,
 it is advised to start with a relatively large simplex.
 
-If a specific simplex is wanted, it is possible to construct the $n+1$ vector of $n$ dimensional vectors,
+If a specific simplex is wanted, it is possible to construct the ``(n+1)``-vector of ``n``-dimensional vectors,
 and pass it to the solver using a new type definition and a new method for the function `simplexer`.
 For example, let us minimize the two-dimensional Rosenbrock function, and choose three vertices that have elements
 that are simply standard uniform draws.
@@ -89,16 +91,20 @@ end
 
 ### The parameters of Nelder-Mead
 The different types of steps in the algorithm are governed by four parameters:
-$\alpha$ for the reflection, $\beta$ for the expansion, $\gamma$ for the contraction,
-and $\delta$ for the shrink step. We default to the adaptive parameters scheme in
+``\alpha`` for the reflection, ``\beta`` for the expansion, ``\gamma`` for the contraction,
+and ``\delta`` for the shrink step. We default to the adaptive parameters scheme in
 Gao and Han (2010). These are based on the dimensionality of the problem, and
 are given by
 
-$ \alpha = 1, \quad \beta = 1+2/n,\quad \gamma =0.75 + 1/2n,\quad \delta = 1-1/n $
+```math
+\alpha = 1, \quad \beta = 1+2/n,\quad \gamma =0.75 + 1/2n,\quad \delta = 1-1/n
+```
 
 It is also possible to specify the original parameters from Nelder and Mead (1965)
 
-$ \alpha = 1,\quad \beta = 2, \quad\gamma = 1/2, \quad\delta = 1/2 $
+```math
+\alpha = 1,\quad \beta = 2, \quad\gamma = 1/2, \quad\delta = 1/2
+```
 
 by specifying `parameters  = Optim.FixedParameters()`. For specifying custom values,
 `parameters  = Optim.FixedParameters(α = a, β = b, γ = g, δ = d)` is used, where a, b, g, d are the chosen values. If another

--- a/docs/src/algo/newton.md
+++ b/docs/src/algo/newton.md
@@ -21,32 +21,42 @@ Newton's method for optimization consists of applying Newton's method for solvin
 systems of equations, where the equations are the first order conditions, saying
 that the gradient should equal the zero vector.
 
-$ \nabla f(x) = 0 $
+```math
+\nabla f(x) = 0
+```
 
 A second order Taylor expansion of the left-hand side leads to the iterative scheme
 
-$ x_{n+1} = x_n - H(x_n)^{-1}\nabla f(x_n)$
+```math
+x_{n+1} = x_n - H(x_n)^{-1}\nabla f(x_n)
+```
 
 where the inverse is not calculated directly, but the step size is instead calculated by solving
 
-$ H(x) \textbf{s} = \nabla f(x_n) $.
+```math
+H(x) \textbf{s} = \nabla f(x_n).
+```
 
-This is equivalent to minimizing a quadratic model, $m_k$ around the current $x_n$
+This is equivalent to minimizing a quadratic model, ``m_k`` around the current ``x_n``
 
-$ m_k(s) = f(x_n) + \nabla f(x_n)^\top \textbf{s} + \frac{1}{2} \textbf{s}^\top H(x_n) \textbf{s} $
+```math
+m_k(s) = f(x_n) + \nabla f(x_n)^\top \textbf{s} + \frac{1}{2} \textbf{s}^\top H(x_n) \textbf{s}
+```
 
-For functions where $H(x_n)$ is difficult, or computationally expensive to obtain, we might
+For functions where ``H(x_n)`` is difficult, or computationally expensive to obtain, we might
 replace the Hessian with another positive definite matrix that approximates it.
 Such methods are called Quasi-Newton methods; see (L-)BFGS and Gradient Descent.
 
 In a sufficiently small neighborhood around the minimizer, Newton's method has
 quadratic convergence, but globally it might have slower convergence, or it might
-even diverge. To ensure convergence, a line search is performed for each $\textbf{s}$.
+even diverge. To ensure convergence, a line search is performed for each ``\textbf{s}``.
 This amounts to replacing the step formula above with
 
-$ x_{n+1} = x_n - \alpha \textbf{s}$
+```math
+x_{n+1} = x_n - \alpha \textbf{s}
+```
 
-and finding a scalar $\alpha$ such that we get sufficient descent; see the line search section for more information.
+and finding a scalar ``\alpha`` such that we get sufficient descent; see the line search section for more information.
 
 Additionally, if the function is locally
 concave, the step taken in the formulas above will go in a direction of ascent,

--- a/docs/src/algo/newton_trust_region.md
+++ b/docs/src/algo/newton_trust_region.md
@@ -8,7 +8,7 @@ NewtonTrustRegion(; initial_delta = 1.0,
                     rho_upper = 0.75)
 ```
 
-The constructor takes keywords that determine the initial and maximal size of the trust region, when to grow and shrink the region, and how close the function should be to the quadratic approximation.  The notation follows chapter four of Numerical Optimization.  Below, ```rho```$=\rho$ refers to the ratio of the actual function change to the change in the quadratic approximation for a given step.
+The constructor takes keywords that determine the initial and maximal size of the trust region, when to grow and shrink the region, and how close the function should be to the quadratic approximation.  The notation follows chapter four of Numerical Optimization.  Below, ```rho``` ``=\rho`` refers to the ratio of the actual function change to the change in the quadratic approximation for a given step.
 
 * `initial_delta:`The starting trust region radius
 *  `delta_hat:` The largest allowable trust region radius
@@ -21,25 +21,32 @@ Newton's method with a trust region is designed to take advantage of the second-
 
 Newton's method optimizes a quadratic approximation to a function.  When a function is well approximated by a quadratic (for example, near an optimum), Newton's method converges very quickly by exploiting the second-order information in the Hessian matrix.  However, when the function is not well-approximated by a quadratic, either because the starting point is far from the optimum or the function has a more irregular shape, Newton steps can be erratically large, leading to distant, irrelevant areas of the space.
 
-Trust region methods use second-order information but restrict the steps to be within a "trust region" where the function is believed to be approximately quadratic.  At iteration $k$, a trust region method chooses a step $p$ to minimize a quadratic approximation to the objective such that the step size is no larger than a given trust region size, $\Delta_k$.
+Trust region methods use second-order information but restrict the steps to be within a "trust region" where the function is believed to be approximately quadratic.  At iteration ``k``, a trust region method chooses a step ``p`` to minimize a quadratic approximation to the objective such that the step size is no larger than a given trust region size, ``\Delta_k``.
 
-$\underset{p\in\mathbb{R}^n}\min m_k(p) = f_k + g_k^T p + \frac{1}{2}p^T B_k p \quad\textrm{such that } ||p||\le \Delta_k$
+```math
+\underset{p\in\mathbb{R}^n}\min m_k(p) = f_k + g_k^T p + \frac{1}{2}p^T B_k p \quad\textrm{such that } ||p||\le \Delta_k
+```
 
-Here, $p$ is the step to take at iteration $k$, so that $x_{k+1} = x_k + p$.   In the definition of $m_k(p)$, $f_k = f(x_k)$ is the value at the previous location, $g_k=\nabla f(x_k)$ is the gradient at the previous location, $B_k = \nabla^2 f(x_k)$ is the Hessian matrix at the previous iterate, and $||\cdot||$ is the Euclidian norm.
+Here, ``p`` is the step to take at iteration ``k``, so that ``x_{k+1} = x_k + p``.   In the definition of ``m_k(p)``, ``f_k = f(x_k)`` is the value at the previous location, ``g_k=\nabla f(x_k)`` is the gradient at the previous location, ``B_k = \nabla^2 f(x_k)`` is the Hessian matrix at the previous iterate, and ``||\cdot||`` is the Euclidian norm.
 
-If the trust region size, $\Delta_k$, is large enough that the minimizer of the quadratic approximation $m_k(p)$ has $||p|| \le \Delta_k$, then the step is the same as an ordinary Newton step.  However, if the unconstrained quadratic minimizer lies outside the trust region, then the minimizer to the constrained problem will occur on the boundary, i.e. we will have $||p|| = \Delta_k$.  It turns out that when the Cholesky decomposition of $B_k$ can be computed, the optimal $p$ can be found numerically with relative ease.  ([1], section 4.3)  This is the method currently used in Optim.
+If the trust region size, ``\Delta_k``, is large enough that the minimizer of the quadratic approximation ``m_k(p)`` has ``||p|| \le \Delta_k``, then the step is the same as an ordinary Newton step.  However, if the unconstrained quadratic minimizer lies outside the trust region, then the minimizer to the constrained problem will occur on the boundary, i.e. we will have ``||p|| = \Delta_k``.  It turns out that when the Cholesky decomposition of ``B_k`` can be computed, the optimal ``p`` can be found numerically with relative ease.  ([1], section 4.3)  This is the method currently used in Optim.
 
-It makes sense to adapt the trust region size, $\Delta_k$, as one moves through the space and assesses the quality of the quadratic fit.  This adaptation is controlled by the parameters $\eta$, $\rho_{lower}$, and $\rho_{upper}$, which are parameters to the ```NewtonTrustRegion``` optimization method.  For each step, we calculate
+It makes sense to adapt the trust region size, ``\Delta_k``, as one moves through the space and assesses the quality of the quadratic fit.  This adaptation is controlled by the parameters ``\eta``, ``\rho_{lower}``, and ``\rho_{upper}``, which are parameters to the ```NewtonTrustRegion``` optimization method.  For each step, we calculate
 
-$\rho_k := \frac{f(x_{k+1}) - f(x_k)}{m_k(p) - m_k(0)}$
+```math
+\rho_k := \frac{f(x_{k+1}) - f(x_k)}{m_k(p) - m_k(0)}
+```
 
-Intuitively, $\rho_k$ measures the quality of the quadratic approximation: if $\rho_k \approx 1$, then our quadratic approximation is reasonable.  If  $p$ was on the boundary and $\rho_k > \rho_{upper}$, then perhaps we can benefit from larger steps.  In this case, for the next iteration we grow the trust region geometrically up to a maximum of $\hat\Delta$:
+Intuitively, ``\rho_k`` measures the quality of the quadratic approximation: if ``\rho_k \approx 1``, then our quadratic approximation is reasonable.  If  ``p`` was on the boundary and ``\rho_k > \rho_{upper}``, then perhaps we can benefit from larger steps.  In this case, for the next iteration we grow the trust region geometrically up to a maximum of ``\hat\Delta``:
 
-$\rho_k > \rho_{upper} \Rightarrow \Delta_{k+1} = \min(2 \Delta_k, \hat\Delta)$.
-Conversely, if $\rho_k < \rho_{lower}$, then we shrink the trust region geometrically:
+```math
+\rho_k > \rho_{upper} \Rightarrow \Delta_{k+1} = \min(2 \Delta_k, \hat\Delta).
+```
 
-$\rho_k < \rho_{lower} \Rightarrow \Delta_{k+1} = 0.25 \Delta_k$.
-Finally, we only accept a point if its decrease is appreciable compared to the quadratic approximation.  Specifically, a step is only accepted $\rho_k > \eta$.  As long as we choose $\eta$ to be less than $\rho_{lower}$, we will shrink the trust region whenever we reject a step.  Eventually, if the objective function is locally quadratic, $\Delta_k$ will become small enough that a quadratic approximation will be accurate enough to make progress again.
+Conversely, if ``\rho_k < \rho_{lower}``, then we shrink the trust region geometrically:
+
+``\rho_k < \rho_{lower} \Rightarrow \Delta_{k+1} = 0.25 \Delta_k``.
+Finally, we only accept a point if its decrease is appreciable compared to the quadratic approximation.  Specifically, a step is only accepted ``\rho_k > \eta``.  As long as we choose ``\eta`` to be less than ``\rho_{lower}``, we will shrink the trust region whenever we reject a step.  Eventually, if the objective function is locally quadratic, ``\Delta_k`` will become small enough that a quadratic approximation will be accurate enough to make progress again.
 
 ## Example
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,7 +3,7 @@
 ## What
 Optim is a Julia package for optimizing functions of
 various kinds. While there is some support for box constrained optimization, most
-of the solvers try to find an $x$ that minimizes a function $f(x)$ without any constraints.
+of the solvers try to find an ``x`` that minimizes a function ``f(x)`` without any constraints.
 Thus, the main focus is on unconstrained optimization.
 The provided solvers, under certain conditions, will converge to a local minimum.
 In the case where a global minimum is desired, global optimization techniques should be employed instead (see e.g. [BlackBoxOptim](https://github.com/robertfeldt/BlackBoxOptim.jl)).


### PR DESCRIPTION
Math formatting in the docs is [currently broken](http://julianlsolvers.github.io/Optim.jl/v0.9.3/). This PR fixes math formatting by following the [Documenter instructions](https://juliadocs.github.io/Documenter.jl/latest/man/latex/#MkDocs-and-MathJax-1). I also updated all the math to the [recommended syntax for 0.5](https://juliadocs.github.io/Documenter.jl/latest/man/latex/#Julia-0.5-1).