### PR TITLE
[RFC] Add docstrings to ConjugateGradient, BFGS and the rest

### DIFF
--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -6,7 +6,6 @@
 # If converged, return y_{t}
 # x_{t} = y_{t} + (t - 1.0) / (t + 2.0) * (y_{t} - y_{t - 1})
 
-# L should be function or any other callable
 struct AcceleratedGradientDescent{L} <: Optimizer
     linesearch!::L
 end

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -11,6 +11,30 @@ end
 
 Base.summary(::BFGS) = "BFGS"
 
+"""
+# BFGS
+## Constructor
+```julia
+BFGS(; linesearch = LineSearches.HagerZhang(),
+initial_invH = x -> eye(eltype(x), length(x)),
+resetalpha = true)
+```
+
+## Description
+The `BFGS` method implements the Broyden-Fletcher-Goldfarb-Shanno algorithm as
+described in Nocedal and Wright (sec. 8.1, 1999) and the four individual papers
+Broyden (1970), Fletcher (1970), Goldfarb (1970), and Shanno (1970). It is a
+quasi-Newton method that updates an approximation to the Hessian using past
+approximations as well as the gradient. See also the limited memory variant
+`LBFGS` for an algorithm that is more suitable for high dimensional problems.
+
+## References
+ - Wright, S. J. and J. Nocedal (1999), Numerical optimization. Springer Science 35.67-68: 7.
+ - Broyden, C. G. (1970), The convergence of a class of double-rank minimization algorithms, Journal of the Institute of Mathematics and Its Applications, 6: 76–90.
+ - Fletcher, R. (1970), A New Approach to Variable Metric Algorithms, Computer Journal, 13 (3): 317–322,
+ - Goldfarb, D. (1970), A Family of Variable Metric Updates Derived by Variational Means, Mathematics of Computation, 24 (109): 23–26,
+ - Shanno, D. F. (1970), Conditioning of quasi-Newton methods for function minimization, Mathematics of Computation, 24 (111): 647–656.
+"""
 function BFGS(; linesearch = LineSearches.HagerZhang(),
                 initial_invH = x -> eye(eltype(x), length(x)),
                 resetalpha = true)

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -2,7 +2,6 @@
 # JMW's dx <=> NW's s
 # JMW's dg <=> NW' y
 
-# L should be function or any other callable
 struct BFGS{L, H<:Function} <: Optimizer
     linesearch!::L
     initial_invH::H

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -52,9 +52,6 @@
 #   below.  The default value for alphamax is Inf. See alphamaxfunc
 #   for cgdescent and alphamax for linesearch_hz.
 
-
-# L should be function or any other callable
-
 struct ConjugateGradient{T, Tprep<:Union{Function, Void}, L} <: Optimizer
     eta::Float64
     P::T

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -54,6 +54,7 @@
 
 
 # L should be function or any other callable
+
 struct ConjugateGradient{T, Tprep<:Union{Function, Void}, L} <: Optimizer
     eta::Float64
     P::T
@@ -63,6 +64,30 @@ end
 
 Base.summary(::ConjugateGradient) = "Conjugate Gradient"
 
+"""
+# Conjugate Gradient Descent
+## Constructor
+```julia
+ConjugateGradient(; linesearch = LineSearches.HagerZhang(),
+eta = 0.4,
+P = nothing,
+precondprep = (P, x) -> nothing)
+```
+The strictly positive constant ``eta`` is used in determining
+the next step direction, and the default here deviates from the one used in the
+original paper (where it was ``0.01``). See more details in the original papers
+referenced below.
+
+## Description
+The `ConjugateGradient` method implements Hager and Zhang (2006) and elements
+from Hager and Zhang (2013). Notice, the default `linesearch` is `HagerZhang`
+from LineSearches.jl. This line search is exactly the one proposed in Hager and
+Zhang (2006).
+
+## References
+ - W. W. Hager and H. Zhang (2006) Algorithm 851: CG_DESCENT, a conjugate gradient method with guaranteed descent. ACM Transactions on Mathematical Software 32: 113-137.
+ - W. W. Hager and H. Zhang (2013), The Limited Memory Conjugate Gradient Method. SIAM Journal on Optimization, 23, pp. 2150-2168.
+"""
 function ConjugateGradient(; linesearch = LineSearches.HagerZhang(),
                              eta::Real = 0.4,
                              P::Any = nothing,

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -6,6 +6,25 @@ end
 
 Base.summary(::GradientDescent) = "Gradient Descent"
 
+"""
+# Gradient Descent
+## Constructor
+```julia
+GradientDescent(; linesearch = LineSearches.HagerZhang(),
+P = nothing,
+precondprep = (P, x) -> nothing)
+```
+Keywords are used to control choice of line search, and preconditioning.
+
+## Description
+The `GradientDescent` method a simple gradient descent algorithm, that is the
+search direction is simply the negative gradient at the current iterate, and
+then a line search step is used to compute the final step. See Nocedal and
+Wright (ch. 2.2, 1999) for an explanation of the approach.
+
+## References
+ - Nocedal, J. and Wright, S. J. (1999), Numerical optimization. Springer Science 35.67-68: 7.
+"""
 function GradientDescent(; linesearch = LineSearches.HagerZhang(),
                            P = nothing,
                            precondprep = (P, x) -> nothing)

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -1,4 +1,3 @@
-# L should be function or any other callable
 struct GradientDescent{L, T, Tprep<:Union{Function, Void}} <: Optimizer
     linesearch!::L
     P::T

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -60,7 +60,6 @@ function twoloop!(s::Vector,
     return
 end
 
-# L should be function or any other callable
 struct LBFGS{T, L, Tprep<:Union{Function, Void}} <: Optimizer
     m::Int
     linesearch!::L

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -69,7 +69,34 @@ struct LBFGS{T, L, Tprep<:Union{Function, Void}} <: Optimizer
     extrapolate::Bool
     snap2one::Tuple
 end
+"""
+# LBFGS
+## Constructor
+```julia
+LBFGS(; m::Integer = 10,
+linesearch = LineSearches.HagerZhang(),
+P=nothing,
+precondprep = (P, x) -> nothing,
+extrapolate::Bool=false,
+snap2one = (0.75, Inf))
+```
+`LBFGS` has three special keywords: memory length `m`, `extrapolate` flag,
+and `snap2one` tuple. The memory length determines how many previous Hessian
+approximations to store. The `extrapolate` can be set to `true` to enable an
+extrapolation step used to determine the initial step-size for the line search
+step. The `snap2one` tuple provides boundaries to an interval in which the
+initial step-size should be mapped to the unit step-size.
 
+## Description
+The `LBFGS` method implements the limited-memory BFGS algorithm as described in
+Nocedal and Wright (sec. 9.1, 1999) and original paper by Liu & Nocedal (1989).
+It is a quasi-Newton method that updates an approximation to the Hessian using
+past approximations as well as the gradient.
+
+## References
+ - Wright, S. J. and J. Nocedal (1999), Numerical optimization. Springer Science 35.67-68: 7.
+ - Liu, D. C. and Nocedal, J. (1989). "On the Limited Memory Method for Large Scale Optimization". Mathematical Programming B. 45 (3): 503–528
+"""
 function LBFGS(; m::Integer = 10,
                  linesearch = LineSearches.HagerZhang(),
                  P=nothing,

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -1,7 +1,6 @@
 # See p. 280 of Murphy's Machine Learning
 # x_k1 = x_k - alpha * gr + mu * (x - x_previous)
 
-# L should be function or any other callable
 struct MomentumGradientDescent{L} <: Optimizer
     mu::Float64
     linesearch!::L

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -3,6 +3,25 @@ struct Newton{L} <: Optimizer
     resetalpha::Bool
 end
 
+"""
+# Newton
+## Constructor
+```julia
+Newton(; linesearch = LineSearches.HagerZhang(),
+resetalpha = true)
+```
+The `resetalpha` flag specifies if the initial guess for the step-size should be
+reset to one at each iteration.
+
+## Description
+The `Newton` method implements Newton's method for optimizing a function. We use
+a special factorization from the package `PositiveFactorizations.jl` to ensure
+that each search direction is a direction of descent. See Wright and Nocedal and
+Wright (ch. 6, 1999) for a discussion of Newton's method in practice.
+
+## References
+ - Nocedal, J. and S. J. Wright (1999), Numerical optimization. Springer Science 35.67-68: 7.
+"""
 function Newton(; linesearch = LineSearches.HagerZhang(), resetalpha = true)
     Newton(linesearch,resetalpha)
 end


### PR DESCRIPTION
Since new (and existing) users might not always be able to remember how to specify everything, we should have informative doc strings. I've added one for `ConjugateGradient` and one for `BFGS`. The output looks something like

![conjugate](https://user-images.githubusercontent.com/8431156/30001726-b71c798e-9096-11e7-96eb-9fda1a3b9915.png)

for the former and

![bfgs](https://user-images.githubusercontent.com/8431156/30001727-bb5a5f0c-9096-11e7-8f0d-0c4d2cd6cd32.png)

for the latter in a 80x43 char sized terminal. Feel free to make PRs against this branch to correct mistakes, suggest additional information and add docstrings for more methods.