### PR TITLE
flush trace log

### DIFF
--- a/src/utilities/update.jl
+++ b/src/utilities/update.jl
@@ -14,6 +14,7 @@ function update!(tr::OptimizationTrace{T},
     if show_trace
         if iteration % show_every == 0
             show(os)
+            flush(STDOUT)
         end
     end
     if callback != nothing && (iteration % show_every == 0)


### PR DESCRIPTION
This flushes the standard output every time when a trace is written to it. This is especially useful when we run a long-running optimization and check the convergence from a log file.