### PR TITLE
Safe guard division in ParticleSwarm

### DIFF
--- a/src/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/src/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -324,7 +324,8 @@ function get_swarm_state(X, score, best_point, previous_state)
     dmin = Base.minimum(d)
     dmax = Base.maximum(d)
 
-    f = (dg - dmin) / (dmax - dmin)
+    f = (dg - dmin) / max(dmax - dmin, sqrt(eps(T)))
+
     mu = zeros(T, 4)
     mu[1] = get_mu_1(f)
     mu[2] = get_mu_2(f)


### PR DESCRIPTION
This is to avoid division by zero if the swarm has all identical members.

Edit: I should maybe clarify something. We might want to add some sort of convergence checks here, but the underlying idea is that *at all times*  the swarm should be allowed to escape a local minimum. I'm no expert here, but it appears to me that if `d` is so small it will become practically impossible to escape, and then we might just terminate anyway.