### PR TITLE
Fix ParticleSwarm for Fminbox

### DIFF
--- a/src/multivariate/solvers/constrained/fminbox.jl
+++ b/src/multivariate/solvers/constrained/fminbox.jl
@@ -244,7 +244,7 @@ function optimize(
                 alphaguess = LineSearches.InitialPrevious()
             end
             _optimizer = O(alphaguess = alphaguess, linesearch = linesearch, P = P, precondprep = pcp)
-        elseif O in (NelderMead, SimulatedAnnealing)
+        elseif O in (NelderMead, SimulatedAnnealing, ParticleSwarm)
             _optimizer = O()
         else
             if linesearch == nothing


### PR DESCRIPTION
Fminbox adds linesearch parameters to all solvers that are not explicitly listed. This means that ParticleSwarm and the trust region crash with an error.

@pkofod why is Newton not supported in Fminbox? 
We should also decide how to handle NewtonTrustRegion and KrylovTrustRegion. 
Things to consider:
- Error and say they are not supported 
- Include them in the list together with ParticleSwarm etc. 
- Add a try-catch block around the line that tries to call `optimizer(linesearch=...)` and error with a message saying something along the lines of "$optimizer is not supported with Fminbox. If you think it should be, report it on Github"

