### PR TITLE
Don't disallow sparse Hessians.

### DIFF
--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -28,12 +28,11 @@ end
 
 Base.summary(::Newton) = "Newton's Method"
 
-mutable struct NewtonState{T, N, F<:Base.LinAlg.Cholesky, Thd}
+mutable struct NewtonState{T, N, F<:Base.LinAlg.Cholesky}
     x::Array{T,N}
     x_previous::Array{T, N}
     f_x_previous::T
     F::F
-    Hd::Thd
     s::Array{T, N}
     @add_linesearch_fields()
 end
@@ -48,9 +47,8 @@ function initial_state(method::Newton, options, d, initial_x::Array{T}) where T
                 similar(initial_x), # Maintain previous state in state.x_previous
                 T(NaN), # Store previous f in state.f_x_previous
                 @static(VERSION >= v"0.7.0-DEV.393" ?
-                        Base.LinAlg.Cholesky(Matrix{T}(0, 0), :U, BLAS.BlasInt(0)) :
-                        Base.LinAlg.Cholesky(Matrix{T}(0, 0), :U)),
-                Vector{Int8}(),
+                        Base.LinAlg.Cholesky(similar(d.H, T, 0, 0), :U, BLAS.BlasInt(0)) :
+                        Base.LinAlg.Cholesky(similar(d.H, T, 0, 0), :U)),
                 similar(initial_x), # Maintain current search direction in state.s
                 @initial_linesearch()...) # Maintain a cache for line search results in state.lsr
 end
@@ -65,15 +63,18 @@ function update_state!(d, state::NewtonState{T}, method::Newton) where T
     copy!(state.x_previous, state.x)
     state.f_x_previous  = value(d)
 
-    state.F, state.Hd = ldltfact!(Positive, NLSolversBase.hessian(d))
-    state.s[:] = -(state.F\gradient(d))
+    if typeof(NLSolversBase.hessian(d)) <: AbstractSparseMatrix
+        state.s .= -NLSolversBase.hessian(d)\gradient(d)
+    else
+        state.F = cholfact!(Positive, NLSolversBase.hessian(d))
+        state.s .= -(state.F\gradient(d))
+    end
 
     # Determine the distance of movement along the search line
     lssuccess = perform_linesearch!(state, method, d)
 
-
     # Update current position # x = x + alpha * s
-    LinAlg.axpy!(state.alpha, state.s, state.x)
+    state.x .= state.x .+ state.alpha * state.s
     lssuccess == false # break on linesearch error
 end
 


### PR DESCRIPTION
With https://github.com/JuliaNLSolvers/NLSolversBase.jl/commit/cee18b6f975a83c6974118a86b98b037660f2107 this allows for sparse hessians in `Newton()`. `NewtonTrustRegion()` I'm not so sure about currently. There's some type annotation things going on, but I also have to see if the code does something non-sparse-y things.

The solve step should obviously be different. I think we should go ahead and do the call overloading of a LinearSolver type for the `-H\g` calculation as in DiffEq.jl - though there were some issues that they had to work out (is it worked out? cc @ChrisRackauckas).

Just putting this up here. May merge it as it is and not advertise it, or may go all the way in this PR. At the very least we shouldn't be restricting things if there's no reason to.

I wonder if PositiveFactorizations could play nicely with abstract matrices @timholy ? Currently, it fails in `potrs!`