### PR TITLE
Inplace and autodiff keywords and ForwardDiff HessianConfig bug fix

### DIFF
--- a/docs/src/algo/autodiff.md
+++ b/docs/src/algo/autodiff.md
@@ -22,16 +22,16 @@ function f(x)
     return (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
 end
 
-function g!(storage, x)
-    storage[1] = -2.0 * (1.0 - x[1]) - 400.0 * (x[2] - x[1]^2) * x[1]
-    storage[2] = 200.0 * (x[2] - x[1]^2)
+function g!(G, x)
+    G[1] = -2.0 * (1.0 - x[1]) - 400.0 * (x[2] - x[1]^2) * x[1]
+    G[2] = 200.0 * (x[2] - x[1]^2)
 end
 
-function h!(storage, x)
-    storage[1, 1] = 2.0 - 400.0 * x[2] + 1200.0 * x[1]^2
-    storage[1, 2] = -400.0 * x[1]
-    storage[2, 1] = -400.0 * x[1]
-    storage[2, 2] = 200.0
+function h!(H, x)
+    H[1, 1] = 2.0 - 400.0 * x[2] + 1200.0 * x[1]^2
+    H[1, 2] = -400.0 * x[1]
+    H[2, 1] = -400.0 * x[1]
+    H[2, 2] = 200.0
 end
 
 initial_x = zeros(2)
@@ -59,19 +59,14 @@ julia> Optim.minimizer(optimize(f, initial_x, BFGS()))
 ```
 Still looks good. Returning to automatic differentiation, let us try both solvers using this
 method.  We enable [forward mode](https://github.com/JuliaDiff/ForwardDiff.jl) automatic
-differentiation by adding `autodiff = :forward` when we construct a `OnceDifferentiable`
-instance.
+differentiation by using the `autodiff = :forward` keyword.
 ```jlcon
-julia> od = OnceDifferentiable(f, initial_x; autodiff = :forward);
-
-julia> Optim.minimizer(optimize(od, initial_x, BFGS()))
+julia> Optim.minimizer(optimize(f, initial_x, BFGS(); autodiff = :forward))
 2-element Array{Float64,1}:
  1.0
  1.0
 
-julia> td = TwiceDifferentiable(f, initial_x; autodiff = :forward)
-
-julia> Optim.minimizer(optimize(td, initial_x, Newton()))
+julia> Optim.minimizer(optimize(f, initial_x, Newton(); autodiff = :forward))
 2-element Array{Float64,1}:
  1.0
  1.0

--- a/docs/src/algo/precondition.md
+++ b/docs/src/algo/precondition.md
@@ -40,8 +40,8 @@ initial_x = zeros(100)
 plap(U; n = length(U)) = (n-1)*sum((0.1 + diff(U).^2).^2 ) - sum(U) / (n-1)
 plap1(x) = ForwardDiff.gradient(plap,x)
 precond(n) = spdiagm((-ones(n-1), 2*ones(n), -ones(n-1)), (-1,0,1), n, n)*(n+1)
-df = OnceDifferentiable(x -> plap([0; x; 0]),
-                            (g, x) -> copy!(g, (plap1([0; x; 0]))[2:end-1]))
+f(x) = plap([0; x; 0])
+g!(G, x) = copy!(G, (plap1([0; x; 0]))[2:end-1])
 result = Optim.optimize(df, initial_x, method = ConjugateGradient(P = nothing))
 result = Optim.optimize(df, initial_x, method = ConjugateGradient(P = precond(100)))
 ```

--- a/src/multivariate/optimize/interface.jl
+++ b/src/multivariate/optimize/interface.jl
@@ -34,56 +34,110 @@ fallback_method(d::OnceDifferentiable) = LBFGS()
 fallback_method(d::TwiceDifferentiable) = Newton()
 
 # promote the objective (tuple of callables or an AbstractObjective) according to method requirement
-promote_objtype(method, initial_x, obj_args...) = error("No default objective type for $method and $obj_args.")
+promote_objtype(method, initial_x, autodiff::Symbol, args...) = error("No default objective type for $method and $args.")
 # actual promotions, notice that (args...) captures FirstOrderOptimizer and NonDifferentiable, etc
-promote_objtype(method::ZerothOrderOptimizer, x, args...) = NonDifferentiable(args..., x, real(zero(eltype(x))))
-promote_objtype(method::FirstOrderOptimizer,  x, args...) = OnceDifferentiable(args..., x, real(zero(eltype(x))))
-promote_objtype(method::FirstOrderOptimizer,  x, f, g!, h!) = OnceDifferentiable(f, g!, x, real(zero(eltype(x))))
-promote_objtype(method::SecondOrderOptimizer, x, args...) = TwiceDifferentiable(args..., x, real(zero(eltype(x))))
+promote_objtype(method::ZerothOrderOptimizer, x, autodiff::Symbol, args...) = NonDifferentiable(args..., x, real(zero(eltype(x))))
+promote_objtype(method::FirstOrderOptimizer,  x, autodiff::Symbol, f) = OnceDifferentiable(f, x, real(zero(eltype(x))); autodiff = autodiff)
+promote_objtype(method::FirstOrderOptimizer,  x, autodiff::Symbol, args...) = OnceDifferentiable(args..., x, real(zero(eltype(x))))
+promote_objtype(method::FirstOrderOptimizer,  x, autodiff::Symbol, f, g!, h!) = OnceDifferentiable(f, g!, x, real(zero(eltype(x))))
+promote_objtype(method::SecondOrderOptimizer, x, autodiff::Symbol, f) = TwiceDifferentiable(f, x, real(zero(eltype(x))); autodiff = autodiff)
+promote_objtype(method::SecondOrderOptimizer, x, autodiff::Symbol, f, g) = TwiceDifferentiable(f, g, x, real(zero(eltype(x))); autodiff = autodiff)
+promote_objtype(method::SecondOrderOptimizer, x, autodiff::Symbol, f, g, h) = TwiceDifferentiable(f, g, h, x, real(zero(eltype(x))))
 # no-op
-promote_objtype(method::ZerothOrderOptimizer, x, nd::NonDifferentiable)  = nd
-promote_objtype(method::ZerothOrderOptimizer, x, od::OnceDifferentiable) = od
-promote_objtype(method::FirstOrderOptimizer,  x, od::OnceDifferentiable) = od
-promote_objtype(method::ZerothOrderOptimizer, x, td::TwiceDifferentiable) = td
-promote_objtype(method::FirstOrderOptimizer,  x, td::TwiceDifferentiable) = td
-promote_objtype(method::SecondOrderOptimizer, x, td::TwiceDifferentiable) = td
+promote_objtype(method::ZerothOrderOptimizer, x, autodiff::Symbol, nd::NonDifferentiable)  = nd
+promote_objtype(method::ZerothOrderOptimizer, x, autodiff::Symbol, od::OnceDifferentiable) = od
+promote_objtype(method::FirstOrderOptimizer,  x, autodiff::Symbol, od::OnceDifferentiable) = od
+promote_objtype(method::ZerothOrderOptimizer, x, autodiff::Symbol, td::TwiceDifferentiable) = td
+promote_objtype(method::FirstOrderOptimizer,  x, autodiff::Symbol, td::TwiceDifferentiable) = td
+promote_objtype(method::SecondOrderOptimizer, x, autodiff::Symbol, td::TwiceDifferentiable) = td
 
 # if on method or options are present
-optimize(f,         initial_x::AbstractArray; kwargs...) = optimize((f,),        initial_x; kwargs...)
-optimize(f, g!,     initial_x::AbstractArray; kwargs...) = optimize((f, g!),     initial_x; kwargs...)
-optimize(f, g!, h!, initial_x::AbstractArray; kwargs...) = optimize((f, g!, h!), initial_x; kwargs...)
-function optimize(f::Tuple, initial_x::AbstractArray; kwargs...)
-    method = fallback_method(f...)
-    d = promote_objtype(method, initial_x, f...)
+function optimize(f,         initial_x::AbstractArray; inplace = true, autodiff = :finite, kwargs...)
+    method = fallback_method(f)
     checked_kwargs, method = check_kwargs(kwargs, method)
+    d = promote_objtype(method, initial_x, autodiff, f)
+    add_default_opts!(checked_kwargs, method)
+
+    options = Options(; checked_kwargs...)
+    optimize(d, initial_x, method, options)
+end
+function optimize(f, g, initial_x::AbstractArray; inplace = true, autodiff = :finite, kwargs...)
+    g! = inplace ? g : (G, x) -> copy!(G, g(x))
+
+    method = fallback_method(f)
+    checked_kwargs, method = check_kwargs(kwargs, method)
+    d = promote_objtype(method, initial_x, autodiff, f, g!)
+    add_default_opts!(checked_kwargs, method)
+
+    options = Options(; checked_kwargs...)
+    optimize(d, initial_x, method, options)
+end
+function optimize(f, g, h, initial_x::AbstractArray; inplace = true, autodiff = :finite, kwargs...)
+    g! = inplace ? g : (G, x) -> copy!(G, g(x))
+    h! = inplace ? h : (H, x) -> copy!(H, h(x))
+
+    method = fallback_method(f, g!, h!)
+    checked_kwargs, method = check_kwargs(kwargs, method)
+    d = promote_objtype(method, initial_x, autodiff, f, g!, h!)
     add_default_opts!(checked_kwargs, method)
 
     options = Options(; checked_kwargs...)
     optimize(d, initial_x, method, options)
 end
 
-# no method supplied
-optimize(d::T,      initial_x::AbstractArray, options::Options) where T<:AbstractObjective = optimize((d,), initial_x, fallback_method(T), options)
-optimize(f,         initial_x::AbstractArray, options::Options) = optimize((f,),        initial_x, fallback_method(f), options)
-optimize(f, g!,     initial_x::AbstractArray, options::Options) = optimize((f, g!),     initial_x, fallback_method(f), options)
-optimize(f, g!, h!, initial_x::AbstractArray, options::Options) = optimize((f, g!, h!), initial_x, fallback_method(f), options)
+# no method supplied with objective
+function optimize(d::T, initial_x::AbstractArray, options::Options) where T<:AbstractObjective
+    optimize(d, initial_x, fallback_method(T), options)
+end
+# no method supplied with inplace and autodiff keywords becauase objective is not supplied
+function optimize(f, initial_x::AbstractArray, options::Options; inplace = true, autodiff = :finite)
+    method = fallback_method(f)
+    d = promote_objtype(method, initial_x, autodiff, f)
+    optimize(d, initial_x, method, options)
+end
+function optimize(f, g, initial_x::AbstractArray, options::Options; inplace = true, autodiff = :finite)
+    g! = inplace ? g : (G, x) -> copy!(G, g(x))
+    method = fallback_method(f, g!)
+    d = promote_objtype(method, initial_x, autodiff, f, g!)
+    optimize(d, initial_x, method, options)
+end
+function optimize(f, g, h, initial_x::AbstractArray, options::Options; inplace = true, autodiff = :finite)
+
+    g! = inplace ? g : (G, x) -> copy!(G, g(x))
+    h! = inplace ? h : (H, x) -> copy!(H, h(x))
+    method = fallback_method(f, g!, h!)
+    d = promote_objtype(method, initial_x, method, autodiff, f, g!, h!)
+
+    optimize(d, initial_x, method, options)
+end
 
 # potentially everything is supplied (besides caches)
-optimize(f,         initial_x::AbstractArray, method::AbstractOptimizer,
-         options::Options = Options(;default_options(method)...)) = optimize((f,),        initial_x, method, options)
-optimize(f, g!,     initial_x::AbstractArray, method::AbstractOptimizer,
-         options::Options = Options(;default_options(method)...)) = optimize((f, g!),     initial_x, method, options)
-optimize(f, g!, h!, initial_x::AbstractArray, method::AbstractOptimizer,
-         options::Options = Options(;default_options(method)...)) = optimize((f, g!, h!), initial_x, method, options)
-function optimize(f::Tuple, initial_x::AbstractArray, method::AbstractOptimizer,
-                  options::Options = Options(;default_options(method)...))
-    d = promote_objtype(method, initial_x, f...)
+function optimize(f, initial_x::AbstractArray, method::AbstractOptimizer,
+                     options::Options = Options(;default_options(method)...); inplace = true, autodiff = :finite)
+
+    d = promote_objtype(method, initial_x, autodiff, f)
+    optimize(d, initial_x, method, options)
+end
+function optimize(f, g, initial_x::AbstractArray, method::AbstractOptimizer,
+         options::Options = Options(;default_options(method)...); inplace = true, autodiff = :finite)
+
+    g! = inplace ? g : (G, x) -> copy!(G, g(x))
+    d = promote_objtype(method, initial_x, autodiff, f, g!)
+
+    optimize(d, initial_x, method, options)
+end
+function optimize(f, g, h, initial_x::AbstractArray, method::AbstractOptimizer,
+         options::Options = Options(;default_options(method)...); inplace = true, autodiff = :finite)
+
+    g! = inplace ? g : (G, x) -> copy!(G, g(x))
+    h! = inplace ? h : (H, x) -> copy!(H, h(x))
+    d = promote_objtype(method, initial_x, autodiff, f, g!, h!)
 
     optimize(d, initial_x, method, options)
 end
 
 function optimize(d::D, initial_x::AbstractArray, method::SecondOrderOptimizer,
-                  options::Options = Options(;default_options(method)...)) where {D <: Union{NonDifferentiable, OnceDifferentiable}}
-    d = promote_objtype(method, initial_x, d)
+                  options::Options = Options(;default_options(method)...); autodiff = :finite) where {D <: Union{NonDifferentiable, OnceDifferentiable}}
+    d = promote_objtype(method, initial_x, autodiff, d)
     optimize(d, initial_x, method, options)
 end

--- a/src/objective_types.jl
+++ b/src/objective_types.jl
@@ -43,7 +43,7 @@ function TwiceDifferentiable(f, g!, x_seed::AbstractVector{T}, F::Real = real(ze
             return
         end
     elseif autodiff == :forward
-        hcfg = ForwardDiff.HessianConfig(similar(x_seed))
+        hcfg = ForwardDiff.HessianConfig(f, similar(x_seed))
         h! = (out, x) -> ForwardDiff.hessian!(out, f, x, hcfg)
     else
         error("The autodiff value $(autodiff) is not supported. Use :finite or :forward.")


### PR DESCRIPTION
```
julia> using Optim, OptimTestProblems

julia> prob = OptimTestProblems.UnconstrainedProblems.examples["Rosenbrock"];

julia> optimize(prob.f, prob.g!,rand(2), Newton(); autodiff=:forward)
Results of Optimization Algorithm
 * Algorithm: Newton's Method
 * Starting Point: [0.9123284150752757,0.36455247528077095]
 * Minimizer: [1.0,1.0]
 * Minimum: 0.000000e+00
 * Iterations: 7
 * Convergence: true
   * |x - x'| ≤ 1.0e-32: false 
     |x - x'| = 1.33e-09 
   * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
     |f(x) - f(x')| = Inf |f(x)|
   * |g(x)| ≤ 1.0e-08: true 
     |g(x)| = 0.00e+00 
   * Stopped by an increasing objective: false
   * Reached Maximum Number of Iterations: false
 * Objective Calls: 17
 * Gradient Calls: 17
 * Hessian Calls: 7

julia> optimize(prob.f, prob.g!,rand(2), Newton(); autodiff=:finite)
Results of Optimization Algorithm
 * Algorithm: Newton's Method
 * Starting Point: [0.4580052231421885,0.6180492074542714]
 * Minimizer: [0.9999999999999873,0.9999999999999761]
 * Minimum: 3.684967e-28
 * Iterations: 11
 * Convergence: true
   * |x - x'| ≤ 1.0e-32: false 
     |x - x'| = 1.18e-07 
   * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
     |f(x) - f(x')| = 1.64e+13 |f(x)|
   * |g(x)| ≤ 1.0e-08: true 
     |g(x)| = 6.03e-13 
   * Stopped by an increasing objective: false
   * Reached Maximum Number of Iterations: false
 * Objective Calls: 36
 * Gradient Calls: 36
 * Hessian Calls: 11
```


```
julia> using Optim, OptimTestProblems

julia> prob = OptimTestProblems.UnconstrainedProblems.examples["Rosenbrock"];

julia> f = prob.f
rosenbrock (generic function with 1 method)

julia> function g(x)
           G = similar(x)
           prob.g!(G, x)
           G
       end
g (generic function with 1 method)

julia> optimize(f, g, rand(2), BFGS())
ERROR: MethodError: no method matching g(::Array{Float64,1}, ::Array{Float64,1})
Closest candidates are:
  g(::Any) at REPL[4]:2
Stacktrace:
 [1] (::NLSolversBase.#fg!#3{OptimTestProblems.MultivariateProblems.UnconstrainedProblems.#rosenbrock,#g})(::Array{Float64,1}, ::Array{Float64,1}) at /home/pkm/.julia/v0.6/NLSolversBase/src/objective_types/abstract.jl:15
 [2] value_gradient!!(::NLSolversBase.OnceDifferentiable{Float64,Array{Float64,1},Array{Float64,1},Val{false}}, ::Array{Float64,1}) at /home/pkm/.julia/v0.6/NLSolversBase/src/interface.jl:86
 [3] initial_state(::Optim.BFGS{LineSearches.InitialStatic{Float64},LineSearches.HagerZhang{Float64},Optim.##67#69}, ::Optim.Options{Float64,Void}, ::NLSolversBase.OnceDifferentiable{Float64,Array{Float64,1},Array{Float64,1},Val{false}}, ::Array{Float64,1}) at /home/pkm/.julia/v0.6/Optim/src/multivariate/solvers/first_order/bfgs.jl:64
 [4] #optimize#167(::Bool, ::Symbol, ::Function, ::Function, ::#g, ::Array{Float64,1}, ::Optim.BFGS{LineSearches.InitialStatic{Float64},LineSearches.HagerZhang{Float64},Optim.##67#69}, ::Optim.Options{Float64,Void}) at /home/pkm/.julia/v0.6/Optim/src/multivariate/optimize/interface.jl:127
 [5] optimize(::Function, ::Function, ::Array{Float64,1}, ::Optim.BFGS{LineSearches.InitialStatic{Float64},LineSearches.HagerZhang{Float64},Optim.##67#69}) at /home/pkm/.julia/v0.6/Optim/src/multivariate/optimize/interface.jl:124

julia> optimize(f, g, rand(2), BFGS(); inplace = false)
Results of Optimization Algorithm
 * Algorithm: BFGS
 * Starting Point: [0.7760450782452455,0.8989758022215468]
 * Minimizer: [1.0000000000000584,1.0000000000001137]
 * Minimum: 4.376650e-27
 * Iterations: 11
 * Convergence: true
   * |x - x'| ≤ 1.0e-32: false 
     |x - x'| = 4.68e-09 
   * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
     |f(x) - f(x')| = 5.20e+09 |f(x)|
   * |g(x)| ≤ 1.0e-08: true 
     |g(x)| = 1.36e-12 
   * Stopped by an increasing objective: false
   * Reached Maximum Number of Iterations: false
 * Objective Calls: 30
 * Gradient Calls: 30

julia> optimize(f, prob.g!, rand(2), BFGS(); inplace = true)
Results of Optimization Algorithm
 * Algorithm: BFGS
 * Starting Point: [0.8571025012583477,0.8105436754557733]
 * Minimizer: [0.9999999999999277,0.9999999999998554]
 * Minimum: 5.223751e-27
 * Iterations: 10
 * Convergence: true
   * |x - x'| ≤ 1.0e-32: false 
     |x - x'| = 3.85e-11 
   * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
     |f(x) - f(x')| = 3.18e+07 |f(x)|
   * |g(x)| ≤ 1.0e-08: true 
     |g(x)| = 1.45e-13 
   * Stopped by an increasing objective: false
   * Reached Maximum Number of Iterations: false
 * Objective Calls: 29
 * Gradient Calls: 29

julia> optimize(f, prob.g!, rand(2), BFGS())
Results of Optimization Algorithm
 * Algorithm: BFGS
 * Starting Point: [0.5098989289812828,0.5423022342250212]
 * Minimizer: [0.9999999999701694,0.9999999999472033]
 * Minimum: 5.602012e-21
 * Iterations: 14
 * Convergence: true
   * |x - x'| ≤ 1.0e-32: false 
     |x - x'| = 6.64e-07 
   * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
     |f(x) - f(x')| = 2.24e+07 |f(x)|
   * |g(x)| ≤ 1.0e-08: true 
     |g(x)| = 2.81e-09 
   * Stopped by an increasing objective: false
   * Reached Maximum Number of Iterations: false
 * Objective Calls: 41
 * Gradient Calls: 41
```