### PR TITLE
RFC: more generic convergence assessment

### DIFF
--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -16,7 +16,7 @@ after_while!(d, state, method, options) = nothing
 initial_convergence(d, state, method, initial_x, options) = false 
 initial_convergence(d, state, method::ZerothOrderOptimizer, initial_x, options) = false
  
-function initial_convergence(d, state, method::FirstOrderOptimizer, initial_x, options) 
+function initial_convergence(d, state, method::AbstractOptimizer, initial_x, options) 
     gradient!(d, initial_x)
     vecnorm(gradient(d), Inf) < options.g_tol
 end 

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -13,13 +13,11 @@ update_h!(d, state, method::SecondOrderOptimizer) = hessian!(d, state.x)
 
 after_while!(d, state, method, options) = nothing
 
-initial_convergence(d, state, method, initial_x, options) = false 
-initial_convergence(d, state, method::ZerothOrderOptimizer, initial_x, options) = false
- 
 function initial_convergence(d, state, method::AbstractOptimizer, initial_x, options) 
     gradient!(d, initial_x)
     vecnorm(gradient(d), Inf) < options.g_tol
 end 
+initial_convergence(d, state, method::ZerothOrderOptimizer, initial_x, options) = false
 
 function optimize(d::D, initial_x::AbstractArray{Tx, N}, method::M,
                   options::Options = Options(;default_options(method)...),

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -281,6 +281,10 @@ function assess_convergence(state::NelderMeadState, d, options)
     return false, false, g_converged, g_converged, false
 end
 
+function initial_convergence(d, state::NelderMeadState, method::NelderMead, initial_x, options)
+    nmobjective(state.f_simplex, state.m, length(initial_x)) < options.g_tol
+end 
+
 function trace!(tr, d, state, iteration, method::NelderMead, options)
     dt = Dict()
     if options.extended_trace

--- a/src/utilities/assess_convergence.jl
+++ b/src/utilities/assess_convergence.jl
@@ -63,11 +63,13 @@ function default_convergence_assessment(state::AbstractOptimizerState, d, option
         f_increased = true
     end
 
-    if g_residual(gradient(d)) ≤ options.g_tol
-        g_converged = true
-    end
-
+    g_converged = gradient_convergence_assessment(state,d,options)
+    
     converged = x_converged || f_converged || g_converged
 
     return x_converged, f_converged, g_converged, converged, f_increased
 end
+
+gradient_convergence_assessment(state::AbstractOptimizerState, d, options) = g_residual(gradient(d)) ≤ options.g_tol
+gradient_convergence_assessment(state::ZerothOrderState, d, options) = false
+


### PR DESCRIPTION
I've tried to implement some of the changes discussed in #309, which allows my two minimal examples of [ZerothOrderOptimizer](https://gist.github.com/jonathanBieler/47d9ae7e95e7ca0f7352de8f84827ae3) and [FirstOrderOptimizer](https://gist.github.com/jonathanBieler/ed2ae8868e7b317c9e6d2db86f6ed2b9) defined outside of Optim to run.