### PR TITLE
Acceleration / nonlinear preconditioning with N-GMRES and O-ACCEL

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.6.0
 PositiveFactorizations
 Compat 0.18.0
-LineSearches 3.2.0
+LineSearches 3.2.4
 Calculus
 NLSolversBase 4.0.0
 ForwardDiff 0.5.0

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -42,6 +42,7 @@ pages:
                 - 'Conjugate Gradient': 'algo/cg.md'
                 - 'Gradient Descent': 'algo/gradientdescent.md'
                 - '(L-)BFGS': 'algo/lbfgs.md'
+                - 'Acceleration': 'algo/ngmres.md'
             - Hessian Required:
                 - Newton: 'algo/newton.md'
                 - Newton with Trust Region: 'algo/newton_trust_region.md'

--- a/docs/src/algo/ngmres.md
+++ b/docs/src/algo/ngmres.md
@@ -42,6 +42,8 @@ GMRES for linear problems.
 Application of the algorithm to optimization is covered, for example, in [2].
 A description of O-ACCEL and its connection to N-GMRES can be found in [3].
 
+*We recommend trying [LBFGS](lbfgs.md) on your problem before N-GMRES or O-ACCEL. All three algorithms have similar computational cost and memory requirements, however, L-BFGS is more efficient for many problems.*
+
 ## Example
 
 This example shows how to accelerate `GradientDescent` on the Extended Rosenbrock problem.

--- a/docs/src/algo/ngmres.md
+++ b/docs/src/algo/ngmres.md
@@ -1,0 +1,162 @@
+# Acceleration methods: N-GMRES and O-ACCEL
+## Constructors
+```julia
+NGMRES(;
+        alphaguess = LineSearches.InitialStatic(),
+        linesearch = LineSearches.HagerZhang(),
+        manifold = Flat(),
+        wmax::Int = 10,
+        ϵ0 = 1e-12,
+        nlprecon = GradientDescent(
+            alphaguess = LineSearches.InitialPrevious(),
+            linesearch = LineSearches.Static(alpha=1e-4,scaled=true),
+            manifold = manifold),
+        nlpreconopts = Options(iterations = 1, allow_f_increases = true),
+      )
+```
+
+```julia
+OACCEL(;manifold::Manifold = Flat(),
+       alphaguess = LineSearches.InitialStatic(),
+       linesearch = LineSearches.HagerZhang(),
+       nlprecon = GradientDescent(
+           alphaguess = LineSearches.InitialPrevious(),
+           linesearch = LineSearches.Static(alpha=1e-4,scaled=true),
+           manifold = manifold),
+       nlpreconopts = Options(iterations = 1, allow_f_increases = true),
+       ϵ0 = 1e-12,
+       wmax::Int = 10)
+```
+
+## Description
+These algorithms take a step given by the nonlinear preconditioner `nlprecon`
+and proposes an accelerated step on a subspace spanned by the previous
+`wmax` iterates.
+
+- N-GMRES accelerates based on a minimization of an approximation to the $\ell_2$ norm of the
+gradient.
+- O-ACCEL accelerates based on a minimization of a n approximation to the objective.
+
+N-GMRES was originally developed for solving nonlinear systems [1], and reduces to
+GMRES for linear problems.
+Application of the algorithm to optimization is covered, for example, in [2].
+A description of O-ACCEL and its connection to N-GMRES can be found in [3].
+
+## Example
+
+This example shows how to accelerate `GradientDescent` on the Extended Rosenbrock problem.
+First, we try to optimize using `GradientDescent`.
+
+```julia
+using Optim, OptimTestProblems
+UP = OptimTestProblems.UnconstrainedProblems
+prob = UP.examples["Extended Rosenbrock"]
+optimize(UP.objective(prob), UP.gradient(prob), prob.initial_x, GradientDescent())
+```
+The algorithm does not converge within 1000 iterations.
+
+```
+Results of Optimization Algorithm
+ * Algorithm: Gradient Descent
+ * Starting Point: [-1.2,1.0, ...]
+ * Minimizer: [0.8923389282461412,0.7961268644300445, ...]
+ * Minimum: 2.898230e-01
+ * Iterations: 1000
+ * Convergence: false
+   * |x - x'| ≤ 1.0e-32: false 
+     |x - x'| = 4.02e-04 
+   * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
+     |f(x) - f(x')| = 2.38e-03 |f(x)|
+   * |g(x)| ≤ 1.0e-08: false 
+     |g(x)| = 8.23e-02 
+   * Stopped by an increasing objective: false
+   * Reached Maximum Number of Iterations: true
+ * Objective Calls: 2525
+ * Gradient Calls: 2525
+```        
+
+Now, we use `OACCEL` to accelerate `GradientDescent`.
+```julia
+# Default nonlinear procenditioner for `OACCEL`
+nlprecon =  GradientDescent(linesearch=LineSearches.Static(alpha=1e-4,scaled=true))
+# Default size of subspace that OACCEL accelerates over is `wmax = 10`
+oacc10 = OACCEL(nlprecon=nlprecon, wmax=10)
+optimize(UP.objective(prob), UP.gradient(prob), prob.initial_x, oacc10)
+```
+This drastically improves the `GradientDescent` algorithm, converging in 87 iterations.
+```
+Results of Optimization Algorithm
+ * Algorithm: O-ACCEL preconditioned with Gradient Descent
+ * Starting Point: [-1.2,1.0, ...]
+ * Minimizer: [1.0000000011361219,1.0000000022828495, ...]
+ * Minimum: 3.255053e-17
+ * Iterations: 87
+ * Convergence: true
+   * |x - x'| ≤ 1.0e-32: false 
+     |x - x'| = 6.51e-08 
+   * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
+     |f(x) - f(x')| = 7.56e+02 |f(x)|
+   * |g(x)| ≤ 1.0e-08: true 
+     |g(x)| = 1.06e-09 
+   * Stopped by an increasing objective: false
+   * Reached Maximum Number of Iterations: false
+ * Objective Calls: 285
+ * Gradient Calls: 285
+```
+
+We can improve the acceleration further by changing the acceleration subspace size `wmax`.
+```julia
+oacc5 = OACCEL(nlprecon=nlprecon, wmax=5)
+optimize(UP.objective(prob), UP.gradient(prob), prob.initial_x, oacc5)
+```
+Now, the O-ACCEL algorithm has accelerated `GradientDescent` to converge in 50 iterations.
+```
+Results of Optimization Algorithm
+ * Algorithm: O-ACCEL preconditioned with Gradient Descent
+ * Starting Point: [-1.2,1.0, ...]
+ * Minimizer: [0.9999999999392858,0.9999999998784691, ...]
+ * Minimum: 9.218164e-20
+ * Iterations: 50
+ * Convergence: true
+   * |x - x'| ≤ 1.0e-32: false 
+     |x - x'| = 2.76e-07 
+   * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
+     |f(x) - f(x')| = 5.18e+06 |f(x)|
+   * |g(x)| ≤ 1.0e-08: true 
+     |g(x)| = 4.02e-11 
+   * Stopped by an increasing objective: false
+   * Reached Maximum Number of Iterations: false
+ * Objective Calls: 181
+ * Gradient Calls: 181
+```
+
+As a final comparison, we can do the same with N-GMRES.
+```julia
+ngmres5 = NGMRES(nlprecon=nlprecon, wmax=5)
+optimize(UP.objective(prob), UP.gradient(prob), prob.initial_x, ngmres5)
+```
+Again, this significantly improves the `GradientDescent` algorithm, and converges in 63 iterations.
+```
+Results of Optimization Algorithm
+ * Algorithm: Nonlinear GMRES preconditioned with Gradient Descent
+ * Starting Point: [-1.2,1.0, ...]
+ * Minimizer: [0.9999999998534468,0.9999999997063993, ...]
+ * Minimum: 5.375569e-19
+ * Iterations: 63
+ * Convergence: true
+   * |x - x'| ≤ 1.0e-32: false 
+     |x - x'| = 9.94e-09 
+   * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
+     |f(x) - f(x')| = 1.29e+03 |f(x)|
+   * |g(x)| ≤ 1.0e-08: true 
+     |g(x)| = 4.94e-11 
+   * Stopped by an increasing objective: false
+   * Reached Maximum Number of Iterations: false
+ * Objective Calls: 222
+ * Gradient Calls: 222
+```
+
+## References
+[1] De Sterck. Steepest descent preconditioning for nonlinear GMRES optimization. NLAA, 2013.
+[2] Washio and Oosterlee. Krylov subspace acceleration for nonlinear multigrid schemes. ETNA, 1997.
+[3] Riseth. Objective acceleration for unconstrained optimization. 2018.

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -31,10 +31,6 @@ end
 function NLSolversBase.value(obj::ManifoldObjective)
     value(obj.inner_obj)
 end
-function NLSolversBase.value!!(obj::ManifoldObjective, x)
-    xin = complex_to_real(obj, retract(obj.manifold, real_to_complex(obj,x)))
-    value!!(obj.inner_obj, xin)
-end
 function NLSolversBase.gradient(obj::ManifoldObjective)
     gradient(obj.inner_obj)
 end
@@ -47,26 +43,12 @@ function NLSolversBase.gradient!(obj::ManifoldObjective,x)
     project_tangent!(obj.manifold,real_to_complex(obj,gradient(obj.inner_obj)),real_to_complex(obj,xin))
     return gradient(obj.inner_obj)
 end
-function NLSolversBase.gradient!!(obj::ManifoldObjective,x)
-    xin = complex_to_real(obj, retract(obj.manifold, real_to_complex(obj,x)))
-    gradient!!(obj.inner_obj,xin)
-    project_tangent!(obj.manifold,real_to_complex(obj,gradient(obj.inner_obj)),real_to_complex(obj,xin))
-    return gradient(obj.inner_obj)
-end
 function NLSolversBase.value_gradient!(obj::ManifoldObjective,x)
     xin = complex_to_real(obj, retract(obj.manifold, real_to_complex(obj,x)))
     value_gradient!(obj.inner_obj,xin)
     project_tangent!(obj.manifold,real_to_complex(obj,gradient(obj.inner_obj)),real_to_complex(obj,xin))
     return value(obj.inner_obj)
 end
-
-function NLSolversBase.value_gradient!!(obj::ManifoldObjective,x)
-    xin = complex_to_real(obj, retract(obj.manifold, real_to_complex(obj,x)))
-    value_gradient!!(obj.inner_obj,xin)
-    project_tangent!(obj.manifold,real_to_complex(obj,gradient(obj.inner_obj)),real_to_complex(obj,xin))
-    return value(obj.inner_obj)
-end
-
 
 # fallback for out-of-place ops
 project_tangent(M::Manifold,x) = project_tangent!(M, similar(x), x)

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -79,9 +79,6 @@ module Optim
     # preconditioning functionality
     include("multivariate/precon.jl")
 
-    # Nonlinear GMRES
-    include("multivariate/solvers/first_order/ngmres.jl")
-
     # Gradient Descent
     include("multivariate/solvers/first_order/gradient_descent.jl")
     include("multivariate/solvers/first_order/accelerated_gradient_descent.jl")
@@ -99,9 +96,11 @@ module Optim
     include("multivariate/solvers/second_order/newton_trust_region.jl")
     include("multivariate/solvers/second_order/krylov_trust_region.jl")
 
+    # Nonlinear GMRES
+    include("multivariate/solvers/first_order/ngmres.jl")
+
     # Constrained optimization
     include("multivariate/solvers/constrained/fminbox.jl")
-
 
     # Univariate methods
     include("univariate/solvers/golden_section.jl")

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -37,6 +37,7 @@ module Optim
            Fminbox,
            GoldenSection,
            GradientDescent,
+           NGMRES,
            LBFGS,
            MomentumGradientDescent,
            NelderMead,
@@ -76,6 +77,9 @@ module Optim
 
     # preconditioning functionality
     include("multivariate/precon.jl")
+
+    # Nonlinear GMRES
+    include("multivariate/solvers/first_order/ngmres.jl")
 
     # Gradient Descent
     include("multivariate/solvers/first_order/gradient_descent.jl")

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -38,6 +38,7 @@ module Optim
            GoldenSection,
            GradientDescent,
            NGMRES,
+           OACCEL,
            LBFGS,
            MomentumGradientDescent,
            NelderMead,

--- a/src/multivariate/optimize/interface.jl
+++ b/src/multivariate/optimize/interface.jl
@@ -17,6 +17,9 @@ function check_kwargs(kwargs, fallback_method)
 end
 
 default_options(method::AbstractOptimizer) = Dict{Symbol, Any}()
+function default_options(method::AbstractNGMRES)
+    Dict(:allow_f_increases => true)
+end
 
 function add_default_opts!(opts::Dict{Symbol, Any}, method::AbstractOptimizer)
     for newopt in default_options(method)

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -14,7 +14,8 @@ update_h!(d, state, method::SecondOrderOptimizer) = hessian!(d, state.x)
 after_while!(d, state, method, options) = nothing
 
 function optimize(d::D, initial_x::AbstractArray{Tx, N}, method::M,
-    options::Options = Options(), state = initial_state(method, options, d, complex_to_real(d, initial_x))) where {D<:AbstractObjective, M<:AbstractOptimizer, Tx, N}
+                  options::Options = Options(;default_options(method)...),
+                  state = initial_state(method, options, d, complex_to_real(d, initial_x))) where {D<:AbstractObjective, M<:AbstractOptimizer, Tx, N}
     if length(initial_x) == 1 && typeof(method) <: NelderMead
         error("You cannot use NelderMead for univariate problems. Alternatively, use either interval bound univariate optimization, or another method such as BFGS or Newton.")
     end
@@ -81,7 +82,7 @@ function optimize(d::D, initial_x::AbstractArray{Tx, N}, method::M,
     T = typeof(options.f_tol)
     Tf = typeof(value(d))
     f_incr_pick = f_increased && !options.allow_f_increases
-   
+
     return MultivariateOptimizationResults{typeof(method), T, Tx, Tf, N, typeof(tr)}(method,
                                         NLSolversBase.iscomplex(d),
                                         real_to_complex(d, initial_x),

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -51,7 +51,7 @@ function optimize(d::D, initial_x::AbstractArray{Tx, N}, method::M,
     while !converged && !stopped && iteration < options.iterations
         iteration += 1
 
-        update_state!(d, state, method) && break # it returns true if it's forced by something in update! to stop (eg dx_dg == 0.0 in BFGS)
+        update_state!(d, state, method) && break # it returns true if it's forced by something in update! to stop (eg dx_dg == 0.0 in BFGS, or linesearch errors)
         update_g!(d, state, method)
         x_converged, f_converged,
         g_converged, converged, f_increased = assess_convergence(state, d, options)

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -163,6 +163,7 @@ function update_state!(d, state::NGMRESState{X,T}, method::NGMRES) where X where
         # Moving from xP to xA is *not* a descent direction
         # Discard xA
         state.restart = true # TODO: expand restart heuristics
+        Base.warn("Restart")
     else
         state.restart = false
         perform_linesearch!(state, method, d)

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -55,7 +55,7 @@ NGMRES(;
 ## Description
 This algorithm takes a step given by the nonlinear preconditioner `nlprecon`
 and proposes an accelerated step by minimizing an approximation of
-the \ell_2 residual of the gradient on a subspace spanned by the previous
+the \(\ell_2\) residual of the gradient on a subspace spanned by the previous
 `wmax` iterates.
 
 N-GMRES was originally developed for solving nonlinear systems [1], and reduces to
@@ -81,7 +81,7 @@ function NGMRES(;manifold::Manifold = Flat(),
 end
 
 """
-# OACCEL
+# O-ACCEL
 ## Constructor
 ```julia
 OACCEL(;manifold::Manifold = Flat(),

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -288,6 +288,7 @@ function update_state!(d, state::NGMRESState{X,T}, method::AbstractNGMRES) where
         # Discard xA
         state.restart = true # TODO: expand restart heuristics
         lssuccess = true
+        state.alpha = 0.0
     else
         state.restart = false
 

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -48,9 +48,10 @@ function NGMRES(; linesearch = LineSearches.Static()
                 # γA = 2.0, γB = 0.9, # (defaults in Washio and Oosterlee)
                 # γC = 2.0, ϵB = 0.1, # (defaults in Washio and Oosterlee)
                 ϵ0 = 1e-12, # ϵ0 = 1e-12  -- number was an arbitrary choice
-                10) # wmax = 10  -- number was an arbitrary choice
+                wmax = 10) # wmax = 10  -- number was an arbitrary choice
+    # TODO: make wmax mandatory?
     NGMRES(linesearch, precon, preconopts, #γA, γB, γC, ϵB,
-           ϵ0)
+           ϵ0, wmax)
 end
 
 mutable struct NGMRESState{P,TA,T,N}
@@ -170,7 +171,7 @@ function update_g!(d, state, method::NGMRES)
     value_gradient!(d, state.x)
     if state.restart == false
         state.curw = max(state.curw + 1, method.wmax)
-        j = mod(state.iteration,method.wmax) + 1
+        j = mod(state.iteration, method.wmax) + 1
     else
         state.restart = true
         state.curw = 1

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -37,7 +37,9 @@ Application of the algorithm to optimization is covered, for example, in~\cite{s
 }
 """
 
-immutable NGMRES{Tp,TPrec <: Optimizer,L} <: Optimizer
+abstract type AbstractNGMRES <: Optimizer end
+
+immutable NGMRES{Tp,TPrec <: Optimizer,L} <: AbstractNGMRES
     linesearch!::L    # Preconditioner moving from xP to xA (precondition x to accelerated x)
     precon::TPrec # Nonlinear preconditioner
     preconopts::Options # Preconditioner options
@@ -50,7 +52,7 @@ immutable NGMRES{Tp,TPrec <: Optimizer,L} <: Optimizer
     # TODO: Add manifold support?
 end
 
-immutable OACCEL{Tp,TPrec <: Optimizer,L} <: NGMRES
+immutable OACCEL{Tp,TPrec <: Optimizer,L} <: AbstractNGMRES
     linesearch!::L    # Preconditioner moving from xP to xA (precondition x to accelerated x)
     precon::TPrec # Nonlinear preconditioner
     preconopts::Options # Preconditioner options
@@ -160,7 +162,7 @@ end
 end
 
 
-function initial_state(method::NGMRES, options, d, initial_x::AbstractArray{T}) where T
+function initial_state(method::AbstractNGMRES, options, d, initial_x::AbstractArray{T}) where T
     if !(typeof(method.precon) <: GradientDescent)
         warn_once("Use caution. NGMRES has only been tested with Gradient Descent preconditioning")
     end
@@ -207,7 +209,7 @@ function initial_state(method::NGMRES, options, d, initial_x::AbstractArray{T}) 
 end
 
 
-function update_state!(d, state::NGMRESState{X,T}, method::NGMRES) where X where T
+function update_state!(d, state::NGMRESState{X,T}, method::AbstractNGMRES) where X where T
 
     # Reset step length for preconditioner, in case the previous value is detrimental
     state.preconstate.alpha = one(state.preconstate.alpha)
@@ -297,7 +299,7 @@ function update_state!(d, state::NGMRESState{X,T}, method::NGMRES) where X where
     lssuccess == false # Break on linesearch error
 end
 
-function update_g!(d, state, method::NGMRES)
+function update_g!(d, state, method::AbstractNGMRES)
     # Update the function value and gradient
     value_gradient!(d, state.x)
     if state.restart == false
@@ -316,7 +318,7 @@ function update_g!(d, state, method::NGMRES)
     end
 end
 
-function trace!(tr, d, state, iteration, method::NGMRES, options)
+function trace!(tr, d, state, iteration, method::AbstractNGMRES, options)
     dt = Dict()
     if state.restart == false
 

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -342,7 +342,7 @@ function update_state!(d, state::NGMRESState{X,T}, method::AbstractNGMRES) where
         #state.dphi0_previous = state.nlpreconstate.dphi0_previous # assumes precon is a linesearch based method. TODO: Deal with trust region based methods
         # state.x_previous and state.x are dealt with by reference
 
-        lssuccess = perform_linesearch!(state, method, d)
+        lssuccess = perform_linesearch!(state, method, ManifoldObjective(method.manifold, d))
         @. state.x = state.x + state.alpha * state.s
         # Manifold start
         retract!(method.manifold, real_to_complex(d,state.x))

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -237,8 +237,8 @@ function update_state!(d, state::NGMRESState{X,T}, method::AbstractNGMRES) where
 
     for i = 1:curw
         # Update storage vectors according to method {NGMRES, OACCEL}
-        _updateξ!(state.ξ, state.X, state.x, state.R, gP, method)
-        _updateb!(state.b, ξ, η, method)
+        _updateξ!(state.ξ, i, state.X, state.x, state.R, gP, method)
+        _updateb!(state.b, i, state.ξ, η, method)
     end
 
     for i = 1:curw

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -93,9 +93,11 @@ end
 
 function OACCEL(;
                 alphaguess = LineSearches.InitialStatic(),
-                linesearch = LineSearches.MoreThuente(),
-                nlprecon = GradientDescent(alphaguess = LineSearches.InitialPrevious(),
-                                           linesearch = LineSearches.Static(alpha=1e-4,scaled=true)), # Step length arbitrary
+                linesearch = LineSearches.HagerZhang(),
+                nlprecon = GradientDescent(
+                    alphaguess = LineSearches.InitialPrevious(),
+                    linesearch = LineSearches.Static(alpha=1e-4,scaled=true),
+                    manifold = manifold), # Step length arbitrary
                 nlpreconopts = Options(iterations = 1, allow_f_increases = true),
                 ϵ0 = 1e-12, # ϵ0 = 1e-12  -- number was an arbitrary choice
                 wmax::Int = 10) # wmax = 10  -- number was an arbitrary choice to match L-BFGS field `m`

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -258,7 +258,7 @@ nlprecon_post_optimize!(d, state, method) = update_h!(d, state.nlpreconstate, me
 nlprecon_post_accelerate!(d, state, method) = update_h!(d, state.nlpreconstate, method)
 
 function nlprecon_post_accelerate!(d, state::NGMRESState{X,T},
-                                   method::Union{LBFGS,BFGS})  where X where T
+                                   method::LBFGS)  where X where T
     state.nlpreconstate.pseudo_iteration += 1
     update_h!(d, state.nlpreconstate, method)
 end

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -191,8 +191,8 @@ end
 
 function trace!(tr, d, state, iteration, method::NGMRES, options)
     # TODO: create NGMRES-specific trace
-    #common_trace!(tr, d, state, iteration, method, options)
-    Base.warn_once("We need to implement tracing for N-GMRES")
+    Base.warn_once("We need to implement proper tracing for N-GMRES")
+    common_trace!(tr, d, state, iteration, method, options)
 end
 
 function assess_convergence(state::NGMRESState, d, options)

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -42,9 +42,9 @@ end
 
 Base.summary(s::NGMRES) = "Nonlinear GMRES preconditioned with $(summary(s.precon))"
 
-function NGMRES(; linesearch = LineSearches.Static(),
-                precon = GradientDescent(linesearch = LineSearches.Static()),
-                preconopts = Options(iterations = 1),
+function NGMRES(; linesearch = LineSearches.BackTracking(),
+                precon = GradientDescent(linesearch = LineSearches.Static(alpha=1e-4,scaled=true)), # Step length arbitrary
+                preconopts = Options(iterations = 1, allow_f_increases = true),
                 # γA = 2.0, γB = 0.9, # (defaults in Washio and Oosterlee)
                 # γC = 2.0, ϵB = 0.1, # (defaults in Washio and Oosterlee)
                 ϵ0 = 1e-12, # ϵ0 = 1e-12  -- number was an arbitrary choice

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -4,7 +4,7 @@
 - How to deal with f_increased (as state and preconstate shares the same x and x_previous vectors)
 - Check whether this makes sense for other preconditioners than GradientDescent
 * There might be some issue of dealing with x_current and x_previous in MomentumGradientDescent
-  * Trust region based methods may not work because we assume the preconditioner calls perform_linesearch!
+* Trust region based methods may not work because we assume the preconditioner calls perform_linesearch!
 =#
 
 """
@@ -182,7 +182,7 @@ end
 
 function initial_state(method::AbstractNGMRES, options, d, initial_x::AbstractArray{T}) where T
     if !(typeof(method.precon) <: GradientDescent)
-        warn_once("Use caution. NGMRES has only been tested with Gradient Descent preconditioning")
+        Base.warn_once("Use caution. NGMRES has only been tested with Gradient Descent preconditioning")
     end
     preconstate = initial_state(method.precon, method.preconopts, d, initial_x)
     wmax = method.wmax
@@ -228,12 +228,15 @@ end
 
 precon_post_optimize!(d, state, method) = update_h!(d, state.preconstate, method)
 
-function precon_post_optimize!(d, state::NGMRESState{X,T}), method::Union{LBFGS,BFGS})
+function precon_post_optimize!(d, state::NGMRESState{X,T},
+                               method::Union{LBFGS,BFGS}) where X where T
     update_h!(d, state.preconstate, method)
 end
 
 precon_post_accelerate!(d, state, method) = update_h!(d, state.preconstate, method)
-function precon_post_accelerate!(d, state::NGMRESState{X,T}), method::Union{LBFGS,BFGS})
+
+function precon_post_accelerate!(d, state::NGMRESState{X,T},
+                                 method::Union{LBFGS,BFGS})  where X where T
     state.preconstate.pseudo_iteration += 1
     update_h!(d, state.preconstate, method)
 end

--- a/test/general/types.jl
+++ b/test/general/types.jl
@@ -14,6 +14,8 @@ import Compat.String
     f_prob = UP.objective(prob)
     for g_free in (NelderMead(), SimulatedAnnealing())
         res = Optim.optimize(f_prob, prob.initial_x, g_free)
+        @test typeof(f_prob(prob.initial_x)) == typeof(Optim.minimum(res))
+        @test eltype(x0) == eltype(Optim.minimizer(res))
 
         io = IOBuffer()
         show(io, res)
@@ -42,6 +44,8 @@ import Compat.String
     end
 
     res = Optim.optimize(UP.objective(prob), UP.gradient(prob), prob.initial_x, LBFGS())
+    @test typeof(f_prob(prob.initial_x)) == typeof(Optim.minimum(res))
+    @test eltype(x0) == eltype(Optim.minimizer(res))
 
     io = IOBuffer()
     show(io, res)

--- a/test/general/types.jl
+++ b/test/general/types.jl
@@ -15,7 +15,7 @@ import Compat.String
     for g_free in (NelderMead(), SimulatedAnnealing())
         res = Optim.optimize(f_prob, prob.initial_x, g_free)
         @test typeof(f_prob(prob.initial_x)) == typeof(Optim.minimum(res))
-        @test eltype(x0) == eltype(Optim.minimizer(res))
+        @test eltype(prob.initial_x) == eltype(Optim.minimizer(res))
 
         io = IOBuffer()
         show(io, res)
@@ -45,7 +45,7 @@ import Compat.String
 
     res = Optim.optimize(UP.objective(prob), UP.gradient(prob), prob.initial_x, LBFGS())
     @test typeof(f_prob(prob.initial_x)) == typeof(Optim.minimum(res))
-    @test eltype(x0) == eltype(Optim.minimizer(res))
+    @test eltype(prob.initial_x) == eltype(Optim.minimizer(res))
 
     io = IOBuffer()
     show(io, res)

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -16,8 +16,9 @@
     for method in (Optim.GradientDescent, Optim.ConjugateGradient, Optim.LBFGS, Optim.BFGS,
                    Optim.NGMRES, Optim.OACCEL)
         debug_printing && print_with_color(:green, "Solver: $(summary(method()))\n")
-
         res = Optim.optimize(fcomplex, gcomplex!, x0, method())
+        debug_printing && print_with_color(:red, "Iter\tf-calls\tg-calls\n")
+        debug_printing && print_with_color(:green, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
         @test Optim.converged(res)
         @test Optim.minimizer(res) ≈ A\b rtol=1e-2
     end

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -30,7 +30,9 @@
         debug_printing && print_with_color(:green, "Iter\tf-calls\tg-calls\n")
         debug_printing && print_with_color(:red, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
         if !Optim.converged(res)
+            warn("$(summary(solver)) failed.")
             display(res)
+            println("########################")
         end
         ressum = summary(res) # Just check that no errors arise when doing display(res)
         @test typeof(fcomplex(x0)) == typeof(Optim.minimum(res))
@@ -39,19 +41,23 @@
         @test Optim.minimizer(res) ≈ A\b rtol=1e-2
     end
 
-    solver = Optim.MomentumGradientDescent(mu=0.0)
+    solver = Optim.MomentumGradientDescent(mu=0.0) # mu = 0 is basically GradienDescent?
     allow_f_increases = true # Fix Win32 failure
-        dopts = Optim.default_options(solver)
-        if haskey(dopts, :allow_f_increases)
-            allow_f_increases = allow_f_increases || dopts[:allow_f_increases]
-            delete!(dopts, :allow_f_increases)
-        end
+    dopts = Optim.default_options(solver)
+    if haskey(dopts, :allow_f_increases)
+        allow_f_increases = allow_f_increases || dopts[:allow_f_increases]
+        delete!(dopts, :allow_f_increases)
+    end
     options = Optim.Options(allow_f_increases = allow_f_increases; dopts...)
     debug_printing && print_with_color(:green, "Solver: $(summary(solver))\n")
     res = Optim.optimize(fcomplex, gcomplex!, x0, solver, options)
     debug_printing && print_with_color(:green, "Iter\tf-calls\tg-calls\n")
     debug_printing && print_with_color(:red, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
-    display(res)
+    if !Optim.converged(res)
+        warn("$(summary(solver)) failed.")
+        display(res)
+        println("########################")
+    end
     ressum = summary(res) # Just check that no errors arise when doing display(res)
     @test typeof(fcomplex(x0)) == typeof(Optim.minimum(res))
     @test eltype(x0) == eltype(Optim.minimizer(res))

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -17,13 +17,16 @@
                    Optim.NGMRES, Optim.OACCEL)
         debug_printing && print_with_color(:green, "Solver: $(summary(method()))\n")
         res = Optim.optimize(fcomplex, gcomplex!, x0, method())
-        debug_printing && print_with_color(:red, "Iter\tf-calls\tg-calls\n")
-        debug_printing && print_with_color(:green, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
+        debug_printing && print_with_color(:green, "Iter\tf-calls\tg-calls\n")
+        debug_printing && print_with_color(:red, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
         @test Optim.converged(res)
         @test Optim.minimizer(res) ≈ A\b rtol=1e-2
     end
 
     debug_printing && print_with_color(:green, "Solver: $(summary(MomentumGradientDescent(mu=0.0)))\n")
     res = Optim.optimize(fcomplex, gcomplex!, x0, Optim.MomentumGradientDescent(mu=0.0))
+    debug_printing && print_with_color(:green, "Iter\tf-calls\tg-calls\n")
+    debug_printing && print_with_color(:red, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
     @test Optim.converged(res)
+    @test Optim.minimizer(res) ≈ A\b rtol=1e-2
 end

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -22,6 +22,9 @@
         if !Optim.converged(res)
             display(res)
         end
+        ressum = summary(res) # Just check that no errors arise when doing display(res)
+        @test typeof(fcomplex(x0)) == typeof(Optim.minimum(res))
+        @test eltype(x0) == eltype(Optim.minimizer(res))
         @test Optim.converged(res)
         @test Optim.minimizer(res) ≈ A\b rtol=1e-2
     end
@@ -31,6 +34,9 @@
     debug_printing && print_with_color(:green, "Iter\tf-calls\tg-calls\n")
     debug_printing && print_with_color(:red, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
     display(res)
+    ressum = summary(res) # Just check that no errors arise when doing display(res)
+    @test typeof(fcomplex(x0)) == typeof(Optim.minimum(res))
+    @test eltype(x0) == eltype(Optim.minimizer(res))
     @test Optim.converged(res)
     @test Optim.minimizer(res) ≈ A\b rtol=1e-2
 end

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -19,6 +19,9 @@
         res = Optim.optimize(fcomplex, gcomplex!, x0, method())
         debug_printing && print_with_color(:green, "Iter\tf-calls\tg-calls\n")
         debug_printing && print_with_color(:red, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
+        if !Optim.converged(res)
+            display(res)
+        end
         @test Optim.converged(res)
         @test Optim.minimizer(res) ≈ A\b rtol=1e-2
     end
@@ -27,6 +30,7 @@
     res = Optim.optimize(fcomplex, gcomplex!, x0, Optim.MomentumGradientDescent(mu=0.0))
     debug_printing && print_with_color(:green, "Iter\tf-calls\tg-calls\n")
     debug_printing && print_with_color(:red, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
+    display(res)
     @test Optim.converged(res)
     @test Optim.minimizer(res) ≈ A\b rtol=1e-2
 end

--- a/test/multivariate/manifolds.jl
+++ b/test/multivariate/manifolds.jl
@@ -18,6 +18,8 @@
                    Optim.NGMRES, Optim.OACCEL)
         debug_printing && print_with_color(:green, "Solver: $(summary(method()))\n")
         res = Optim.optimize(fmanif, gmanif!, x0, method(manifold=manif))
+        debug_printing && print_with_color(:red, "Iter\tf-calls\tg-calls\n")
+        debug_printing && print_with_color(:green, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
         @test Optim.converged(res)
     end
     res = Optim.optimize(fmanif, gmanif!, x0, Optim.MomentumGradientDescent(mu=0.0, manifold=manif))

--- a/test/multivariate/manifolds.jl
+++ b/test/multivariate/manifolds.jl
@@ -18,8 +18,8 @@
                    Optim.NGMRES, Optim.OACCEL)
         debug_printing && print_with_color(:green, "Solver: $(summary(method()))\n")
         res = Optim.optimize(fmanif, gmanif!, x0, method(manifold=manif))
-        debug_printing && print_with_color(:red, "Iter\tf-calls\tg-calls\n")
-        debug_printing && print_with_color(:green, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
+        debug_printing && print_with_color(:green, "Iter\tf-calls\tg-calls\n")
+        debug_printing && print_with_color(:red, "$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n")
         @test Optim.converged(res)
     end
     res = Optim.optimize(fmanif, gmanif!, x0, Optim.MomentumGradientDescent(mu=0.0, manifold=manif))

--- a/test/multivariate/manifolds.jl
+++ b/test/multivariate/manifolds.jl
@@ -14,7 +14,9 @@
     manif = Optim.Stiefel()
 
     # AcceleratedGradientDescent should be compatible also, but I haven't been able to make it converge
-    for method in (Optim.GradientDescent, Optim.ConjugateGradient, Optim.LBFGS, Optim.BFGS)
+    for method in (Optim.GradientDescent, Optim.ConjugateGradient, Optim.LBFGS, Optim.BFGS,
+                   Optim.NGMRES, Optim.OACCEL)
+        debug_printing && print_with_color(:green, "Solver: $(summary(method()))\n")
         res = Optim.optimize(fmanif, gmanif!, x0, method(manifold=manif))
         @test Optim.converged(res)
     end

--- a/test/multivariate/solvers/first_order/ngmres.jl
+++ b/test/multivariate/solvers/first_order/ngmres.jl
@@ -1,13 +1,96 @@
 # TODO: add specialized tests
 
 @testset "N-GMRES" begin
-    run_optim_tests(NGMRES();
-                    f_increase_exceptions = ("Rosenbrock", "Powell", "Himmelblau"))
+    method = NGMRES
+    solver = method()
 
+    skip = ("Trigonometric", )
+    run_optim_tests(solver; skip = skip,
+                    iteration_exceptions = (("Penalty Function I", 10000), ),
+                    show_name = debug_printing)
+
+    # Specialized tests
+    prob = UP.examples["Rosenbrock"]
+    df = OnceDifferentiable(UP.objective(prob),
+                            UP.gradient(prob),
+                            prob.initial_x)
+
+    @test solver.nlpreconopts.iterations == 1
+    @test solver.nlpreconopts.allow_f_increases == true
+
+    defopts = Optim.default_options(solver)
+    @test defopts == Dict(:allow_f_increases => true)
+
+    state = Optim.initial_state(solver, Optim.Options(;defopts...), df,
+                                prob.initial_x)
+    @test state.x          === state.nlpreconstate.x
+    @test state.x_previous === state.nlpreconstate.x_previous
+    @test size(state.X)    == (length(state.x), solver.wmax)
+    @test size(state.R)    == (length(state.x), solver.wmax)
+    @test size(state.Q)    == (solver.wmax, solver.wmax)
+    @test size(state.ξ)    == (solver.wmax,)
+    @test state.curw       == 1
+    @test size(state.A)    == (solver.wmax, solver.wmax)
+    @test length(state.b)  == solver.wmax
+    @test length(state.xA) == length(state.x)
+
+    # Test that tracing doesn't throw errors
+    res = optimize(df, prob.initial_x, solver,
+                   Optim.Options(extended_trace=true, store_trace=true;
+                                 defopts...))
+
+    @test Optim.converged(res)
+    # TODO: is it a bad idea to hardcode these?
+    @test Optim.iterations(res) == 65
+    @test Optim.f_calls(res) == 235
+    @test Optim.g_calls(res) == 235
+    @test Optim.minimum(res) < 1e-10
+
+    @test_throws AssertionError method(manifold=Optim.Sphere(), nlprecon = GradientDescent())
 end
 
+
 @testset "O-ACCEL" begin
-    run_optim_tests(OACCEL();
-                    f_increase_exceptions = ("Rosenbrock", "Hosaki",
-                                             "Powell", "Himmelblau"))
+    method = OACCEL
+    solver = method()
+    skip = ("Trigonometric", )
+    run_optim_tests(solver; skip = skip,
+                    iteration_exceptions = (("Penalty Function I", 10000), ),
+                    show_name = debug_printing)
+
+    prob = UP.examples["Rosenbrock"]
+    df = OnceDifferentiable(UP.objective(prob),
+                            UP.gradient(prob),
+                            prob.initial_x)
+    @test solver.nlpreconopts.iterations == 1
+    @test solver.nlpreconopts.allow_f_increases == true
+
+    defopts = Optim.default_options(solver)
+    @test defopts == Dict(:allow_f_increases => true)
+
+    state = Optim.initial_state(solver, Optim.Options(;defopts...), df,
+                                prob.initial_x)
+    @test state.x          === state.nlpreconstate.x
+    @test state.x_previous === state.nlpreconstate.x_previous
+    @test size(state.X)    == (length(state.x), solver.wmax)
+    @test size(state.R)    == (length(state.x), solver.wmax)
+    @test size(state.Q)    == (solver.wmax, solver.wmax)
+    @test size(state.ξ)    == (solver.wmax, 2)
+    @test state.curw       == 1
+    @test size(state.A)    == (solver.wmax, solver.wmax)
+    @test length(state.b)  == solver.wmax
+    @test length(state.xA) == length(state.x)
+
+    # Test that tracing doesn't throw errors
+    res = optimize(df, prob.initial_x, solver,
+                   Optim.Options(extended_trace=true, store_trace=true;
+                                 defopts...))
+    @test Optim.converged(res)
+    # TODO: is it a bad idea to hardcode these?
+    @test Optim.iterations(res) == 87
+    @test Optim.f_calls(res) == 291
+    @test Optim.g_calls(res) == 291
+    @test Optim.minimum(res) < 1e-10
+
+    @test_throws AssertionError method(manifold=Optim.Sphere(), nlprecon = GradientDescent())
 end

--- a/test/multivariate/solvers/first_order/ngmres.jl
+++ b/test/multivariate/solvers/first_order/ngmres.jl
@@ -1,5 +1,3 @@
-# TODO: add specialized tests
-
 @testset "N-GMRES" begin
     method = NGMRES
     solver = method()
@@ -40,10 +38,11 @@
                                  defopts...))
 
     @test Optim.converged(res)
+    # The bounds are due to different systems behaving differently
     # TODO: is it a bad idea to hardcode these?
-    @test Optim.iterations(res) == 65
-    @test Optim.f_calls(res) == 235
-    @test Optim.g_calls(res) == 235
+    @test 64 < Optim.iterations(res) < 84
+    @test 234 < Optim.f_calls(res) <  286
+    @test 234 < Optim.g_calls(res) < 286
     @test Optim.minimum(res) < 1e-10
 
     @test_throws AssertionError method(manifold=Optim.Sphere(), nlprecon = GradientDescent())
@@ -86,10 +85,12 @@ end
                    Optim.Options(extended_trace=true, store_trace=true;
                                  defopts...))
     @test Optim.converged(res)
+    # The bounds are due to different systems behaving differently
     # TODO: is it a bad idea to hardcode these?
-    @test Optim.iterations(res) == 87
-    @test Optim.f_calls(res) == 291
-    @test Optim.g_calls(res) == 291
+    @test 72 < Optim.iterations(res) < 88
+    @test 245 < Optim.f_calls(res) <  292
+    @test 245 < Optim.g_calls(res) <  292
+
     @test Optim.minimum(res) < 1e-10
 
     @test_throws AssertionError method(manifold=Optim.Sphere(), nlprecon = GradientDescent())

--- a/test/multivariate/solvers/first_order/ngmres.jl
+++ b/test/multivariate/solvers/first_order/ngmres.jl
@@ -46,6 +46,18 @@
     @test Optim.minimum(res) < 1e-10
 
     @test_throws AssertionError method(manifold=Optim.Sphere(), nlprecon = GradientDescent())
+
+    for nlprec in (LBFGS, BFGS)
+        solver = method(nlprecon=nlprec())
+        clear!(df)
+        res = optimize(df, prob.initial_x, solver)
+
+        if !Optim.converged(res)
+            display(res)
+        end
+        @test Optim.converged(res)
+        @test Optim.minimum(res) < 1e-10
+    end
 end
 
 
@@ -94,4 +106,16 @@ end
     @test Optim.minimum(res) < 1e-10
 
     @test_throws AssertionError method(manifold=Optim.Sphere(), nlprecon = GradientDescent())
+
+    for nlprec in (LBFGS, BFGS)
+        solver = method(nlprecon=nlprec())
+        clear!(df)
+        res = optimize(df, prob.initial_x, solver)
+
+        if !Optim.converged(res)
+            display(res)
+        end
+        @test Optim.converged(res)
+        @test Optim.minimum(res) < 1e-10
+    end
 end

--- a/test/multivariate/solvers/first_order/ngmres.jl
+++ b/test/multivariate/solvers/first_order/ngmres.jl
@@ -1,3 +1,5 @@
+# TODO: add specialized tests
+
 @testset "N-GMRES" begin
     run_optim_tests(NGMRES();
                     f_increase_exceptions = ("Rosenbrock", "Powell", "Himmelblau"))

--- a/test/multivariate/solvers/first_order/ngmres.jl
+++ b/test/multivariate/solvers/first_order/ngmres.jl
@@ -1,0 +1,11 @@
+@testset "N-GMRES" begin
+    run_optim_tests(NGMRES();
+                    f_increase_exceptions = ("Rosenbrock", "Powell", "Himmelblau"))
+
+end
+
+@testset "O-ACCEL" begin
+    run_optim_tests(OACCEL();
+                    f_increase_exceptions = ("Rosenbrock", "Hosaki",
+                                             "Powell", "Himmelblau"))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using OptimTestProblems
 UP = OptimTestProblems.UnconstrainedProblems
 using Base.Test
 
-debug_printing = true
+debug_printing = false
 
 general_tests = [
     "api",
@@ -34,34 +34,34 @@ univariate_tests = [
 univariate_tests = map(s->"./univariate/"*s*".jl", univariate_tests)
 
 multivariate_tests = [
-    # optimize
-    # "optimize/interface",
-    # "optimize/optimize",
-    # # solvers
-    # ## constrained
-    # "solvers/constrained/constrained",
-    # ## first order
-    # "solvers/first_order/accelerated_gradient_descent",
-    # "solvers/first_order/bfgs",
-    # "solvers/first_order/cg",
-    # "solvers/first_order/gradient_descent",
-    # "solvers/first_order/l_bfgs",
-    # "solvers/first_order/momentum_gradient_descent",
+    ## optimize
+    "optimize/interface",
+    "optimize/optimize",
+    ## solvers
+    ## constrained
+    "solvers/constrained/constrained",
+    ## first order
+    "solvers/first_order/accelerated_gradient_descent",
+    "solvers/first_order/bfgs",
+    "solvers/first_order/cg",
+    "solvers/first_order/gradient_descent",
+    "solvers/first_order/l_bfgs",
+    "solvers/first_order/momentum_gradient_descent",
     "solvers/first_order/ngmres",
-    # ## second order
-    # "solvers/second_order/newton",
-    # "solvers/second_order/newton_trust_region",
-    # "solvers/second_order/krylov_trust_region",
-    # ## zeroth order
-    # "solvers/zeroth_order/grid_search",
-    # "solvers/zeroth_order/nelder_mead",
-    # "solvers/zeroth_order/particle_swarm",
-    # "solvers/zeroth_order/simulated_annealing",
-    # # other
-    # "array",
-    # "extrapolate",
-    # "lsthrow",
-    # "precon",
+    ## second order
+    "solvers/second_order/newton",
+    "solvers/second_order/newton_trust_region",
+    "solvers/second_order/krylov_trust_region",
+    ## zeroth order
+    "solvers/zeroth_order/grid_search",
+    "solvers/zeroth_order/nelder_mead",
+    "solvers/zeroth_order/particle_swarm",
+    "solvers/zeroth_order/simulated_annealing",
+    ## other
+    "array",
+    "extrapolate",
+    "lsthrow",
+    "precon",
     "manifolds",
     "complex",
 ]
@@ -129,18 +129,18 @@ function run_optim_tests(method; convergence_exceptions = (),
     end
 end
 
-# @testset "general" begin
-#     for my_test in general_tests
-#         println(my_test)
-#         @time include(my_test)
-#     end
-# end
-# @testset "univariate" begin
-#     for my_test in univariate_tests
-#         println(my_test)
-#         @time include(my_test)
-#     end
-# end
+@testset "general" begin
+    for my_test in general_tests
+        println(my_test)
+        @time include(my_test)
+    end
+end
+@testset "univariate" begin
+    for my_test in univariate_tests
+        println(my_test)
+        @time include(my_test)
+    end
+end
 @testset "multivariate" begin
     for my_test in multivariate_tests
         println(my_test)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,8 +96,11 @@ function run_optim_tests(method; convergence_exceptions = (),
         dopts = Optim.default_options(method)
         if haskey(dopts, :allow_f_increases)
             allow_f_increases = allow_f_increases || dopts[:allow_f_increases]
+            delete!(dopts, :allow_f_increases)
         end
-        options = Optim.Options(allow_f_increases = allow_f_increases, iterations = iters, show_trace = show_trace)
+        options = Optim.Options(allow_f_increases = allow_f_increases,
+                                iterations = iters, show_trace = show_trace;
+                                dopts...)
 
         # Use finite difference if it is not differentiable enough
         if  !(name in skip)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ multivariate_tests = [
     "solvers/first_order/gradient_descent",
     "solvers/first_order/l_bfgs",
     "solvers/first_order/momentum_gradient_descent",
+    "solvers/first_order/ngmres",
     ## second order
     "solvers/second_order/newton",
     "solvers/second_order/newton_trust_region",
@@ -91,7 +92,12 @@ function run_optim_tests(method; convergence_exceptions = (),
         # If name wasn't found, use default 1000 iterations, else use provided number
         iters = length(iter_id) == 0 ? 1000 : iteration_exceptions[iter_id[1]][2]
         # Construct options
-        options = Optim.Options(allow_f_increases = name in f_increase_exceptions, iterations = iters, show_trace = show_trace)
+        allow_f_increases = (name in f_increase_exceptions)
+        dopts = Optim.default_options(method)
+        if haskey(dopts, :allow_f_increases)
+            allow_f_increases = allow_f_increases || dopts[:allow_f_increases]
+        end
+        options = Optim.Options(allow_f_increases = allow_f_increases, iterations = iters, show_trace = show_trace)
 
         # Use finite difference if it is not differentiable enough
         if  !(name in skip)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using OptimTestProblems
 UP = OptimTestProblems.UnconstrainedProblems
 using Base.Test
 
-debug_printing = false
+debug_printing = true
 
 general_tests = [
     "api",
@@ -35,33 +35,33 @@ univariate_tests = map(s->"./univariate/"*s*".jl", univariate_tests)
 
 multivariate_tests = [
     # optimize
-    "optimize/interface",
-    "optimize/optimize",
-    # solvers
-    ## constrained
-    "solvers/constrained/constrained",
-    ## first order
-    "solvers/first_order/accelerated_gradient_descent",
-    "solvers/first_order/bfgs",
-    "solvers/first_order/cg",
-    "solvers/first_order/gradient_descent",
-    "solvers/first_order/l_bfgs",
-    "solvers/first_order/momentum_gradient_descent",
+    # "optimize/interface",
+    # "optimize/optimize",
+    # # solvers
+    # ## constrained
+    # "solvers/constrained/constrained",
+    # ## first order
+    # "solvers/first_order/accelerated_gradient_descent",
+    # "solvers/first_order/bfgs",
+    # "solvers/first_order/cg",
+    # "solvers/first_order/gradient_descent",
+    # "solvers/first_order/l_bfgs",
+    # "solvers/first_order/momentum_gradient_descent",
     "solvers/first_order/ngmres",
-    ## second order
-    "solvers/second_order/newton",
-    "solvers/second_order/newton_trust_region",
-    "solvers/second_order/krylov_trust_region",
-    ## zeroth order
-    "solvers/zeroth_order/grid_search",
-    "solvers/zeroth_order/nelder_mead",
-    "solvers/zeroth_order/particle_swarm",
-    "solvers/zeroth_order/simulated_annealing",
-    # other
-    "array",
-    "extrapolate",
-    "lsthrow",
-    "precon",
+    # ## second order
+    # "solvers/second_order/newton",
+    # "solvers/second_order/newton_trust_region",
+    # "solvers/second_order/krylov_trust_region",
+    # ## zeroth order
+    # "solvers/zeroth_order/grid_search",
+    # "solvers/zeroth_order/nelder_mead",
+    # "solvers/zeroth_order/particle_swarm",
+    # "solvers/zeroth_order/simulated_annealing",
+    # # other
+    # "array",
+    # "extrapolate",
+    # "lsthrow",
+    # "precon",
     "manifolds",
     "complex",
 ]
@@ -126,18 +126,18 @@ function run_optim_tests(method; convergence_exceptions = (),
     end
 end
 
-@testset "general" begin
-    for my_test in general_tests
-        println(my_test)
-        @time include(my_test)
-    end
-end
-@testset "univariate" begin
-    for my_test in univariate_tests
-        println(my_test)
-        @time include(my_test)
-    end
-end
+# @testset "general" begin
+#     for my_test in general_tests
+#         println(my_test)
+#         @time include(my_test)
+#     end
+# end
+# @testset "univariate" begin
+#     for my_test in univariate_tests
+#         println(my_test)
+#         @time include(my_test)
+#     end
+# end
 @testset "multivariate" begin
     for my_test in multivariate_tests
         println(my_test)


### PR DESCRIPTION
This implements solvers that do two things:
- Show an example of nonlinear preconditioning.
- Introduce two nonlinear preconditioning algorithms that significantly improves the performance of Gradient Descent.

This implements two acceleration algorithms, [Nonlinear GMRES](http://www.hansdesterck.net/Publications-by-topic/nonlinear-preconditioning-for-nonlinear-optimization) and ["Objective Acceleration"](https://arxiv.org/abs/1710.05200).
I have tested them as accelerators on top of Gradient Descent and L-BFGS. For GD it is very efficient, for L-BFGS I am not sure if it has value ( the situations where the accelerators improve L-BFGS, it can be better to combine them with GD instead ).

Give me feedback on 
- whether you think these belong in Optim.jl, or should be a separate package (@pkofod ?);
- whether this approach to nonlinear preconditioning is useful or not (@ChrisRackauckas ?).

TODO:
- [x] Make the algorithms work with complex numbers (help @antoine-levitt ?)
- [x] See if it is reasonable to support Manifolds (help @antoine-levitt ? )
- [x] Add documentation.
- [x] Add tests.
- [x] Add specialised tests
- [x] Get https://github.com/JuliaLang/METADATA.jl/pull/12920 merged 
- [x] Add issue for improving the tracing
- [x] Add issue: use QR updating for system matrix 



If it works well and people are happy, this fixes #477 .