### PR TITLE
Allow callable types for callback

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,5 @@
 abstract type Optimizer end
-struct Options{T, TCallback <: Union{Void, Function}}
+struct Options{T, TCallback}
     x_tol::T
     f_tol::T
     g_tol::T


### PR DESCRIPTION
Currently, we can't use callable types as callback functions. This fixes that issue.