### PR TITLE
Use abstract type instead of typealias for solver distinction.

### DIFF
--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -63,6 +63,6 @@ end
 function optimize(df::OnceDifferentiable,
     l::Array{T},
     u::Array{T},
-    F::Fminbox{O}; kwargs...) where {T<:AbstractFloat,O<:Optimizer}
+    F::Fminbox{O}; kwargs...) where {T<:AbstractFloat,O<:AbstractOptimizer}
     throw(ErrorException("Optimizing an objective `obj` without providing an initial `x` has been deprecated without backwards compatability. Please explicitly provide an `x`: `optimize(obj, x, l, u, method, options)``"))
 end

--- a/src/multivariate/optimize/interface.jl
+++ b/src/multivariate/optimize/interface.jl
@@ -1,7 +1,3 @@
-const ZerothOrderSolver = Union{NelderMead, SimulatedAnnealing, ParticleSwarm}
-const FirstOrderSolver = Union{AcceleratedGradientDescent, ConjugateGradient, GradientDescent,
-                               MomentumGradientDescent, BFGS, LBFGS}
-const SecondOrderSolver = Union{Newton, NewtonTrustRegion, KrylovTrustRegion}
 # Multivariate optimization
 function check_kwargs(kwargs, fallback_method)
     kws = Dict{Symbol, Any}()
@@ -61,10 +57,10 @@ optimize(f, g!,     initial_x::AbstractArray, options::Options) = optimize((f, g
 optimize(f, g!, h!, initial_x::AbstractArray, options::Options) = optimize((f, g!, h!), initial_x, fallback_method(f), options)
 
 # potentially everything is supplied (besides caches)
-optimize(f,         initial_x::AbstractArray, method::Optimizer, options::Options = Options()) = optimize((f,),        initial_x, method, options)
-optimize(f, g!,     initial_x::AbstractArray, method::Optimizer, options::Options = Options()) = optimize((f, g!),     initial_x, method, options)
-optimize(f, g!, h!, initial_x::AbstractArray, method::Optimizer, options::Options = Options()) = optimize((f, g!, h!), initial_x, method, options)
-function optimize(f::Tuple, initial_x::AbstractArray, method::Optimizer, options::Options = Options())
+optimize(f,         initial_x::AbstractArray, method::AbstractOptimizer, options::Options = Options()) = optimize((f,),        initial_x, method, options)
+optimize(f, g!,     initial_x::AbstractArray, method::AbstractOptimizer, options::Options = Options()) = optimize((f, g!),     initial_x, method, options)
+optimize(f, g!, h!, initial_x::AbstractArray, method::AbstractOptimizer, options::Options = Options()) = optimize((f, g!, h!), initial_x, method, options)
+function optimize(f::Tuple, initial_x::AbstractArray, method::AbstractOptimizer, options::Options = Options())
     d = promote_objtype(method, initial_x, f...)
 
     optimize(d, initial_x, method, options)

--- a/src/multivariate/optimize/interface.jl
+++ b/src/multivariate/optimize/interface.jl
@@ -25,18 +25,18 @@ fallback_method(d::TwiceDifferentiable) = Newton()
 
 # promote the objective (tuple of callables or an AbstractObjective) according to method requirement
 promote_objtype(method, initial_x, obj_args...) = error("No default objective type for $method and $obj_args.")
-# actual promotions, notice that (args...) captures FirstOrderSolver and NonDifferentiable, etc
-promote_objtype(method::ZerothOrderSolver, x, args...) = NonDifferentiable(args..., x, real(zero(eltype(x))))
-promote_objtype(method::FirstOrderSolver,  x, args...) = OnceDifferentiable(args..., x, real(zero(eltype(x))))
-promote_objtype(method::FirstOrderSolver,  x, f, g!, h!) = OnceDifferentiable(f, g!, x, real(zero(eltype(x))))
-promote_objtype(method::SecondOrderSolver, x, args...) = TwiceDifferentiable(args..., x, real(zero(eltype(x))))
+# actual promotions, notice that (args...) captures FirstOrderOptimizer and NonDifferentiable, etc
+promote_objtype(method::ZerothOrderOptimizer, x, args...) = NonDifferentiable(args..., x, real(zero(eltype(x))))
+promote_objtype(method::FirstOrderOptimizer,  x, args...) = OnceDifferentiable(args..., x, real(zero(eltype(x))))
+promote_objtype(method::FirstOrderOptimizer,  x, f, g!, h!) = OnceDifferentiable(f, g!, x, real(zero(eltype(x))))
+promote_objtype(method::SecondOrderOptimizer, x, args...) = TwiceDifferentiable(args..., x, real(zero(eltype(x))))
 # no-op
-promote_objtype(method::ZerothOrderSolver, x, nd::NonDifferentiable)  = nd
-promote_objtype(method::ZerothOrderSolver, x, od::OnceDifferentiable) = od
-promote_objtype(method::FirstOrderSolver,  x, od::OnceDifferentiable) = od
-promote_objtype(method::ZerothOrderSolver, x, td::TwiceDifferentiable) = td
-promote_objtype(method::FirstOrderSolver,  x, td::TwiceDifferentiable) = td
-promote_objtype(method::SecondOrderSolver, x, td::TwiceDifferentiable) = td
+promote_objtype(method::ZerothOrderOptimizer, x, nd::NonDifferentiable)  = nd
+promote_objtype(method::ZerothOrderOptimizer, x, od::OnceDifferentiable) = od
+promote_objtype(method::FirstOrderOptimizer,  x, od::OnceDifferentiable) = od
+promote_objtype(method::ZerothOrderOptimizer, x, td::TwiceDifferentiable) = td
+promote_objtype(method::FirstOrderOptimizer,  x, td::TwiceDifferentiable) = td
+promote_objtype(method::SecondOrderOptimizer, x, td::TwiceDifferentiable) = td
 
 # if on method or options are present
 optimize(f,         initial_x::AbstractArray; kwargs...) = optimize((f,),        initial_x; kwargs...)
@@ -66,7 +66,7 @@ function optimize(f::Tuple, initial_x::AbstractArray, method::AbstractOptimizer,
     optimize(d, initial_x, method, options)
 end
 
-function optimize(d::D, initial_x::AbstractArray, method::SecondOrderSolver, options::Options = Options()) where {D <: Union{NonDifferentiable, OnceDifferentiable}}
+function optimize(d::D, initial_x::AbstractArray, method::SecondOrderOptimizer, options::Options = Options()) where {D <: Union{NonDifferentiable, OnceDifferentiable}}
     d = promote_objtype(method, initial_x, d)
     optimize(d, initial_x, method, options)
 end

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -14,7 +14,7 @@ update_h!(d, state, method::SecondOrderSolver) = hessian!(d, state.x)
 after_while!(d, state, method, options) = nothing
 
 function optimize(d::D, initial_x::AbstractArray, method::M,
-    options::Options = Options(), state = initial_state(method, options, d, complex_to_real(d, initial_x))) where {D<:AbstractObjective, M<:Optimizer}
+    options::Options = Options(), state = initial_state(method, options, d, complex_to_real(d, initial_x))) where {D<:AbstractObjective, M<:AbstractOptimizer}
     if length(initial_x) == 1 && typeof(method) <: NelderMead
         error("You cannot use NelderMead for univariate problems. Alternatively, use either interval bound univariate optimization, or another method such as BFGS or Newton.")
     end

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -1,15 +1,15 @@
 update_g!(d, state, method) = nothing
-function update_g!(d, state, method::M) where M<:Union{FirstOrderSolver, Newton}
+function update_g!(d, state, method::M) where M<:Union{FirstOrderOptimizer, Newton}
     # Update the function value and gradient
     value_gradient!(d, state.x)
 end
 update_fg!(d, state, method) = nothing
-update_fg!(d, state, method::ZerothOrderSolver) = value!(d, state.x)
-update_fg!(d, state, method::M) where M<:Union{FirstOrderSolver, Newton} = value_gradient!(d, state.x)
+update_fg!(d, state, method::ZerothOrderOptimizer) = value!(d, state.x)
+update_fg!(d, state, method::M) where M<:Union{FirstOrderOptimizer, Newton} = value_gradient!(d, state.x)
 
 # Update the Hessian
 update_h!(d, state, method) = nothing
-update_h!(d, state, method::SecondOrderSolver) = hessian!(d, state.x)
+update_h!(d, state, method::SecondOrderOptimizer) = hessian!(d, state.x)
 
 after_while!(d, state, method, options) = nothing
 

--- a/src/multivariate/solvers/constrained/fminbox.jl
+++ b/src/multivariate/solvers/constrained/fminbox.jl
@@ -93,7 +93,7 @@ function precondprepbox!(P, x, l, u, mu)
     @. P.diag = 1/(mu*(1/(x-l)^2 + 1/(u-x)^2) + 1)
 end
 
-struct Fminbox{T<:Optimizer} <: Optimizer end
+struct Fminbox{T<:AbstractOptimizer} <: AbstractOptimizer end
 Fminbox() = Fminbox{ConjugateGradient}() # default optimizer
 
 Base.summary(::Fminbox{O}) where {O} = "Fminbox with $(summary(O()))"
@@ -102,7 +102,7 @@ function optimize(obj,
                   initial_x::Array{T},
                   l::Array{T},
                   u::Array{T},
-                  F::Fminbox{O}; kwargs...) where {T<:AbstractFloat,O<:Optimizer}
+                  F::Fminbox{O}; kwargs...) where {T<:AbstractFloat,O<:AbstractOptimizer}
      optimize(OnceDifferentiable(obj, initial_x, zero(T)), l, u, F; kwargs...)
 end
 
@@ -111,7 +111,7 @@ function optimize(f,
                   initial_x::Array{T},
                   l::Array{T},
                   u::Array{T},
-                  F::Fminbox{O}; kwargs...) where {T<:AbstractFloat,O<:Optimizer}
+                  F::Fminbox{O}; kwargs...) where {T<:AbstractFloat,O<:AbstractOptimizer}
      optimize(OnceDifferentiable(f, g!, initial_x, zero(T)), l, u, F; kwargs...)
 end
 
@@ -140,7 +140,7 @@ function optimize(
         optimizer_o = Options(store_trace = store_trace,
                                           show_trace = show_trace,
                                           extended_trace = extended_trace),
-        nargs...) where {T<:AbstractFloat,O<:Optimizer}
+        nargs...) where {T<:AbstractFloat,O<:AbstractOptimizer}
 
     O == Newton && warn("Newton is not supported as the inner optimizer. Defaulting to ConjugateGradient.")
     x = copy(initial_x)

--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -21,7 +21,7 @@ function AcceleratedGradientDescent(;
     AcceleratedGradientDescent(alphaguess, linesearch, manifold)
 end
 
-mutable struct AcceleratedGradientDescentState{T,N}
+mutable struct AcceleratedGradientDescentState{T,N} <: AbstractOptimizerState
     x::Array{T,N}
     x_previous::Array{T,N}
     f_x_previous::T

--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -6,7 +6,7 @@
 # If converged, return y_{t}
 # x_{t} = y_{t} + (t - 1.0) / (t + 2.0) * (y_{t} - y_{t - 1})
 
-struct AcceleratedGradientDescent{IL, L} <: FirstOrderSolver
+struct AcceleratedGradientDescent{IL, L} <: FirstOrderOptimizer
     alphaguess!::IL
     linesearch!::L
     manifold::Manifold

--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -6,7 +6,7 @@
 # If converged, return y_{t}
 # x_{t} = y_{t} + (t - 1.0) / (t + 2.0) * (y_{t} - y_{t - 1})
 
-struct AcceleratedGradientDescent{IL, L} <: Optimizer
+struct AcceleratedGradientDescent{IL, L} <: FirstOrderSolver
     alphaguess!::IL
     linesearch!::L
     manifold::Manifold

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -2,7 +2,7 @@
 # JMW's dx <=> NW's s
 # JMW's dg <=> NW' y
 
-struct BFGS{IL, L, H<:Function} <: FirstOrderSolver
+struct BFGS{IL, L, H<:Function} <: FirstOrderOptimizer
     alphaguess!::IL
     linesearch!::L
     initial_invH::H

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -43,7 +43,7 @@ function BFGS(; alphaguess = LineSearches.InitialStatic(), # TODO: benchmark def
     BFGS(alphaguess, linesearch, initial_invH, manifold)
 end
 
-mutable struct BFGSState{T,N,G}
+mutable struct BFGSState{T,N,G} <: AbstractOptimizerState
     x::Array{T,N}
     x_previous::Array{T,N}
     g_previous::G

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -2,7 +2,7 @@
 # JMW's dx <=> NW's s
 # JMW's dg <=> NW' y
 
-struct BFGS{IL, L, H<:Function} <: Optimizer
+struct BFGS{IL, L, H<:Function} <: FirstOrderSolver
     alphaguess!::IL
     linesearch!::L
     initial_invH::H

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -41,7 +41,7 @@
 #   below.  The default value for alphamax is Inf. See alphamaxfunc
 #   for cgdescent and alphamax for linesearch_hz.
 
-struct ConjugateGradient{T, Tprep<:Union{Function, Void}, IL, L} <: Optimizer
+struct ConjugateGradient{T, Tprep<:Union{Function, Void}, IL, L} <: FirstOrderSolver
     eta::Float64
     P::T
     precondprep!::Tprep

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -41,7 +41,7 @@
 #   below.  The default value for alphamax is Inf. See alphamaxfunc
 #   for cgdescent and alphamax for linesearch_hz.
 
-struct ConjugateGradient{T, Tprep<:Union{Function, Void}, IL, L} <: FirstOrderSolver
+struct ConjugateGradient{T, Tprep<:Union{Function, Void}, IL, L} <: FirstOrderOptimizer
     eta::Float64
     P::T
     precondprep!::Tprep

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -90,7 +90,7 @@ function ConjugateGradient(; alphaguess = LineSearches.InitialHagerZhang(),
                       manifold)
 end
 
-mutable struct ConjugateGradientState{T,N,G}
+mutable struct ConjugateGradientState{T,N,G} <: AbstractOptimizerState
     x::Array{T,N}
     x_previous::Array{T,N}
     g_previous::G

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -1,4 +1,4 @@
-struct GradientDescent{IL, L, T, Tprep<:Union{Function, Void}} <: Optimizer
+struct GradientDescent{IL, L, T, Tprep<:Union{Function, Void}} <: FirstOrderSolver
     alphaguess!::IL
     linesearch!::L
     P::T

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -1,4 +1,4 @@
-struct GradientDescent{IL, L, T, Tprep<:Union{Function, Void}} <: FirstOrderSolver
+struct GradientDescent{IL, L, T, Tprep<:Union{Function, Void}} <: FirstOrderOptimizer
     alphaguess!::IL
     linesearch!::L
     P::T

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -36,7 +36,7 @@ function GradientDescent(; alphaguess = LineSearches.InitialPrevious(), # TODO: 
     GradientDescent(alphaguess, linesearch, P, precondprep, manifold)
 end
 
-mutable struct GradientDescentState{T,N}
+mutable struct GradientDescentState{T,N} <: AbstractOptimizerState
     x::Array{T,N}
     x_previous::Array{T,N}
     f_x_previous::T

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -79,7 +79,7 @@ function twoloop!(s::Vector,
     return
 end
 
-struct LBFGS{T, IL, L, Tprep<:Union{Function, Void}} <: FirstOrderSolver
+struct LBFGS{T, IL, L, Tprep<:Union{Function, Void}} <: FirstOrderOptimizer
     m::Int
     alphaguess!::IL
     linesearch!::L

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -133,7 +133,7 @@ end
 
 Base.summary(::LBFGS) = "L-BFGS"
 
-mutable struct LBFGSState{T,N,M,G}
+mutable struct LBFGSState{T,N,M,G} <: AbstractOptimizerState
     x::Array{T,N}
     x_previous::Array{T,N}
     g_previous::G

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -79,7 +79,7 @@ function twoloop!(s::Vector,
     return
 end
 
-struct LBFGS{T, IL, L, Tprep<:Union{Function, Void}} <: Optimizer
+struct LBFGS{T, IL, L, Tprep<:Union{Function, Void}} <: FirstOrderSolver
     m::Int
     alphaguess!::IL
     linesearch!::L

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -17,7 +17,7 @@ function MomentumGradientDescent(; mu::Real = 0.01,
     MomentumGradientDescent(Float64(mu), alphaguess, linesearch, manifold)
 end
 
-mutable struct MomentumGradientDescentState{T,N}
+mutable struct MomentumGradientDescentState{T,N} <: AbstractOptimizerState
     x::Array{T,N}
     x_previous::Array{T,N}
     x_momentum::Array{T,N}

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -1,7 +1,7 @@
 # See p. 280 of Murphy's Machine Learning
 # x_k1 = x_k - alpha * gr + mu * (x - x_previous)
 
-struct MomentumGradientDescent{IL,L} <: FirstOrderSolver
+struct MomentumGradientDescent{IL,L} <: FirstOrderOptimizer
     mu::Float64
     alphaguess!::IL
     linesearch!::L

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -1,7 +1,7 @@
 # See p. 280 of Murphy's Machine Learning
 # x_k1 = x_k - alpha * gr + mu * (x - x_previous)
 
-struct MomentumGradientDescent{IL,L} <: Optimizer
+struct MomentumGradientDescent{IL,L} <: FirstOrderSolver
     mu::Float64
     alphaguess!::IL
     linesearch!::L

--- a/src/multivariate/solvers/second_order/krylov_trust_region.jl
+++ b/src/multivariate/solvers/second_order/krylov_trust_region.jl
@@ -21,7 +21,7 @@ update_h!(d, state, method::KrylovTrustRegion) = nothing
 
 
 # TODO: support x::Array{T,N} et al.?
-mutable struct KrylovTrustRegionState{T}
+mutable struct KrylovTrustRegionState{T} <: AbstractOptimizerState
     x::Vector{T}
     x_previous::Vector{T}
     f_x_previous::T

--- a/src/multivariate/solvers/second_order/krylov_trust_region.jl
+++ b/src/multivariate/solvers/second_order/krylov_trust_region.jl
@@ -1,4 +1,4 @@
-immutable KrylovTrustRegion{T <: Real} <: Optimizer
+immutable KrylovTrustRegion{T <: Real} <: SecondOrderSolver
     initial_radius::T
     max_radius::T
     eta::T

--- a/src/multivariate/solvers/second_order/krylov_trust_region.jl
+++ b/src/multivariate/solvers/second_order/krylov_trust_region.jl
@@ -1,4 +1,4 @@
-immutable KrylovTrustRegion{T <: Real} <: SecondOrderSolver
+immutable KrylovTrustRegion{T <: Real} <: SecondOrderOptimizer
     initial_radius::T
     max_radius::T
     eta::T

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -1,4 +1,4 @@
-struct Newton{IL, L} <: Optimizer
+struct Newton{IL, L} <: SecondOrderSolver
     alphaguess!::IL
     linesearch!::L
 end

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -1,4 +1,4 @@
-struct Newton{IL, L} <: SecondOrderSolver
+struct Newton{IL, L} <: SecondOrderOptimizer
     alphaguess!::IL
     linesearch!::L
 end

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -27,7 +27,7 @@ end
 
 Base.summary(::Newton) = "Newton's Method"
 
-mutable struct NewtonState{T, N, F<:Base.LinAlg.Cholesky}
+mutable struct NewtonState{T, N, F<:Base.LinAlg.Cholesky} <: AbstractOptimizerState
     x::Array{T,N}
     x_previous::Array{T, N}
     f_x_previous::T

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -189,7 +189,7 @@ function solve_tr_subproblem!(gr::Vector{T},
     return m, interior, lambda, hard_case, reached_solution
 end
 
-struct NewtonTrustRegion{T <: Real} <: SecondOrderSolver
+struct NewtonTrustRegion{T <: Real} <: SecondOrderOptimizer
     initial_delta::T
     delta_hat::T
     eta::T

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -189,7 +189,7 @@ function solve_tr_subproblem!(gr::Vector{T},
     return m, interior, lambda, hard_case, reached_solution
 end
 
-struct NewtonTrustRegion{T <: Real} <: Optimizer
+struct NewtonTrustRegion{T <: Real} <: SecondOrderSolver
     initial_delta::T
     delta_hat::T
     eta::T

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -206,7 +206,7 @@ NewtonTrustRegion(; initial_delta::Real = 1.0,
 
 Base.summary(::NewtonTrustRegion) = "Newton's Method (Trust Region)"
 
-mutable struct NewtonTrustRegionState{T,N,G}
+mutable struct NewtonTrustRegionState{T,N,G} <: AbstractOptimizerState
     x::Array{T,N}
     x_previous::Array{T,N}
     g_previous::G

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -37,7 +37,7 @@ end
 FixedParameters(; α = 1.0, β = 2.0, γ = 0.5, δ = 0.5) = FixedParameters(α, β, γ, δ)
 parameters(P::FixedParameters, n::Integer) = (P.α, P.β, P.γ, P.δ)
 
-struct NelderMead{Ts <: Simplexer, Tp <: NMParameters} <: Optimizer
+struct NelderMead{Ts <: Simplexer, Tp <: NMParameters} <: ZerothOrderSolver
     initial_simplex::Ts
     parameters::Tp
 end

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -37,7 +37,7 @@ end
 FixedParameters(; α = 1.0, β = 2.0, γ = 0.5, δ = 0.5) = FixedParameters(α, β, γ, δ)
 parameters(P::FixedParameters, n::Integer) = (P.α, P.β, P.γ, P.δ)
 
-struct NelderMead{Ts <: Simplexer, Tp <: NMParameters} <: ZerothOrderSolver
+struct NelderMead{Ts <: Simplexer, Tp <: NMParameters} <: ZerothOrderOptimizer
     initial_simplex::Ts
     parameters::Tp
 end

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -105,7 +105,7 @@ function Base.show(io::IO, t::OptimizationState{NelderMead})
     return
 end
 
-mutable struct NelderMeadState{T, N}
+mutable struct NelderMeadState{T, N} <: ZerothOrderState
     x::Array{T,N}
     m::Int
     simplex::Vector{Array{T,N}}

--- a/src/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/src/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -1,4 +1,4 @@
-struct ParticleSwarm{T} <: Optimizer
+struct ParticleSwarm{T} <: ZerothOrderSolver
     lower::Vector{T}
     upper::Vector{T}
     n_particles::Int

--- a/src/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/src/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -8,7 +8,7 @@ ParticleSwarm(; lower = [], upper = [], n_particles = 0) = ParticleSwarm(lower, 
 
 Base.summary(::ParticleSwarm) = "Particle Swarm"
 
-mutable struct ParticleSwarmState{T,N}
+mutable struct ParticleSwarmState{T,N} <: ZerothOrderState
     x::Array{T,N}
     iteration::Int
     lower::Array{T,N}

--- a/src/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/src/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -1,4 +1,4 @@
-struct ParticleSwarm{T} <: ZerothOrderSolver
+struct ParticleSwarm{T} <: ZerothOrderOptimizer
     lower::Vector{T}
     upper::Vector{T}
     n_particles::Int

--- a/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
+++ b/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
@@ -10,7 +10,7 @@ function default_neighbor!(x::Array, x_proposal::Array)
     return
 end
 
-struct SimulatedAnnealing{Tn, Ttemp} <: ZerothOrderSolver
+struct SimulatedAnnealing{Tn, Ttemp} <: ZerothOrderOptimizer
     neighbor!::Tn
     temperature::Ttemp
     keep_best::Bool # not used!?

--- a/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
+++ b/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
@@ -10,7 +10,7 @@ function default_neighbor!(x::Array, x_proposal::Array)
     return
 end
 
-struct SimulatedAnnealing{Tn, Ttemp} <: Optimizer
+struct SimulatedAnnealing{Tn, Ttemp} <: ZerothOrderSolver
     neighbor!::Tn
     temperature::Ttemp
     keep_best::Bool # not used!?

--- a/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
+++ b/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
@@ -23,7 +23,7 @@ SimulatedAnnealing(;neighbor = default_neighbor!,
 
 Base.summary(::SimulatedAnnealing) = "Simulated Annealing"
 
-mutable struct SimulatedAnnealingState{T, N}
+mutable struct SimulatedAnnealingState{T, N} <: ZerothOrderState
     x::Array{T,N}
     iteration::Int
     x_current::Array{T, N}

--- a/src/multivariate/solvers/zeroth_order/zeroth_utils.jl
+++ b/src/multivariate/solvers/zeroth_order/zeroth_utils.jl
@@ -1,5 +1,3 @@
-const ZerothOrderStates = Union{NelderMeadState,ParticleSwarmState,SimulatedAnnealingState}
-
 function trace!(tr, d, state, iteration, method::ZerothOrderOptimizer, options)
     dt = Dict()
     if options.extended_trace
@@ -16,9 +14,9 @@ function trace!(tr, d, state, iteration, method::ZerothOrderOptimizer, options)
             options.callback)
 end
 
-function assess_convergence(state::ZerothOrderStates, d, options)
+function assess_convergence(state::ZerothOrderState, d, options)
     false, false, false, false, false
 end
 
-f_abschange(d::AbstractObjective, state::ZerothOrderStates) = convert(typeof(value(d)), NaN)
-x_abschange(state::ZerothOrderStates) = convert(eltype(state.x), NaN)
+f_abschange(d::AbstractObjective, state::ZerothOrderState) = convert(typeof(value(d)), NaN)
+x_abschange(state::ZerothOrderState) = convert(eltype(state.x), NaN)

--- a/src/multivariate/solvers/zeroth_order/zeroth_utils.jl
+++ b/src/multivariate/solvers/zeroth_order/zeroth_utils.jl
@@ -1,6 +1,6 @@
 const ZerothOrderStates = Union{NelderMeadState,ParticleSwarmState,SimulatedAnnealingState}
 
-function trace!(tr, d, state, iteration, method::ZerothOrderSolver, options)
+function trace!(tr, d, state, iteration, method::ZerothOrderOptimizer, options)
     dt = Dict()
     if options.extended_trace
         dt["x"] = copy(state.x)

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,6 +3,10 @@ abstract type ZerothOrderOptimizer <: AbstractOptimizer end
 abstract type FirstOrderOptimizer  <: AbstractOptimizer end
 abstract type SecondOrderOptimizer <: AbstractOptimizer end
 abstract type UnivariateOptimizer  <: AbstractOptimizer end
+
+abstract type AbstractOptimizerState end
+abstract type ZerothOrderState <: AbstractOptimizerState end
+
 struct Options{T, TCallback}
     x_tol::T
     f_tol::T

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,7 +1,8 @@
 abstract type AbstractOptimizer end
-abstract type ZerothOrderSolver <: AbstractOptimizer end
-abstract type FirstOrderSolver  <: AbstractOptimizer end
-abstract type SecondOrderSolver <: AbstractOptimizer end
+abstract type ZerothOrderOptimizer <: AbstractOptimizer end
+abstract type FirstOrderOptimizer  <: AbstractOptimizer end
+abstract type SecondOrderOptimizer <: AbstractOptimizer end
+abstract type UnivariateOptimizer  <: AbstractOptimizer end
 struct Options{T, TCallback}
     x_tol::T
     f_tol::T

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,7 @@
-abstract type Optimizer end
+abstract type AbstractOptimizer end
+abstract type ZerothOrderSolver <: AbstractOptimizer end
+abstract type FirstOrderSolver  <: AbstractOptimizer end
+abstract type SecondOrderSolver <: AbstractOptimizer end
 struct Options{T, TCallback}
     x_tol::T
     f_tol::T
@@ -46,11 +49,11 @@ function print_header(options::Options)
     end
 end
 
-function print_header(method::Optimizer)
+function print_header(method::AbstractOptimizer)
         @printf "Iter     Function value   Gradient norm \n"
 end
 
-struct OptimizationState{T <: Optimizer}
+struct OptimizationState{T <: AbstractOptimizer}
     iteration::Int
     value::Float64
     g_norm::Float64
@@ -61,7 +64,7 @@ OptimizationTrace{T} = Vector{OptimizationState{T}}
 
 abstract type OptimizationResults end
 
-mutable struct MultivariateOptimizationResults{O<:Optimizer,T,N,M} <: OptimizationResults
+mutable struct MultivariateOptimizationResults{O<:AbstractOptimizer,T,N,M} <: OptimizationResults
     method::O
     iscomplex::Bool
     initial_x::Array{T,N}

--- a/src/univariate/solvers/brent.jl
+++ b/src/univariate/solvers/brent.jl
@@ -39,7 +39,7 @@ accelerate convergence.
 ## References
 R. P. Brent (2002) Algorithms for Minimization Without Derivatives. Dover edition.
 """
-struct Brent <: Optimizer end
+struct Brent <: AbstractOptimizer end
 
 Base.summary(::Brent) = "Brent's Method"
 

--- a/src/univariate/solvers/brent.jl
+++ b/src/univariate/solvers/brent.jl
@@ -39,7 +39,7 @@ accelerate convergence.
 ## References
 R. P. Brent (2002) Algorithms for Minimization Without Derivatives. Dover edition.
 """
-struct Brent <: AbstractOptimizer end
+struct Brent <: UnivariateOptimizer end
 
 Base.summary(::Brent) = "Brent's Method"
 

--- a/src/univariate/solvers/golden_section.jl
+++ b/src/univariate/solvers/golden_section.jl
@@ -36,7 +36,7 @@ is the Golden Ratio.
 ## References
 https://en.wikipedia.org/wiki/Golden-section_search
 """
-struct GoldenSection <: Optimizer end
+struct GoldenSection <: AbstractOptimizer end
 
 Base.summary(::GoldenSection) = "Golden Section Search"
 

--- a/src/univariate/solvers/golden_section.jl
+++ b/src/univariate/solvers/golden_section.jl
@@ -36,7 +36,7 @@ is the Golden Ratio.
 ## References
 https://en.wikipedia.org/wiki/Golden-section_search
 """
-struct GoldenSection <: AbstractOptimizer end
+struct GoldenSection <: UnivariateOptimizer end
 
 Base.summary(::GoldenSection) = "Golden Section Search"
 

--- a/src/univariate/types.jl
+++ b/src/univariate/types.jl
@@ -1,4 +1,4 @@
-mutable struct UnivariateOptimizationResults{Tb,Tt,Tf, Tx,M,O<:AbstractOptimizer} <: OptimizationResults
+mutable struct UnivariateOptimizationResults{Tb,Tt,Tf, Tx,M,O<:UnivariateOptimizer} <: OptimizationResults
     method::O
     initial_lower::Tb
     initial_upper::Tb

--- a/src/univariate/types.jl
+++ b/src/univariate/types.jl
@@ -1,4 +1,4 @@
-mutable struct UnivariateOptimizationResults{Tb,Tt,Tf, Tx,M,O<:Optimizer} <: OptimizationResults
+mutable struct UnivariateOptimizationResults{Tb,Tt,Tf, Tx,M,O<:AbstractOptimizer} <: OptimizationResults
     method::O
     initial_lower::Tb
     initial_upper::Tb

--- a/src/utilities/assess_convergence.jl
+++ b/src/utilities/assess_convergence.jl
@@ -44,7 +44,7 @@ end
 # Default function for convergence assessment used by
 # AcceleratedGradientDescentState, BFGSState, ConjugateGradientState,
 # GradientDescentState, LBFGSState, MomentumGradientDescentState and NewtonState
-function default_convergence_assessment(state::Union{AcceleratedGradientDescentState, BFGSState, ConjugateGradientState, GradientDescentState, LBFGSState, MomentumGradientDescentState, NewtonState}, d, options)
+function default_convergence_assessment(state::AbstractOptimizerState, d, options)
     x_converged, f_converged, f_increased, g_converged = false, false, false, false
 
     if x_abschange(state.x, state.x_previous) < options.x_tol

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,12 +65,12 @@ multivariate_tests = [
 multivariate_tests = map(s->"./multivariate/"*s*".jl", multivariate_tests)
 
 differentiability_condition(method, prob) = true
-differentiability_condition(method::Optim.FirstOrderSolver, prob) = prob.isdifferentiable
-differentiability_condition(method::Optim.SecondOrderSolver, prob) = prob.istwicedifferentiable
+differentiability_condition(method::Optim.FirstOrderOptimizer, prob) = prob.isdifferentiable
+differentiability_condition(method::Optim.SecondOrderOptimizer, prob) = prob.istwicedifferentiable
 
 input_tuple(method, prob) = ((prob.f,),)
-input_tuple(method::Optim.FirstOrderSolver, prob) = ((prob.f,), (prob.f, prob.g!))
-input_tuple(method::Optim.SecondOrderSolver, prob) = ((prob.f,), (prob.f, prob.g!), (prob.f, prob.g!, prob.h!))
+input_tuple(method::Optim.FirstOrderOptimizer, prob) = ((prob.f,), (prob.f, prob.g!))
+input_tuple(method::Optim.SecondOrderOptimizer, prob) = ((prob.f,), (prob.f, prob.g!), (prob.f, prob.g!, prob.h!))
 
 function run_optim_tests(method; convergence_exceptions = (),
                                  minimizer_exceptions = (),


### PR DESCRIPTION
@anriseth @jonathanBieler

Are there other things you found annoying while trying to base your stuff off of Optim? I'll be happy to generalize where needed.