### PR TITLE
Pick increased f if allow_f_increases is true

### DIFF
--- a/docs/src/user/config.md
+++ b/docs/src/user/config.md
@@ -44,7 +44,7 @@ In addition to the solver, you can alter the behavior of the Optim package by us
 * `f_calls_limit`: A soft upper limit on the number of objective calls. Defaults to `0` (unlimited).
 * `g_calls_limit`: A soft upper limit on the number of gradient calls. Defaults to `0` (unlimited).
 * `h_calls_limit`: A soft upper limit on the number of Hessian calls. Defaults to `0` (unlimited).
-* `allow_f_increases`: Allow steps that increase the objective value. Defaults to `false`. Take care when `allow_f_increases = true`. When the optimization stops a previous iterate may provide a lower objective value than the reported minimizer.
+* `allow_f_increases`: Allow steps that increase the objective value. Defaults to `false`. Note that, when setting this to `true`, the last iterate will be returned as the minimizer even if the objective increased.
 * `iterations`: How many iterations will run before the algorithm gives up? Defaults to `1_000`.
 * `store_trace`: Should a trace of the optimization algorithm's state be stored? Defaults to `false`.
 * `show_trace`: Should a trace of the optimization algorithm's state be shown on `STDOUT`? Defaults to `false`.

--- a/docs/src/user/config.md
+++ b/docs/src/user/config.md
@@ -44,7 +44,7 @@ In addition to the solver, you can alter the behavior of the Optim package by us
 * `f_calls_limit`: A soft upper limit on the number of objective calls. Defaults to `0` (unlimited).
 * `g_calls_limit`: A soft upper limit on the number of gradient calls. Defaults to `0` (unlimited).
 * `h_calls_limit`: A soft upper limit on the number of Hessian calls. Defaults to `0` (unlimited).
-* `allow_f_increases`: Allow steps that increase the objective value. Defaults to `false`.
+* `allow_f_increases`: Allow steps that increase the objective value. Defaults to `false`. Take care when `allow_f_increases = true`. When the optimization stops a previous iterate may provide a lower objective value than the reported minimizer.
 * `iterations`: How many iterations will run before the algorithm gives up? Defaults to `1_000`.
 * `store_trace`: Should a trace of the optimization algorithm's state be stored? Defaults to `false`.
 * `show_trace`: Should a trace of the optimization algorithm's state be shown on `STDOUT`? Defaults to `false`.

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -76,11 +76,12 @@ function optimize(d::D, initial_x::AbstractArray, method::M,
     if typeof(method) <: KrylovTrustRegion
         # TODO: remove when NLSolversBase.TwiceDifferentiableHV exists
         elty = typeof(state.f_x)
+        f_incr_pick = f_increased && !options.allow_f_increases
         return MultivariateOptimizationResults(method,
                                             NLSolversBase.iscomplex(d),
                                             initial_x,
-                                            pick_best_x(f_increased, state),
-                                            pick_best_f(f_increased, state, d),
+                                            pick_best_x(f_incr_pick, state),
+                                            pick_best_f(f_incr_pick, state, d),
                                             iteration,
                                             iteration == options.iterations,
                                             x_converged,
@@ -99,11 +100,12 @@ function optimize(d::D, initial_x::AbstractArray, method::M,
                                             state.hv_calls)
     else
         elty = typeof(value(d))
+        f_incr_pick = f_increased && !options.allow_f_increases
         return MultivariateOptimizationResults(method,
                                             NLSolversBase.iscomplex(d),
                                             initial_x,
-                                            pick_best_x(f_increased, state),
-                                            pick_best_f(f_increased, state, d),
+                                            pick_best_x(f_incr_pick, state),
+                                            pick_best_f(f_incr_pick, state, d),
                                             iteration,
                                             iteration == options.iterations,
                                             x_converged,

--- a/src/types.jl
+++ b/src/types.jl
@@ -134,7 +134,7 @@ function Base.show(io::IO, r::MultivariateOptimizationResults)
         @printf io "     |f(x) - f(x')| / |f(x)| = %.2e \n" f_residual(r)
         @printf io "   * |g(x)| < %.1e: %s \n" g_tol(r) g_converged(r)
         @printf io "     |g(x)| = %.2e \n"  g_residual(r)
-        @printf io "   * stopped by an increasing objective: %s\n" f_increased(r)
+        @printf io "   * Stopped by an increasing objective: %s\n" (f_increased(r) && !iteration_limit_reached(r))
     end
     @printf io "   * Reached Maximum Number of Iterations: %s\n" iteration_limit_reached(r)
     @printf io " * Objective Calls: %d" f_calls(r)

--- a/src/utilities/assess_convergence.jl
+++ b/src/utilities/assess_convergence.jl
@@ -24,6 +24,8 @@ function assess_convergence(x::Array,
     # Absolute Tolerance
     # if abs(f_x - f_x_previous) < f_tol
     # Relative Tolerance
+    # TODO: we should check this without dividing by f_x:
+    # abs(f_x - f_x_previous) < f_tol*abs(f_x)
     if f_residual(f_x, f_x_previous, f_tol) < f_tol ||
                    abs(f_x - f_x_previous) < eps(abs(f_x)+abs(f_x_previous))
         f_converged = true

--- a/test/general/types.jl
+++ b/test/general/types.jl
@@ -35,7 +35,7 @@ import Compat.String
             @test startswith(lines[8], "   * |x - x'| < ")
             @test startswith(lines[9], "   * |f(x) - f(x')| / |f(x)| < ")
             @test startswith(lines[10], "   * |g(x)| < ")
-            @test startswith(lines[11], "   * stopped by an increasing objective:")
+            @test startswith(lines[11], "   * Stopped by an increasing objective:")
             @test startswith(lines[12], "   * Reached Maximum Number of Iterations: ")
             @test startswith(lines[13], " * Objective Calls: ")
         end
@@ -61,7 +61,7 @@ import Compat.String
     @test startswith(lines[11], "     |f(x) - f(x')| / |f(x)| = ")
     @test startswith(lines[12], "   * |g(x)| < ")
     @test startswith(lines[13],  "     |g(x)| = ")
-    @test startswith(lines[14], "   * stopped by an increasing objective:")
+    @test startswith(lines[14], "   * Stopped by an increasing objective:")
     @test startswith(lines[15], "   * Reached Maximum Number of Iterations: ")
     @test startswith(lines[16], " * Objective Calls: ")
     @test startswith(lines[17], " * Gradient Calls: ")

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -1,15 +1,17 @@
-srand(0)
+@testset "Complex numbers" begin
+    srand(0)
 
-# Test case: solve Ax=b with A and b complex
-n = 4
-A = randn(n,n) + im*randn(n,n)
-A = A'A + I
-b = randn(4) + im*randn(4)
+    # Test case: solve Ax=b with A and b complex
+    n = 4
+    A = randn(n,n) + im*randn(n,n)
+    A = A'A + I
+    b = randn(4) + im*randn(4)
 
-fcomplex(x) = real(vecdot(x,A*x)/2 - vecdot(b,x))
-gcomplex(x) = A*x-b
-gcomplex!(stor,x) = copy!(stor,gcomplex(x))
-x0 = randn(n)+im*randn(n)
-res = Optim.optimize(fcomplex, gcomplex!, x0, Optim.ConjugateGradient())
-@test Optim.converged(res)
-@test Optim.minimizer(res) ≈ A\b rtol=1e-2
+    fcomplex(x) = real(vecdot(x,A*x)/2 - vecdot(b,x))
+    gcomplex(x) = A*x-b
+    gcomplex!(stor,x) = copy!(stor,gcomplex(x))
+    x0 = randn(n)+im*randn(n)
+    res = Optim.optimize(fcomplex, gcomplex!, x0, Optim.ConjugateGradient())
+    @test Optim.converged(res)
+    @test Optim.minimizer(res) ≈ A\b rtol=1e-2
+end

--- a/test/multivariate/f_increase.jl
+++ b/test/multivariate/f_increase.jl
@@ -2,8 +2,11 @@
     f(x) = 2*x[1]^2
     g!(G, x) = copy!(G, 4*x[1])
 
-
-    minimizers = [0.3, -1.5, 0.3, 0.5]
+    # Returned "minimizers" from one iteration of Gradient Descent
+    minimizers = [0.3,  # allow_f_increases = true, alpha = 0.1
+                  -1.5, # allow_f_increases = true, alpha = 1.0
+                  0.3,  # allow_f_increases = false, alpha = 0.1
+                  0.5]  # allow_f_increases = false, alpha = 1.0
     k = 0
     for allow in [true, false]
         for alpha in [0.1, 1.0]

--- a/test/multivariate/f_increase.jl
+++ b/test/multivariate/f_increase.jl
@@ -1,0 +1,18 @@
+@testset "f increase behaviour" begin
+    f(x) = 2*x[1]^2
+    g!(G, x) = copy!(G, 4*x[1])
+
+
+    minimizers = [0.3, -1.5, 0.3, 0.5]
+    k = 0
+    for allow in [true, false]
+        for alpha in [0.1, 1.0]
+            k += 1
+            method = GradientDescent(linesearch=LineSearches.Static(alpha=alpha))
+            opts = Optim.Options(iterations=1,allow_f_increases=allow)
+            res = optimize(f, g!, [0.5], method, opts)
+
+            @test minimizers[k] == Optim.minimizer(res)[1]
+        end
+    end
+end

--- a/test/multivariate/manifolds.jl
+++ b/test/multivariate/manifolds.jl
@@ -1,45 +1,47 @@
-srand(0)
+@testset "Manifolds" begin
+    srand(0)
 
-# Test case: find eigenbasis for first two eigenvalues of a symmetric matrix by minimizing the Rayleigh quotient under orthogonality constraints
-n = 4
-m = 2
-A = Diagonal(linspace(1,2,n))
-fmanif(x) = real(vecdot(x,A*x)/2)
-gmanif(x) = A*x
-gmanif!(stor,x) = copy!(stor,gmanif(x))
-# A[2,2] /= 10 #optional: reduce the gap to make the problem artificially harder
-x0 = randn(n,m)+im*randn(n,m)
+    # Test case: find eigenbasis for first two eigenvalues of a symmetric matrix by minimizing the Rayleigh quotient under orthogonality constraints
+    n = 4
+    m = 2
+    A = Diagonal(linspace(1,2,n))
+    fmanif(x) = real(vecdot(x,A*x)/2)
+    gmanif(x) = A*x
+    gmanif!(stor,x) = copy!(stor,gmanif(x))
+    # A[2,2] /= 10 #optional: reduce the gap to make the problem artificially harder
+    x0 = randn(n,m)+im*randn(n,m)
 
-manif = Optim.Stiefel()
+    manif = Optim.Stiefel()
 
-# AcceleratedGradientDescent should be compatible also, but I haven't been able to make it converge
-for method in (Optim.GradientDescent, Optim.ConjugateGradient, Optim.LBFGS, Optim.BFGS)
-    res = Optim.optimize(fmanif, gmanif!, x0, method(manifold=manif))
+    # AcceleratedGradientDescent should be compatible also, but I haven't been able to make it converge
+    for method in (Optim.GradientDescent, Optim.ConjugateGradient, Optim.LBFGS, Optim.BFGS)
+        res = Optim.optimize(fmanif, gmanif!, x0, method(manifold=manif))
+        @test Optim.converged(res)
+    end
+    res = Optim.optimize(fmanif, gmanif!, x0, Optim.MomentumGradientDescent(mu=0.0, manifold=manif))
     @test Optim.converged(res)
+
+    # Power
+    @views fprod(x) = fmanif(x[:,1]) + fmanif(x[:,2])
+    @views gprod!(stor,x) = (gmanif!(stor[:, 1],x[:, 1]);gmanif!(stor[:, 2],x[:, 2]);stor)
+    m1 = Optim.PowerManifold(Optim.Sphere(), (n,), (2,))
+    srand(0)
+    x0 = randn(n,2) + im*randn(n,2)
+    res = Optim.optimize(fprod, gprod!, x0, Optim.ConjugateGradient(manifold=m1))
+    @test Optim.converged(res)
+    minpow = Optim.minimizer(res)
+
+    # Product
+    @views fprod(x) = fmanif(x[1:n]) + fmanif(x[n+1:2n])
+    @views gprod!(stor,x) = (gmanif!(stor[1:n],x[1:n]);gmanif!(stor[n+1:2n],x[n+1:2n]);stor)
+    m2 = Optim.ProductManifold(Optim.Sphere(), Optim.Sphere(), (n,), (n,))
+    srand(0)
+    x0 = randn(2n) + im*randn(2n)
+    res = Optim.optimize(fprod, gprod!, x0, Optim.ConjugateGradient(manifold=m2))
+    @test Optim.converged(res)
+    minprod = Optim.minimizer(res)
+
+    # results should be exactly equal: same initial guess, same sequence of operations
+    @test minpow[:,1] == minprod[1:n]
+    @test minpow[:,2] == minprod[n+1:2n]
 end
-res = Optim.optimize(fmanif, gmanif!, x0, Optim.MomentumGradientDescent(mu=0.0, manifold=manif))
-@test Optim.converged(res)
-
-# Power
-@views fprod(x) = fmanif(x[:,1]) + fmanif(x[:,2])
-@views gprod!(stor,x) = (gmanif!(stor[:, 1],x[:, 1]);gmanif!(stor[:, 2],x[:, 2]);stor)
-m1 = Optim.PowerManifold(Optim.Sphere(), (n,), (2,))
-srand(0)
-x0 = randn(n,2) + im*randn(n,2)
-res = Optim.optimize(fprod, gprod!, x0, Optim.ConjugateGradient(manifold=m1))
-@test Optim.converged(res)
-minpow = Optim.minimizer(res)
-
-# Product
-@views fprod(x) = fmanif(x[1:n]) + fmanif(x[n+1:2n])
-@views gprod!(stor,x) = (gmanif!(stor[1:n],x[1:n]);gmanif!(stor[n+1:2n],x[n+1:2n]);stor)
-m2 = Optim.ProductManifold(Optim.Sphere(), Optim.Sphere(), (n,), (n,))
-srand(0)
-x0 = randn(2n) + im*randn(2n)
-res = Optim.optimize(fprod, gprod!, x0, Optim.ConjugateGradient(manifold=m2))
-@test Optim.converged(res)
-minprod = Optim.minimizer(res)
-
-# results should be exactly equal: same initial guess, same sequence of operations
-@test minpow[:,1] == minprod[1:n]
-@test minpow[:,2] == minprod[n+1:2n]


### PR DESCRIPTION
I want an option for the optimizer to return the final values of `x` and `f(x)`, even if the last iteration results in `f_increased`.  

Let me know whether you think this is a good idea or not. I can also introduce an extra option `pick_increased_f`, instead of piggy-backing on `allow_f_increases`.