### PR TITLE
DiffeqDiffTools derivatives

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ Calculus
 NLSolversBase 4.0.0
 ForwardDiff 0.5.0
 DiffEqDiffTools 0.2.1 # TODO: update when they release Gradient PR
+Calculus # TODO: Remove when DiffEqDiffTools release Hessian PR

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,5 +5,5 @@ LineSearches 3.2.4
 Calculus
 NLSolversBase 4.0.0
 ForwardDiff 0.5.0
-DiffEqDiffTools 0.2.1 # TODO: update when they release Gradient PR
+DiffEqDiffTools 0.4.0
 Calculus # TODO: Remove when DiffEqDiffTools release Hessian PR

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ LineSearches 3.2.4
 Calculus
 NLSolversBase 4.0.0
 ForwardDiff 0.5.0
+DiffEqDiffTools 0.2.1 # TODO: update when they release Gradient PR

--- a/docs/src/algo/autodiff.md
+++ b/docs/src/algo/autodiff.md
@@ -1,12 +1,15 @@
 # Automatic Differentiation
-As mentioned in the [Minimizing a function](http://www.juliaopt.org/Optim.jl/latest/user/minimization/) section,
+As mentioned in the [Minimizing a function](../user/minimization.md) section,
 it is possible to avoid passing gradients even when using gradient based methods.
-This is because Optim will call the finite central differences functionality
-in [Calculus.jl](https://github.com/johnmyleswhite/Calculus.jl/issues) in those cases.
+This is because Optim will call the finite central differences
+functionality in
+[DiffEqDiffTools.jl](https://github.com/JuliaDiffEq/DiffEqDiffTools.jl)
+in those cases.
 The advantages are clear: you do not have to write the gradients yourself, and
 it works for any function you can pass to Optim. However, there is another good
-way of making the computer provide gradients: automatic differentiation. Again, the
-advantage is that you can easily get gradients from the objective function alone.
+way of making the computer provide gradients: *automatic
+differentiation*. Again, the advantage is that you can easily get
+gradients from the objective function alone.
 As opposed to finite difference, these gradients are exact and we also get Hessians for
 Newton's method. They can perform better than a finite differences scheme, depending
 on the exact problem.
@@ -48,7 +51,7 @@ julia> Optim.minimizer(optimize(f, g!, h!, initial_x, Newton()))
  1.0
 ```
 This is indeed the case. Now let us use finite differences for BFGS.
-```jlcon    
+```jlcon
 julia> Optim.minimizer(optimize(f, initial_x, BFGS()))
 2-element Array{Float64,1}:
  1.0

--- a/docs/src/algo/complex.md
+++ b/docs/src/algo/complex.md
@@ -1,6 +1,35 @@
 # Complex optimization
-Optimization of functions defined on complex inputs (C^n to R) is supported by simply passing a complex `x0` as input. All zeroth and first order optimization algorithms are supported. For now, only explicit gradients are supported.
+Optimization of functions defined on complex inputs (``\mathbb{C}^n
+\to \mathbb{R}``) is supported by simply passing a complex ``x`` as
+input. All zeroth and first order optimization algorithms are
+supported.
 
-The gradient of a complex-to-real function is defined as the only vector `g` such that `f(x+h) = f(x) + real(g' * h) + O(h^2)`. This is sometimes written `g = df/d(z*) = df/d(re(z)) + i df/d(im(z))`.
+The gradient of a complex-to-real function is defined as the only
+vector ``g`` such that
+```math
+f(x+h) = f(x) + \mbox{Re}(g' * h) + \mathcal{O}(h^2).
+```
+This is sometimes written
+```math
+g = \frac{df}{d(z*)} = \frac{df}{d(\mbox{Re}(z))} + i \frac{df}{d(\mbox{Im(z)})}.
+```
 
-The gradient of a C^n to R function is a C^n to C^n map. Even if it is differentiable when seen as a function of R^2n to R^2n, it might not be complex-differentiable. For instance, take f(z) = Re(z)^2. Then g(z) = 2 Re(z), which is not complex-differentiable (holomorphic). Therefore, the Hessian of a C^n to R function is in general not well-defined as a n x n complex matrix (only as a 2n x 2n real matrix), and therefore second-order optimization algorithms are not applicable directly. To use second-order optimization, convert to real variables. 
+The gradient of a ``\mathbb{C}^n \to \mathbb{R}`` function is a
+``\mathbb{C}^n \to \mathbb{C}^n`` map. Even if it is differentiable when
+seen as a function of R^2n to R^2n, it might not be
+complex-differentiable. For instance, take ``f(z) = \mbox{Re}(z)^2``.
+Then ``g(z) = 2 \mbox{Re}(z)``, which is not complex-differentiable
+(holomorphic). Therefore,
+the Hessian of a ``\mathbb{C}^n \to \mathbb{R}`` function is in
+general not well-defined as a ``n \times n`` complex matrix (only as a
+``2n \times 2n`` real matrix), and therefore
+second-order optimization algorithms are not applicable directly. To
+use second-order optimization, convert to real variables.
+
+
+## Examples
+**TODO**
+
+
+## References
+**TODO**

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -5,7 +5,8 @@ module Optim
     using Compat
     using LineSearches
     using NLSolversBase
-    using Calculus
+using Calculus
+    using DiffEqDiffTools
 #    using ReverseDiff
     using ForwardDiff
 

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -5,7 +5,7 @@ module Optim
     using Compat
     using LineSearches
     using NLSolversBase
-using Calculus
+    using Calculus
     using DiffEqDiffTools
 #    using ReverseDiff
     using ForwardDiff

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -77,10 +77,9 @@ function optimize(d::D, initial_x::AbstractArray{Tx, N}, method::M,
     # we can just check minimum, as we've earlier enforced same types/eltypes
     # in variables besides the option settings
     T = typeof(options.f_tol)
-    Tf = typeof(value(d))
     f_incr_pick = f_increased && !options.allow_f_increases
 
-    return MultivariateOptimizationResults{typeof(method), T, Tx, Tf, N, typeof(tr)}(method,
+    return MultivariateOptimizationResults(method,
                                         NLSolversBase.iscomplex(d),
                                         real_to_complex(d, initial_x),
                                         real_to_complex(d, pick_best_x(f_incr_pick, state)),

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -13,10 +13,10 @@ update_h!(d, state, method::SecondOrderOptimizer) = hessian!(d, state.x)
 
 after_while!(d, state, method, options) = nothing
 
-function initial_convergence(d, state, method::AbstractOptimizer, initial_x, options) 
+function initial_convergence(d, state, method::AbstractOptimizer, initial_x, options)
     gradient!(d, initial_x)
     vecnorm(gradient(d), Inf) < options.g_tol
-end 
+end
 initial_convergence(d, state, method::ZerothOrderOptimizer, initial_x, options) = false
 
 function optimize(d::D, initial_x::AbstractArray{Tx, N}, method::M,
@@ -80,7 +80,7 @@ function optimize(d::D, initial_x::AbstractArray{Tx, N}, method::M,
     Tf = typeof(value(d))
     f_incr_pick = f_increased && !options.allow_f_increases
 
-    return MultivariateOptimizationResults(method,
+    return MultivariateOptimizationResults{typeof(method), T, Tx, Tf, N, typeof(tr)}(method,
                                         NLSolversBase.iscomplex(d),
                                         real_to_complex(d, initial_x),
                                         real_to_complex(d, pick_best_x(f_incr_pick, state)),

--- a/src/objective_types.jl
+++ b/src/objective_types.jl
@@ -2,8 +2,8 @@ function OnceDifferentiable(f, x_seed::AbstractArray{T}, F::Real = real(zero(T))
                             DF::AbstractArray = NLSolversBase.alloc_DF(x_seed, F);
                             autodiff = :finite) where T
     if autodiff == :finite
-        # TODO: Allow user to specify Val{:central}, Val{:forward}, :Val{:complex}
-        gcache = DiffEqDiffTools.GradientCache(x_seed, x_seed, nothing, nothing, nothing, Val{:central})
+        # TODO: Allow user to specify Val{:central}, Val{:forward}, :Val{:complex} (requires care when using :forward I think)
+        gcache = DiffEqDiffTools.GradientCache(x_seed, x_seed, Val{:central})
         function g!(storage, x)
             DiffEqDiffTools.finite_difference_gradient!(storage, f, x, gcache)
             return
@@ -37,7 +37,7 @@ function TwiceDifferentiable(f, g!, x_seed::AbstractVector{T}, F::Real = real(ze
         # TODO: Create / request Hessian functionality in DiffEqDiffTools?
         #       (Or is it better to use the finite difference Jacobian of a gradient?)
         # TODO: Allow user to specify Val{:central}, Val{:forward}, :Val{:complex}
-        jcache = DiffEqDiffTools.JacobianCache(x_seed, nothing, nothing, nothing, Val{:central})
+        jcache = DiffEqDiffTools.JacobianCache(x_seed, Val{:central})
         function h!(storage, x)
             DiffEqDiffTools.finite_difference_jacobian!(storage, g!, x, jcache)
             return
@@ -60,7 +60,7 @@ function TwiceDifferentiable(d::OnceDifferentiable, x_seed::AbstractVector{T} = 
         # TODO: Create / request Hessian functionality in DiffEqDiffTools?
         #       (Or is it better to use the finite difference Jacobian of a gradient?)
         # TODO: Allow user to specify Val{:central}, Val{:forward}, :Val{:complex}
-        jcache = DiffEqDiffTools.JacobianCache(x_seed, nothing, nothing, nothing, Val{:central})
+        jcache = DiffEqDiffTools.JacobianCache(x_seed, Val{:central})
         function h!(storage, x)
             DiffEqDiffTools.finite_difference_jacobian!(storage, d.df, x, jcache)
             return
@@ -78,7 +78,7 @@ function TwiceDifferentiable(f, x::AbstractVector{T}, F::Real = real(zero(T));
                              autodiff = :finite) where T
     if autodiff == :finite
         # TODO: Allow user to specify Val{:central}, Val{:forward}, Val{:complex}
-        gcache = DiffEqDiffTools.GradientCache(x, x, nothing, nothing, nothing, Val{:central})
+        gcache = DiffEqDiffTools.GradientCache(x, x, Val{:central})
         function g!(storage, x)
             DiffEqDiffTools.finite_difference_gradient!(storage, f, x, gcache)
             return

--- a/src/objective_types.jl
+++ b/src/objective_types.jl
@@ -1,4 +1,4 @@
-function OnceDifferentiable(f, x_seed::AbstractArray{T}, F::Real = zero(T),
+function OnceDifferentiable(f, x_seed::AbstractArray{T}, F::Real = real(zero(T)),
                             DF::AbstractArray = NLSolversBase.alloc_DF(x_seed, F);
                             autodiff = :finite) where T
     if autodiff == :finite
@@ -27,7 +27,7 @@ function OnceDifferentiable(f, x_seed::AbstractArray{T}, F::Real = zero(T),
     OnceDifferentiable(f, g!, fg!, x_seed, F, DF)
 end
 
-function TwiceDifferentiable(f, g!, x_seed::AbstractVector{T}, F::Real = zero(T); autodiff = :finite) where T
+function TwiceDifferentiable(f, g!, x_seed::AbstractVector{T}, F::Real = real(zero(T)); autodiff = :finite) where T
     n_x = length(x_seed)
     function fg!(storage, x)
         g!(storage, x)
@@ -51,11 +51,11 @@ function TwiceDifferentiable(f, g!, x_seed::AbstractVector{T}, F::Real = zero(T)
     TwiceDifferentiable(f, g!, fg!, h!, x_seed, F)
 end
 
-TwiceDifferentiable(d::NonDifferentiable, x_seed::AbstractVector{T} = d.x_f, F::Real = zero(T); autodiff = :finite) where {T<:Real} =
+TwiceDifferentiable(d::NonDifferentiable, x_seed::AbstractVector{T} = d.x_f, F::Real = real(zero(T)); autodiff = :finite) where {T<:Real} =
     TwiceDifferentiable(d.f, x_seed, F; autodiff = autodiff)
 
 function TwiceDifferentiable(d::OnceDifferentiable, x_seed::AbstractVector{T} = d.x_f,
-                             F::Real = zero(T); autodiff = :finite) where T<:Real
+                             F::Real = real(zero(T)); autodiff = :finite) where T<:Real
     if autodiff == :finite
         # TODO: Create / request Hessian functionality in DiffEqDiffTools?
         #       (Or is it better to use the finite difference Jacobian of a gradient?)
@@ -74,7 +74,7 @@ function TwiceDifferentiable(d::OnceDifferentiable, x_seed::AbstractVector{T} = 
     return TwiceDifferentiable(d.f, d.df, d.fdf, h!, x_seed, F, gradient(d))
 end
 
-function TwiceDifferentiable(f, x::AbstractVector{T}, F::Real = zero(T);
+function TwiceDifferentiable(f, x::AbstractVector{T}, F::Real = real(zero(T));
                              autodiff = :finite) where T
     if autodiff == :finite
         # TODO: Allow user to specify Val{:central}, Val{:forward}, Val{:complex}

--- a/src/objective_types.jl
+++ b/src/objective_types.jl
@@ -1,7 +1,11 @@
 function OnceDifferentiable(f, x_seed::AbstractArray{T}, F = zero(T); autodiff = :finite) where T
     if autodiff == :finite
+        # TODO: Allow user to specify Val{:central}, Val{:forward}, :Val{:complex}
+
+        #gcache = DiffEqDiffTools.GradientCache(x_seed, x_seed, nothing, nothing, nothing, Val{:central})
         function g!(storage, x)
-            Calculus.finite_difference!(f, x, storage, :central)
+            #DiffEqDiffTools.finite_difference_gradient!(storage, f, x, gcache)
+            DiffEqDiffTools.finite_difference_gradient!(storage, f, x, Val{:central})
             return
         end
         function fg!(storage, x)
@@ -20,7 +24,7 @@ function OnceDifferentiable(f, x_seed::AbstractArray{T}, F = zero(T); autodiff =
     else
         error("The autodiff value $autodiff is not support. Use :finite or :forward.")
     end
-    OnceDifferentiable(f, g!, fg!, x_seed)
+    OnceDifferentiable(f, g!, fg!, x_seed, F)
 end
 
 function TwiceDifferentiable(f, g!, x_seed::AbstractVector{T}, F = zero(T); autodiff = :finite) where T
@@ -30,7 +34,10 @@ function TwiceDifferentiable(f, g!, x_seed::AbstractVector{T}, F = zero(T); auto
         return f(x)
     end
     if autodiff == :finite
+        # TODO: Create / request Hessian functionality in DiffEqDiffTools?
+        # TODO: Allow user to specify Val{:central}, Val{:forward}, :Val{:complex}
         function h!(storage, x)
+            #DiffeqDiffTools.finite_difference_jacobian!(storage, g!, )
             Calculus.finite_difference_hessian!(f, x, storage)
             return
         end
@@ -60,11 +67,13 @@ function TwiceDifferentiable(d::OnceDifferentiable, x_seed::AbstractVector{T} = 
     end
     return TwiceDifferentiable(d.f, d.df, d.fdf, h!, x_seed, F, gradient(d))
 end
-    
+
 function TwiceDifferentiable(f, x::AbstractVector{T}, F = zero(T); autodiff = :finite) where T
     if autodiff == :finite
-        function g!(storage::Vector, x::Vector)
-            Calculus.finite_difference!(f, x, storage, :central)
+        # TODO: Allow user to specify Val{:central}, Val{:forward}, Val{:complex}
+        #gcache = DiffEqDiffTools.GradientCache(x, x, nothing, nothing, nothing, Val{:central})
+        function g!(storage, x)
+            DiffEqDiffTools.finite_difference_gradient!(storage, f, x, Val{:central})
             return
         end
         function fg!(storage::Vector, x::Vector)

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -14,8 +14,10 @@
 
     @testset "Finite difference" begin
         oda1 = OnceDifferentiable(fcomplex, x0)
-        NLSolversBase.value_gradient!(oda1, x0)
-        @test gcomplex(x0) ≈ NLSolversBase.gradient(oda1)
+        # TODO: We should update NLSolversBase to accept Complex-valued arrays
+        fx = NLSolversBase.value_gradient!(oda1, NLSolversBase.complex_to_real(x0))
+        @test fx == fcomplex(x0)
+        @test gcomplex(x0) ≈ NLSolversBase.real_to_complex(NLSolversBase.gradient(oda1))
     end
 
     # TODO: AcceleratedGradientDescent fail to converge?

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -5,12 +5,18 @@
     n = 4
     A = randn(n,n) + im*randn(n,n)
     A = A'A + I
-    b = randn(4) + im*randn(4)
+    b = randn(n) + im*randn(n)
 
     fcomplex(x) = real(vecdot(x,A*x)/2 - vecdot(b,x))
     gcomplex(x) = A*x-b
     gcomplex!(stor,x) = copy!(stor,gcomplex(x))
     x0 = randn(n)+im*randn(n)
+
+    @testset "Finite difference" begin
+        oda1 = OnceDifferentiable(fcomplex, x0)
+        NLSolversBase.value_gradient!(oda1, x0)
+        @test gcomplex(x0) ≈ NLSolversBase.gradient(oda1)
+    end
 
     # TODO: AcceleratedGradientDescent fail to converge?
     for method in (Optim.GradientDescent, Optim.ConjugateGradient, Optim.LBFGS, Optim.BFGS,
@@ -39,6 +45,12 @@
         @test eltype(x0) == eltype(Optim.minimizer(res))
         @test Optim.converged(res)
         @test Optim.minimizer(res) ≈ A\b rtol=1e-2
+
+        @testset "Finite difference" begin
+            res = Optim.optimize(fcomplex, x0, solver, options)
+            @test Optim.converged(res)
+            @test Optim.minimizer(res) ≈ A\b rtol=1e-2
+        end
     end
 
     solver = Optim.MomentumGradientDescent(mu=0.0) # mu = 0 is basically GradienDescent?
@@ -63,4 +75,9 @@
     @test eltype(x0) == eltype(Optim.minimizer(res))
     @test Optim.converged(res)
     @test Optim.minimizer(res) ≈ A\b rtol=1e-2
+    @testset "Finite difference" begin
+        res = Optim.optimize(fcomplex, x0, solver, options)
+        @test Optim.converged(res)
+        @test Optim.minimizer(res) ≈ A\b rtol=1e-2
+    end
 end

--- a/test/multivariate/fdtime.jl
+++ b/test/multivariate/fdtime.jl
@@ -3,14 +3,14 @@
     fd_input_tuple(method::Optim.SecondOrderOptimizer, prob) = ((UP.objective(prob),), (UP.objective(prob), UP.gradient(prob)))
 
     function run_optim_fd_tests(method; convergence_exceptions = (),
-                          minimizer_exceptions = (),
-                          minimum_exceptions = (),
-                          f_increase_exceptions = (),
-                          iteration_exceptions = (),
-                          skip = (),
-                          show_name = false,
-                          show_trace = false,
-                          show_res = false)
+                                minimizer_exceptions = (),
+                                minimum_exceptions = (),
+                                f_increase_exceptions = (),
+                                iteration_exceptions = (),
+                                skip = (),
+                                show_name = false,
+                                show_trace = false,
+                                show_res = false)
         # Loop over unconstrained problems
         for (name, prob) in OptimTestProblems.UnconstrainedProblems.examples
             if !isfinite(prob.minimum) || !any(isfinite, prob.solutions)
@@ -55,6 +55,15 @@
     end
 
     skip = ("Trigonometric",)
-    run_optim_fd_tests(LBFGS(), skip = skip,
-                       show_name=debug_printing)
+    @testset "Timing with LBFGS" begin
+        debug_printing && print_with_color(:blue, "#####################\nSolver: L-BFGS\n")
+        run_optim_fd_tests(LBFGS(), skip = skip,
+                           show_name=debug_printing)
+    end
+
+    @testset "Timing with Newton" begin
+        debug_printing && print_with_color(:blue, "#####################\nSolver: Newton\n")
+        run_optim_fd_tests(Newton(), skip = skip,
+                           show_name=debug_printing)
+    end
 end

--- a/test/multivariate/fdtime.jl
+++ b/test/multivariate/fdtime.jl
@@ -1,6 +1,6 @@
 @testset "Finite difference timing" begin
-    fd_input_tuple(method::Optim.FirstOrderOptimizer, prob) = ((UP.objective(prob),),)
-    fd_input_tuple(method::Optim.SecondOrderOptimizer, prob) = ((UP.objective(prob),), (UP.objective(prob), UP.gradient(prob)))
+    fd_input_tuple(method::Optim.FirstOrderOptimizer, prob) = ((MVP.objective(prob),),)
+    fd_input_tuple(method::Optim.SecondOrderOptimizer, prob) = ((MVP.objective(prob),), (MVP.objective(prob), MVP.gradient(prob)))
 
     function run_optim_fd_tests(method;
                                 problems = ("Extended Rosenbrock", "Large Polynomial", "Powell",
@@ -10,7 +10,7 @@
 
         # Loop over unconstrained problems
         for name in problems
-            prob = UP.examples[name]
+            prob = MVP.UnconstrainedProblems.examples[name]
             show_name && print_with_color(:green, "Problem: ", name, "\n")
             options = Optim.Options(allow_f_increases=true, show_trace = show_trace)
             for (i, input) in enumerate(fd_input_tuple(method, prob))

--- a/test/multivariate/fdtime.jl
+++ b/test/multivariate/fdtime.jl
@@ -34,8 +34,9 @@
 
                     # Loop over appropriate input combinations of f, g!, and h!
                     results = Optim.optimize(input..., prob.initial_x, method, options)
+                    debug_printing && print_with_color(:red, "f-calls: $(Optim.f_calls(results))\n")
                     @time Optim.optimize(input..., prob.initial_x, method, options)
-                    @test isa(summary(results), String)
+
                     show_res && println(results)
                     if !((name, i) in convergence_exceptions)
                         @test Optim.converged(results)
@@ -55,5 +56,5 @@
 
     skip = ("Trigonometric",)
     run_optim_fd_tests(LBFGS(), skip = skip,
-                       show_name=true, show_res=true)
+                       show_name=debug_printing)
 end

--- a/test/multivariate/fdtime.jl
+++ b/test/multivariate/fdtime.jl
@@ -2,68 +2,40 @@
     fd_input_tuple(method::Optim.FirstOrderOptimizer, prob) = ((UP.objective(prob),),)
     fd_input_tuple(method::Optim.SecondOrderOptimizer, prob) = ((UP.objective(prob),), (UP.objective(prob), UP.gradient(prob)))
 
-    function run_optim_fd_tests(method; convergence_exceptions = (),
-                                minimizer_exceptions = (),
-                                minimum_exceptions = (),
-                                f_increase_exceptions = (),
-                                iteration_exceptions = (),
-                                skip = (),
-                                show_name = false,
-                                show_trace = false,
-                                show_res = false)
+    function run_optim_fd_tests(method;
+                                problems = ("Extended Rosenbrock", "Large Polynomial", "Powell",
+                                            "Paraboloid Diagonal"),
+                                show_name = false, show_trace = false,
+                                show_time = false, show_res = false)
+
         # Loop over unconstrained problems
-        for (name, prob) in OptimTestProblems.UnconstrainedProblems.examples
-            if !isfinite(prob.minimum) || !any(isfinite, prob.solutions)
-                debug_printing && println("$name has no registered minimum/minimizer. Skipping ...")
-                continue
-            end
+        for name in problems
+            prob = UP.examples[name]
             show_name && print_with_color(:green, "Problem: ", name, "\n")
-            # Look for name in the first elements of the iteration_exceptions tuples
-            iter_id = find(n[1] == name for n in iteration_exceptions)
-            # If name wasn't found, use default 1000 iterations, else use provided number
-            iters = length(iter_id) == 0 ? 1000 : iteration_exceptions[iter_id[1]][2]
-            # Construct options
-            options = Optim.Options(allow_f_increases = name in f_increase_exceptions, iterations = iters, show_trace = show_trace)
+            options = Optim.Options(show_trace = show_trace)
+            for (i, input) in enumerate(fd_input_tuple(method, prob))
+                # Loop over appropriate input combinations of f, g!, and h!
+                results = Optim.optimize(input..., prob.initial_x, method, options)
 
-            # Use finite difference if it is not differentiable enough
-            if  !(name in skip)
-                for (i, input) in enumerate(fd_input_tuple(method, prob))
-                    if (!prob.isdifferentiable && i > 1) || (!prob.istwicedifferentiable && i > 2)
-                        continue
-                    end
+                debug_printing && print_with_color(:red, "f-calls: $(Optim.f_calls(results))\n")
+                show_res && display(results)
 
-                    # Loop over appropriate input combinations of f, g!, and h!
-                    results = Optim.optimize(input..., prob.initial_x, method, options)
-                    debug_printing && print_with_color(:red, "f-calls: $(Optim.f_calls(results))\n")
-                    @time Optim.optimize(input..., prob.initial_x, method, options)
+                show_time && @time Optim.optimize(input..., prob.initial_x, method, options)
 
-                    show_res && println(results)
-                    if !((name, i) in convergence_exceptions)
-                        @test Optim.converged(results)
-                    end
-                    if !((name, i) in minimum_exceptions)
-                        @test Optim.minimum(results) < prob.minimum + sqrt(eps(typeof(prob.minimum)))
-                    end
-                    if !((name, i) in minimizer_exceptions)
-                        @test norm(Optim.minimizer(results) - prob.solutions) < 1e-2
-                    end
-                end
-            else
-                debug_printing && print_with_color(:blue, "Skipping $name\n")
+                @test Optim.converged(results)
+                @test Optim.minimum(results) < prob.minimum + sqrt(eps(typeof(prob.minimum)))
+                @test norm(Optim.minimizer(results) - prob.solutions) < 1e-2
             end
         end
     end
 
-    skip = ("Trigonometric",)
     @testset "Timing with LBFGS" begin
         debug_printing && print_with_color(:blue, "#####################\nSolver: L-BFGS\n")
-        run_optim_fd_tests(LBFGS(), skip = skip,
-                           show_name=debug_printing)
+        run_optim_fd_tests(LBFGS(), show_name=debug_printing, show_time = debug_printing)
     end
 
     @testset "Timing with Newton" begin
         debug_printing && print_with_color(:blue, "#####################\nSolver: Newton\n")
-        run_optim_fd_tests(Newton(), skip = skip,
-                           show_name=debug_printing)
+        run_optim_fd_tests(Newton(), show_name=debug_printing, show_time = debug_printing)
     end
 end

--- a/test/multivariate/fdtime.jl
+++ b/test/multivariate/fdtime.jl
@@ -12,7 +12,7 @@
         for name in problems
             prob = UP.examples[name]
             show_name && print_with_color(:green, "Problem: ", name, "\n")
-            options = Optim.Options(show_trace = show_trace)
+            options = Optim.Options(allow_f_increases=true, show_trace = show_trace)
             for (i, input) in enumerate(fd_input_tuple(method, prob))
                 # Loop over appropriate input combinations of f, g!, and h!
                 results = Optim.optimize(input..., prob.initial_x, method, options)

--- a/test/multivariate/fdtime.jl
+++ b/test/multivariate/fdtime.jl
@@ -4,7 +4,7 @@
 
     function run_optim_fd_tests(method;
                                 problems = ("Extended Rosenbrock", "Large Polynomial", "Powell",
-                                            "Paraboloid Diagonal"),
+                                            "Paraboloid Diagonal", "Penalty Function I",),
                                 show_name = false, show_trace = false,
                                 show_time = false, show_res = false)
 

--- a/test/multivariate/fdtime.jl
+++ b/test/multivariate/fdtime.jl
@@ -1,0 +1,59 @@
+@testset "Finite difference timing" begin
+    fd_input_tuple(method::Optim.FirstOrderOptimizer, prob) = ((UP.objective(prob),),)
+    fd_input_tuple(method::Optim.SecondOrderOptimizer, prob) = ((UP.objective(prob),), (UP.objective(prob), UP.gradient(prob)))
+
+    function run_optim_fd_tests(method; convergence_exceptions = (),
+                          minimizer_exceptions = (),
+                          minimum_exceptions = (),
+                          f_increase_exceptions = (),
+                          iteration_exceptions = (),
+                          skip = (),
+                          show_name = false,
+                          show_trace = false,
+                          show_res = false)
+        # Loop over unconstrained problems
+        for (name, prob) in OptimTestProblems.UnconstrainedProblems.examples
+            if !isfinite(prob.minimum) || !any(isfinite, prob.solutions)
+                debug_printing && println("$name has no registered minimum/minimizer. Skipping ...")
+                continue
+            end
+            show_name && print_with_color(:green, "Problem: ", name, "\n")
+            # Look for name in the first elements of the iteration_exceptions tuples
+            iter_id = find(n[1] == name for n in iteration_exceptions)
+            # If name wasn't found, use default 1000 iterations, else use provided number
+            iters = length(iter_id) == 0 ? 1000 : iteration_exceptions[iter_id[1]][2]
+            # Construct options
+            options = Optim.Options(allow_f_increases = name in f_increase_exceptions, iterations = iters, show_trace = show_trace)
+
+            # Use finite difference if it is not differentiable enough
+            if  !(name in skip)
+                for (i, input) in enumerate(fd_input_tuple(method, prob))
+                    if (!prob.isdifferentiable && i > 1) || (!prob.istwicedifferentiable && i > 2)
+                        continue
+                    end
+
+                    # Loop over appropriate input combinations of f, g!, and h!
+                    results = Optim.optimize(input..., prob.initial_x, method, options)
+                    @time Optim.optimize(input..., prob.initial_x, method, options)
+                    @test isa(summary(results), String)
+                    show_res && println(results)
+                    if !((name, i) in convergence_exceptions)
+                        @test Optim.converged(results)
+                    end
+                    if !((name, i) in minimum_exceptions)
+                        @test Optim.minimum(results) < prob.minimum + sqrt(eps(typeof(prob.minimum)))
+                    end
+                    if !((name, i) in minimizer_exceptions)
+                        @test norm(Optim.minimizer(results) - prob.solutions) < 1e-2
+                    end
+                end
+            else
+                debug_printing && print_with_color(:blue, "Skipping $name\n")
+            end
+        end
+    end
+
+    skip = ("Trigonometric",)
+    run_optim_fd_tests(LBFGS(), skip = skip,
+                       show_name=true, show_res=true)
+end

--- a/test/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/test/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -28,6 +28,7 @@
                              options)
     @test norm(Optim.minimizer(res) - [1.0, 1.0]) < 0.1
 
+    # TODO: Is there a way to suppress the trace results?
     options = Optim.Options(iterations=300, show_trace=true, extended_trace=true, store_trace=true)
     res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles), options)
     @test summary(res) == "Particle Swarm"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ multivariate_tests = [
     "precon",
     "manifolds",
     "complex",
+    "fdtime",
 ]
 multivariate_tests = map(s->"./multivariate/"*s*".jl", multivariate_tests)
 


### PR DESCRIPTION
This tries to use the DiffeqDiffTools finite difference derivatives rather than Calculus.

I made a comparison between the running times using Calculus and this PR, available here:
https://gist.github.com/anriseth/ccc51401525b923fbdc8147b2c8ed36f 
**Summary**: 
- DiffEqDiffTools is much faster at approximating the Hessian if it has access to the gradient
- DiffEqDiffTools is much worse if we approximate the Hessian using the Jacobian of a finite-difference gradient (People should not do this anyway?)
- DiffEqDiffTools is slightly slower at approximating gradients than Calculus. *Could be because the problems tested are too cheap, so the cache allocation is more costly?*

**Preliminary conclusion:**
If this enables FD gradients for complex number optimization, then the little extra cost in gradient evaluation is worth it. We need to think about how to deal with Hessian when only `f` is supplied, however.

**TODOs**:
- [x] Test gradients for complex number optimization
- [x] Update docs on complex number optimization and say we support finite difference gradients.
- [x] Update REQUIRE version DiffEqDiffTools
- [x] Create an issue reminding us to update to DiffEqDiffTools Hessians when https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/issues/13 is closed.
- [x] ~Add a `warn_once` for Newton that it may be faster to use LBFGS instead of Finite Differences? (Alternatively, mention it in the docs)~
- [x] ~Remove all Calculus remnants~
- [x] ~Add `GradientCache` and `JacobianCache` as parameter inputs for OnceDifferentiable?~

Closes #476 (almost)
