### PR TITLE
samin changes: defaults, verbosity, and documentation

### DIFF
--- a/docs/src/algo/samin.md
+++ b/docs/src/algo/samin.md
@@ -25,23 +25,23 @@ julia> using Optim, OptimTestProblems
 
 julia> prob = OptimTestProblems.UnconstrainedProblems.examples["Rosenbrock"];
 
-julia> res = Optim.optimize(prob.f, prob.initial_x, fill(-100.0, 2), fill(100.0, 2), SAMIN(), Optim.Options(iterations=20000))
-Results of Optimization Algorithm
+julia> res = Optim.optimize(prob.f, prob.initial_x, fill(-100.0, 2), fill(100.0, 2), SAMIN(rt=0.9), Optim.Options(iterations=20000))
+Results of Optimization AlgorithmResults of Optimization Algorithm
  * Algorithm: SAMIN
  * Starting Point: [-1.2,1.0]
- * Minimizer: [1.0170012560033472,1.0343750729202243]
- * Minimum: 2.897402e-04
- * Iterations: 5901
+ * Minimizer: [1.0000002252116529,1.0000004516135839]
+ * Minimum: 5.086195e-14
+ * Iterations: 19851
  * Convergence: false
-   * |x - x'| ≤ 0.0e+00: false
-     |x - x'| = NaN
+   * |x - x'| ≤ 0.0e+00: false 
+     |x - x'| = NaN 
    * |f(x) - f(x')| ≤ 0.0e+00 |f(x)|: false
      |f(x) - f(x')| = NaN |f(x)|
-   * |g(x)| ≤ 0.0e+00: false
-     |g(x)| = NaN
+   * |g(x)| ≤ 0.0e+00: false 
+     |g(x)| = NaN 
    * Stopped by an increasing objective: false
    * Reached Maximum Number of Iterations: false
- * Objective Calls: 5901
+ * Objective Calls: 19851
  * Gradient Calls: 0
 ```
 

--- a/docs/src/algo/samin.md
+++ b/docs/src/algo/samin.md
@@ -21,13 +21,13 @@ multiple times to verify that the same solution is found each time. If this is n
 increase rt. When in doubt, start with a conservative rt, for example, rt=0.95, and allow for
 a generous iteration limit. The algorithm requires lower and upper bounds on the parameters,
 although these bounds are often set rather wide, and are not necessarily meant to reflect
-constraints in the model,but rather bounds that enclose the parameter space. If the final
+constraints in the model, but rather bounds that enclose the parameter space. If the final
 `x`s are very close to the boundary (which can be checked by setting verbosity=1), it is a
 good idea to restart the optimizer with wider bounds, unless the bounds actually reflect
 hard constraints on `x`.
 
 ## Example
-This is example shows a successful minimization:
+This example shows a successful minimization:
 ```julia
 julia> using Optim, OptimTestProblems
 
@@ -65,7 +65,7 @@ Results of Optimization Algorithm
  * Gradient Calls: 0
 ```
 ## Example
-This is example shows an unsuccessful minimization, because the cooling rate,
+This example shows an unsuccessful minimization, because the cooling rate,
 rt=0.5, is too rapid:
 ```julia
 julia> using Optim, OptimTestProblems

--- a/docs/src/algo/samin.md
+++ b/docs/src/algo/samin.md
@@ -3,35 +3,55 @@
 ```julia
 SAMIN(; nt::Int = 5     # reduce temperature every nt*ns*dim(x_init) evaluations
         ns::Int = 5     # adjust bounds every ns*dim(x_init) evaluations
-        rt::T = 0.5     # geometric temperature reduction factor: when temp changes, new temp is t=rt*t
+        rt::T = 0.9     # geometric temperature reduction factor: when temp changes, new temp is t=rt*t
         neps::Int = 5   # number of previous best values the final result is compared to
-        f_tol::T = 1e-8 # the required tolerance level for function value comparisons
-        x_tol::T = 1e-5 # the required tolerance level for x
-        coverage_ok::Bool = false, # increase temperature until parameter space is covered
+        f_tol::T = 1e-12 # the required tolerance level for function value comparisons
+        x_tol::T = 1e-6 # the required tolerance level for x
+        coverage_ok::Bool = false, # if false, increase temperature until initial parameter space is covered
         verbosity::Int = 0) # scalar: 0, 1, 2 or 3 (default = 0).
 ```
 ## Description
 The `SAMIN` method implements the Simulated Annealing algorithm for problems with
-bounds constrains a described in Goffe et. al. (1994) and Goffe (1996). The
-algorithm requires bounds, although these bounds are often set rather wide, and
-are not necessarily meant to reflect constraints in the model, but rather bounds
-that are there to improve the search. If the final `x`s are very close to the boundary,
-it is a good idea to restart the optimizer with wider bounds, unless the bounds
-actually reflect hard constraints on `x`.
+bounds constraints as described in Goffe et. al. (1994) and Goffe (1996). A key control
+parameter is rt, the geometric temperature reduction rate, which should be between zero
+and one. Setting rt lower will cause the algorithm to contract the search space more quickly,
+reducing the run time. Setting rt too low will cause the algorithm to narrow the search
+too quickly, and the true minimizer may be skipped over. If possible, run the algorithm
+multiple times to verify that the same solution is found each time. If this is not the case,
+increase rt. When in doubt, start with a conservative rt, for example, rt=0.95, and allow for
+a generous iteration limit. The algorithm requires lower and upper bounds on the parameters,
+although these bounds are often set rather wide, and are not necessarily meant to reflect
+constraints in the model,but rather bounds that enclose the parameter space. If the final
+`x`s are very close to the boundary (which can be checked by setting verbosity=1), it is a
+good idea to restart the optimizer with wider bounds, unless the bounds actually reflect
+hard constraints on `x`.
 
 ## Example
+This is example shows a successful minimization:
 ```julia
 julia> using Optim, OptimTestProblems
 
 julia> prob = OptimTestProblems.UnconstrainedProblems.examples["Rosenbrock"];
 
-julia> res = Optim.optimize(prob.f, prob.initial_x, fill(-100.0, 2), fill(100.0, 2), SAMIN(rt=0.9), Optim.Options(iterations=20000))
-Results of Optimization AlgorithmResults of Optimization Algorithm
+julia> res = Optim.optimize(prob.f, prob.initial_x, fill(-100.0, 2), fill(100.0, 2), SAMIN(), Optim.Options(iterations=10^6))
+================================================================================
+SAMIN results
+==> Normal convergence <==
+total number of objective function evaluations: 23701
+
+     Obj. value:      0.0000000000
+
+       parameter      search width
+         1.00000           0.00000 
+         1.00000           0.00000 
+================================================================================
+
+Results of Optimization Algorithm
  * Algorithm: SAMIN
  * Starting Point: [-1.2,1.0]
- * Minimizer: [1.0000002252116529,1.0000004516135839]
- * Minimum: 5.086195e-14
- * Iterations: 19851
+ * Minimizer: [0.9999999893140956,0.9999999765350857]
+ * Minimum: 5.522977e-16
+ * Iterations: 23701
  * Convergence: false
    * |x - x'| ≤ 0.0e+00: false 
      |x - x'| = NaN 
@@ -41,8 +61,47 @@ Results of Optimization AlgorithmResults of Optimization Algorithm
      |g(x)| = NaN 
    * Stopped by an increasing objective: false
    * Reached Maximum Number of Iterations: false
- * Objective Calls: 19851
+ * Objective Calls: 23701
  * Gradient Calls: 0
+```
+## Example
+This is example shows an unsuccessful minimization, because the cooling rate,
+rt=0.5, is too rapid:
+```julia
+julia> using Optim, OptimTestProblems
+
+julia> prob = OptimTestProblems.UnconstrainedProblems.examples["Rosenbrock"];
+julia> res = Optim.optimize(prob.f, prob.initial_x, fill(-100.0, 2), fill(100.0, 2), SAMIN(rt=0.5), Optim.Options(iterations=10^6))
+================================================================================
+SAMIN results
+==> Normal convergence <==
+total number of objective function evaluations: 12051
+
+     Obj. value:      0.0011613045
+
+       parameter      search width
+         0.96592           0.00000 
+         0.93301           0.00000 
+================================================================================
+
+Results of Optimization Algorithm
+ * Algorithm: SAMIN
+ * Starting Point: [-1.2,1.0]
+ * Minimizer: [0.9659220825756248,0.9330054696322896]
+ * Minimum: 1.161304e-03
+ * Iterations: 12051
+ * Convergence: false
+   * |x - x'| ≤ 0.0e+00: false 
+     |x - x'| = NaN 
+   * |f(x) - f(x')| ≤ 0.0e+00 |f(x)|: false
+     |f(x) - f(x')| = NaN |f(x)|
+   * |g(x)| ≤ 0.0e+00: false 
+     |g(x)| = NaN 
+   * Stopped by an increasing objective: false
+   * Reached Maximum Number of Iterations: false
+ * Objective Calls: 12051
+ * Gradient Calls: 0
+
 ```
 
 ## References

--- a/src/multivariate/solvers/constrained/samin.jl
+++ b/src/multivariate/solvers/constrained/samin.jl
@@ -76,7 +76,7 @@ function optimize(obj_fn, x::AbstractArray, lb::AbstractArray, ub::AbstractArray
     xopt = copy(x)
     f_old = value(d, x)
     fopt = copy(f_old) # give it something to compare to
-    details = [f_calls(d) t fopt]
+    details = [f_calls(d) t fopt xopt']
     bounds = ub - lb
     # check for out-of-bounds starting values
     for i = 1:n
@@ -123,7 +123,7 @@ function optimize(obj_fn, x::AbstractArray, lb::AbstractArray, ub::AbstractArray
                                 xopt = copy(xp)
                                 fopt = copy(fp)
                                 nnew +=1
-                                details = [details; [f_calls(d) t fp]]
+                                details = [details; [f_calls(d) t fp xp']]
                             end
                         # If the point is higher, use the Metropolis criteria to decide on
                         # acceptance or rejection.

--- a/test/multivariate/solvers/constrained/samin.jl
+++ b/test/multivariate/solvers/constrained/samin.jl
@@ -4,5 +4,5 @@
     xtrue = prob.solutions
     f = OptimTestProblems.MultivariateProblems.objective(prob)
     x0 = prob.initial_x
-    optimize(f, x0, x0.-100., x0.+100.0, Optim.SAMIN())
+    optimize(f, x0, x0.-100., x0.+100.0, Optim.SAMIN(), Optim.Options(iterations=1000000))
 end


### PR DESCRIPTION
This increases the default temperature reduction rate from 0.5 to 0.9, which is more conservative, and which will be more likely to give the correct solution, at the cost of more iterations. The default tolerances are made more strict. The final results are displayed by default. The documentation has been extended with a bit of advice, and with examples of both successful and unsuccessful runs.