### PR TITLE
L-BFGS: Use scaled initial guess for inverse Hessian

### DIFF
--- a/docs/src/algo/lbfgs.md
+++ b/docs/src/algo/lbfgs.md
@@ -13,7 +13,9 @@ LBFGS(; m = 10,
         alphaguess = LineSearches.InitialStatic(),
         linesearch = LineSearches.HagerZhang(),
         P = nothing,
-        precondprep = (P, x) -> nothing)
+        precondprep = (P, x) -> nothing,
+        manifold = Flat(),
+        scaleinvH0::Bool = true && (typeof(P) <: Void))
 ```
 ## Description
 This means that it takes steps according to

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -14,7 +14,7 @@ function twoloop!(s::Vector,
                   pseudo_iteration::Integer,
                   alpha::Vector,
                   q::Vector,
-                  scaleinvH::Bool,
+                  scaleinvH0::Bool,
                   precon,
                   devec_fun #all data is passed to this function is flat vectors, but precon might expect something different. this function undoes the flattening
                   )
@@ -42,7 +42,7 @@ function twoloop!(s::Vector,
     # Copy q into s for forward pass
     # apply preconditioner if precon != nothing
     # (Note: preconditioner update was done outside of this function)
-    if scaleinvH == true && typeof(precon) <: Void && upper > 0
+    if scaleinvH0 == true && upper > 0
         # Use the initial scaling guess if no preconditioner is used
         # See Nocedal & Wright (2nd ed), Equation (7.20)
         idx = mod1(upper, m)
@@ -77,7 +77,7 @@ struct LBFGS{T, IL, L, Tprep<:Union{Function, Void}} <: Optimizer
     P::T
     precondprep!::Tprep
     manifold::Manifold
-    scaleinvH::Bool
+    scaleinvH0::Bool
 end
 """
 # LBFGS
@@ -89,7 +89,7 @@ linesearch = LineSearches.HagerZhang(),
 P=nothing,
 precondprep = (P, x) -> nothing,
 manifold = Flat(),
-scaleinvH::Bool = true)
+scaleinvH0::Bool = true && (T <: Void)
 ```
 `LBFGS` has two special keywords; the memory length `m`,
 and the `scaleinvH0` flag.
@@ -118,8 +118,8 @@ function LBFGS(; m::Integer = 10,
                  P=nothing,
                  precondprep = (P, x) -> nothing,
                  manifold::Manifold=Flat(),
-                 scaleinvH::Bool = true)
-    LBFGS(Int(m), alphaguess, linesearch, P, precondprep, manifold, scaleinvH)
+                 scaleinvH0::Bool = true && (typeof(P) <: Void) )
+    LBFGS(Int(m), alphaguess, linesearch, P, precondprep, manifold, scaleinvH0)
 end
 
 Base.summary(::LBFGS) = "L-BFGS"
@@ -179,7 +179,7 @@ function update_state!(d, state::LBFGSState{T}, method::LBFGS) where T
     devec_fun(x) = real_to_complex(d,reshape(x, size(state.s)))
     twoloop!(vec(state.s), vec(gradient(d)), vec(state.rho), state.dx_history, state.dg_history,
              method.m, state.pseudo_iteration,
-             state.twoloop_alpha, vec(state.twoloop_q), method.scaleinvH, method.P, devec_fun)
+             state.twoloop_alpha, vec(state.twoloop_q), method.scaleinvH0, method.P, devec_fun)
     project_tangent!(method.manifold, real_to_complex(d,state.s), real_to_complex(d,state.x))
 
     # Save g value to prepare for update_g! call

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -42,9 +42,16 @@ function twoloop!(s::Vector,
     # Copy q into s for forward pass
     # apply preconditioner if precon != nothing
     # (Note: preconditioner update was done outside of this function)
-    if scaleinvH0 == true && upper > 0
+    if scaleinvH0 == true && pseudo_iteration > 1
         # Use the initial scaling guess if no preconditioner is used
         # See Nocedal & Wright (2nd ed), Equation (7.20)
+
+        #=
+        pseudo_iteration > 1 prevents this scaling from happening
+        at the first iteration, but also at the first step after
+        a reset due to invH being non-positive definite (pseudo_iteration = 1).
+        TODO: Maybe we can still use the scaling as long as iteration > 1?
+        =#
         idx = mod1(upper, m)
         sidx = view(dx_history, :, idx) # TODO: should these use devec_fun?
         yidx = view(dg_history, :, idx) # TODO: should these use devec_fun?

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -97,7 +97,7 @@ linesearch = LineSearches.HagerZhang(),
 P=nothing,
 precondprep = (P, x) -> nothing,
 manifold = Flat(),
-scaleinvH0::Bool = true && (T <: Void)
+scaleinvH0::Bool = true && (typeof(P) <: Void))
 ```
 `LBFGS` has two special keywords; the memory length `m`,
 and the `scaleinvH0` flag.

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -14,6 +14,7 @@ function twoloop!(s::Vector,
                   pseudo_iteration::Integer,
                   alpha::Vector,
                   q::Vector,
+                  scaleinvH::Bool,
                   precon,
                   devec_fun #all data is passed to this function is flat vectors, but precon might expect something different. this function undoes the flattening
                   )
@@ -41,7 +42,7 @@ function twoloop!(s::Vector,
     # Copy q into s for forward pass
     # apply preconditioner if precon != nothing
     # (Note: preconditioner update was done outside of this function)
-    if method.scaleinvH == true && typeof(precon) <: Void && upper > 0
+    if scaleinvH == true && typeof(precon) <: Void && upper > 0
         # Use the initial scaling guess if no preconditioner is used
         # See Nocedal & Wright (2nd ed), Equation (7.20)
         idx = mod1(upper, m)
@@ -172,7 +173,7 @@ function update_state!(d, state::LBFGSState{T}, method::LBFGS) where T
     devec_fun(x) = real_to_complex(d,reshape(x, size(state.s)))
     twoloop!(vec(state.s), vec(gradient(d)), vec(state.rho), state.dx_history, state.dg_history,
              method.m, state.pseudo_iteration,
-             state.twoloop_alpha, vec(state.twoloop_q), method.P, devec_fun)
+             state.twoloop_alpha, vec(state.twoloop_q), method.scaleinvH, method.P, devec_fun)
     project_tangent!(method.manifold, real_to_complex(d,state.s), real_to_complex(d,state.x))
 
     # Save g value to prepare for update_g! call

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -49,7 +49,7 @@ function twoloop!(s::Vector,
         sidx = view(dx_history, :, idx) # TODO: should these use devec_fun?
         yidx = view(dg_history, :, idx) # TODO: should these use devec_fun?
         scaling = dot(sidx, yidx) / sum(abs2, yidx) # TODO: Should this be vecdot?
-        s .= scaling*q
+        @. s = scaling*q
     else
         A_ldiv_B!(devec_fun(s), precon, devec_fun(q))
     end
@@ -88,22 +88,28 @@ alphaguess = LineSearches.InitialStatic(),
 linesearch = LineSearches.HagerZhang(),
 P=nothing,
 precondprep = (P, x) -> nothing,
-manifold = Flat())
+manifold = Flat(),
+scaleinvH::Bool = true)
 ```
-`LBFGS` has a special keyword; the memory length `m`.
+`LBFGS` has two special keywords; the memory length `m`,
+and the `scaleinvH0` flag.
 The memory length determines how many previous Hessian
 approximations to store.
-In addition, it supports preconditioning via the `P` and `precondprep`
+When `scaleinvH0 == true`,
+then the initial guess in the two-loop recursion to approximate the
+inverse Hessian is the scaled identity, as can be found in Nocedal and Wright (2nd edition) (sec. 7.2).
+
+In addition, LBFGS supports preconditioning via the `P` and `precondprep`
 keywords.
 
 ## Description
 The `LBFGS` method implements the limited-memory BFGS algorithm as described in
-Nocedal and Wright (sec. 9.1, 1999) and original paper by Liu & Nocedal (1989).
+Nocedal and Wright (sec. 7.2, 2006) and original paper by Liu & Nocedal (1989).
 It is a quasi-Newton method that updates an approximation to the Hessian using
 past approximations as well as the gradient.
 
 ## References
- - Wright, S. J. and J. Nocedal (1999), Numerical optimization. Springer Science 35.67-68: 7.
+ - Wright, S. J. and J. Nocedal (2006), Numerical optimization, 2nd edition. Springer
  - Liu, D. C. and Nocedal, J. (1989). "On the Limited Memory Method for Large Scale Optimization". Mathematical Programming B. 45 (3): 503–528
 """
 function LBFGS(; m::Integer = 10,

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -41,7 +41,7 @@ function twoloop!(s::Vector,
     # Copy q into s for forward pass
     # apply preconditioner if precon != nothing
     # (Note: preconditioner update was done outside of this function)
-    if typeof(precon) <: Void && upper > 0
+    if method.scaleinvH == true && typeof(precon) <: Void && upper > 0
         # Use the initial scaling guess if no preconditioner is used
         # See Nocedal & Wright (2nd ed), Equation (7.20)
         idx = mod1(upper, m)
@@ -76,6 +76,7 @@ struct LBFGS{T, IL, L, Tprep<:Union{Function, Void}} <: Optimizer
     P::T
     precondprep!::Tprep
     manifold::Manifold
+    scaleinvH::Bool
 end
 """
 # LBFGS
@@ -109,8 +110,9 @@ function LBFGS(; m::Integer = 10,
                  linesearch = LineSearches.HagerZhang(),  # TODO: benchmark defaults
                  P=nothing,
                  precondprep = (P, x) -> nothing,
-                 manifold::Manifold=Flat())
-    LBFGS(Int(m), alphaguess, linesearch, P, precondprep, manifold)
+                 manifold::Manifold=Flat(),
+                 scaleinvH::Bool = true)
+    LBFGS(Int(m), alphaguess, linesearch, P, precondprep, manifold, scaleinvH)
 end
 
 Base.summary(::LBFGS) = "L-BFGS"


### PR DESCRIPTION
If a preconditioner is not used, I propose that we default to the scaled initial guess for the inverse Hessian as given in Nocedal and Wright. (See 6.21 or 7.20 in the second edition).

I have also included a resetalpha setting for L-BFGS. It should probably be default for all line searches that `alphaguess!` sets `state.alpha=1`. None of the algorithms I know of uses the previous step length as an initial guess anyway. (Maybe for case of Momentum and AcceleratedGradientDescent; but they need a revamp of `alphaguess!` to work properly anyway)
And as the state is now, BackTracking will perform terribly, as it can only decrease step lengths.