### PR TITLE
Move updates

### DIFF
--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -1,6 +1,3 @@
-# Update the Hessian
-update_h!(d, state, method) = nothing
-update_h!(d, state, method::SecondOrderOptimizer) = hessian!(d, state.x)
 
 after_while!(d, state, method, options) = nothing
 
@@ -44,7 +41,7 @@ function optimize(d::D, initial_x::Tx, method::M,
         # TODO: Do the same for x_tol?
         counter_f_tol = f_converged ? counter_f_tol+1 : 0
         converged = converged | (counter_f_tol > options.successive_f_tol)
-        
+
         if tracing
             # update trace; callbacks can stop routine early by returning true
             stopped_by_callback = trace!(tr, d, state, iteration, method, options)

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -1,12 +1,3 @@
-update_g!(d, state, method) = nothing
-function update_g!(d, state, method::M) where M<:Union{FirstOrderOptimizer, Newton}
-    # Update the function value and gradient
-    value_gradient!(d, state.x)
-end
-update_fg!(d, state, method) = nothing
-update_fg!(d, state, method::ZerothOrderOptimizer) = value!(d, state.x)
-update_fg!(d, state, method::M) where M<:Union{FirstOrderOptimizer, Newton} = value_gradient!(d, state.x)
-
 # Update the Hessian
 update_h!(d, state, method) = nothing
 update_h!(d, state, method::SecondOrderOptimizer) = hessian!(d, state.x)
@@ -47,16 +38,13 @@ function optimize(d::D, initial_x::Tx, method::M,
         iteration += 1
 
         update_state!(d, state, method) && break # it returns true if it's forced by something in update! to stop (eg dx_dg == 0.0 in BFGS, or linesearch errors)
-        update_g!(d, state, method) # TODO: Should this be `update_fg!`?
         x_converged, f_converged,
         g_converged, converged, f_increased = assess_convergence(state, d, options)
         # For some problems it may be useful to require `f_converged` to be hit multiple times
         # TODO: Do the same for x_tol?
         counter_f_tol = f_converged ? counter_f_tol+1 : 0
         converged = converged | (counter_f_tol > options.successive_f_tol)
-
-        !converged && update_h!(d, state, method) # only relevant if not converged
-
+        
         if tracing
             # update trace; callbacks can stop routine early by returning true
             stopped_by_callback = trace!(tr, d, state, iteration, method, options)

--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -70,6 +70,8 @@ function update_state!(d, state::AcceleratedGradientDescentState, method::Accele
     state.x .= state.y .+ scaling.*(state.y .- state.y_previous)
     retract!(method.manifold, state.x)
 
+    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+
     lssuccess == false # break on linesearch error
 end
 

--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -70,7 +70,7 @@ function update_state!(d, state::AcceleratedGradientDescentState, method::Accele
     state.x .= state.y .+ scaling.*(state.y .- state.y_previous)
     retract!(method.manifold, state.x)
 
-    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+    value_gradient!(d, state.x)
 
     lssuccess == false # break on linesearch error
 end

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -101,13 +101,6 @@ function update_state!(d, state::BFGSState, method::BFGS)
     state.x .= state.x .+ state.dx
     retract!(method.manifold, state.x)
     value_gradient!(d, state.x)
-    update_h!(d, state, method) # only relevant if not converged
-
-    lssuccess == false # break on linesearch error
-end
-
-function update_h!(d, state, method::BFGS)
-    n = length(state.x)
     # Measure the change in the gradient
     state.dg .= gradient(d) .- state.g_previous
 
@@ -128,6 +121,8 @@ function update_h!(d, state, method::BFGS)
             @inbounds state.invH[i, j] += c1 * state.dx[i] * state.dx[j]' - c2 * (state.u[i] * state.dx[j]' + state.u[j]' * state.dx[i])
         end
     end
+
+    lssuccess == false # break on linesearch error
 end
 
 function assess_convergence(state::BFGSState, d, options)

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -100,6 +100,8 @@ function update_state!(d, state::BFGSState, method::BFGS)
     state.dx .= state.alpha.*state.s
     state.x .= state.x .+ state.dx
     retract!(method.manifold, state.x)
+    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+    update_h!(d, state, method) # only relevant if not converged
 
     lssuccess == false # break on linesearch error
 end

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -101,9 +101,17 @@ function update_state!(d, state::BFGSState, method::BFGS)
     state.x .= state.x .+ state.dx
     retract!(method.manifold, state.x)
     value_gradient!(d, state.x)
+
+    bfgs_update!(d, state)
+
+    lssuccess == false # break on linesearch error
+end
+
+function bfgs_update!(d, state)
+    # Update the inverse Hessian approximation using Sherman-Morrison
+    n = length(state.x)
     # Measure the change in the gradient
     state.dg .= gradient(d) .- state.g_previous
-
     # Update the inverse Hessian approximation using Sherman-Morrison
     dx_dg = real(vecdot(state.dx, state.dg))
     if dx_dg == 0.0
@@ -121,8 +129,6 @@ function update_state!(d, state::BFGSState, method::BFGS)
             @inbounds state.invH[i, j] += c1 * state.dx[i] * state.dx[j]' - c2 * (state.u[i] * state.dx[j]' + state.u[j]' * state.dx[i])
         end
     end
-
-    lssuccess == false # break on linesearch error
 end
 
 function assess_convergence(state::BFGSState, d, options)

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -100,7 +100,7 @@ function update_state!(d, state::BFGSState, method::BFGS)
     state.dx .= state.alpha.*state.s
     state.x .= state.x .+ state.dx
     retract!(method.manifold, state.x)
-    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+    value_gradient!(d, state.x)
     update_h!(d, state, method) # only relevant if not converged
 
     lssuccess == false # break on linesearch error

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -189,8 +189,6 @@ function update_state!(d, state::ConjugateGradientState, method::ConjugateGradie
         state.s .= beta.*state.s .- state.pg
         project_tangent!(method.manifold, state.s, state.x)
 
-        update_g!(d, state, method) # TODO: Should this be `update_fg!`?
-
         lssuccess == false # break on linesearch error
 end
 

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -142,7 +142,7 @@ function initial_state(method::ConjugateGradient, options, d, initial_x)
                          similar(initial_x), # Preconditioned intermediate value in CG calculation
                          pg, # Maintain the preconditioned gradient in pg
                          -pg, # Maintain current search direction in state.s
-                         @initial_linesearch()...) 
+                         @initial_linesearch()...)
 end
 
 function update_state!(d, state::ConjugateGradientState, method::ConjugateGradient)
@@ -188,6 +188,9 @@ function update_state!(d, state::ConjugateGradientState, method::ConjugateGradie
         beta = max(betak, etak)
         state.s .= beta.*state.s .- state.pg
         project_tangent!(method.manifold, state.s, state.x)
+
+        update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+
         lssuccess == false # break on linesearch error
 end
 

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -76,8 +76,9 @@ function update_state!(d, state::GradientDescentState{T}, method::GradientDescen
     # Update current position # x = x + alpha * s
     @. state.x = state.x + state.alpha * state.s
     retract!(method.manifold, state.x)
-    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
 
+    value_gradient!(d, state.x)
+    
     lssuccess == false # break on linesearch error
 end
 

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -76,6 +76,8 @@ function update_state!(d, state::GradientDescentState{T}, method::GradientDescen
     # Update current position # x = x + alpha * s
     @. state.x = state.x + state.alpha * state.s
     retract!(method.manifold, state.x)
+    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+
     lssuccess == false # break on linesearch error
 end
 

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -202,7 +202,7 @@ function update_state!(d, state::LBFGSState, method::LBFGS)
     state.x .= state.x .+ state.dx
     retract!(method.manifold, state.x)
 
-    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+    value_gradient!(d, state.x)
     update_h!(d, state, method) # only relevant if not converged
 
     lssuccess == false # break on linesearch error

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -204,6 +204,12 @@ function update_state!(d, state::LBFGSState, method::LBFGS)
 
     value_gradient!(d, state.x)
 
+    lbfgs_update!(d, state, method.m)
+
+    lssuccess == false # break on linesearch error
+end
+
+function lbfgs_update!(d, state, m)
     # Measure the change in the gradient
     state.dg .= gradient(d) .- state.g_previous
 
@@ -213,12 +219,10 @@ function update_state!(d, state::LBFGSState, method::LBFGS)
         # TODO: Introduce a formal error? There was a warning here previously
         return true
     end
-    idx = mod1(state.pseudo_iteration, method.m)
+    idx = mod1(state.pseudo_iteration, m)
     @inbounds state.dx_history[idx] .= state.dx
     @inbounds state.dg_history[idx] .= state.dg
     @inbounds state.rho[idx] = rho_iteration
-    
-    lssuccess == false # break on linesearch error
 end
 
 function assess_convergence(state::LBFGSState, d, options)

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -202,6 +202,9 @@ function update_state!(d, state::LBFGSState, method::LBFGS)
     state.x .= state.x .+ state.dx
     retract!(method.manifold, state.x)
 
+    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+    update_h!(d, state, method) # only relevant if not converged
+
     lssuccess == false # break on linesearch error
 end
 

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -203,14 +203,7 @@ function update_state!(d, state::LBFGSState, method::LBFGS)
     retract!(method.manifold, state.x)
 
     value_gradient!(d, state.x)
-    update_h!(d, state, method) # only relevant if not converged
 
-    lssuccess == false # break on linesearch error
-end
-
-
-function update_h!(d, state, method::LBFGS)
-    n = length(state.x)
     # Measure the change in the gradient
     state.dg .= gradient(d) .- state.g_previous
 
@@ -224,6 +217,8 @@ function update_h!(d, state, method::LBFGS)
     @inbounds state.dx_history[idx] .= state.dx
     @inbounds state.dg_history[idx] .= state.dg
     @inbounds state.rho[idx] = rho_iteration
+    
+    lssuccess == false # break on linesearch error
 end
 
 function assess_convergence(state::LBFGSState, d, options)

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -56,6 +56,9 @@ function update_state!(d, state::MomentumGradientDescentState, method::MomentumG
 
     state.x .+= state.alpha.*state.s .+ method.mu.*state.x_momentum
     retract!(method.manifold, state.x)
+
+    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+
     lssuccess == false # break on linesearch error
 end
 

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -57,7 +57,7 @@ function update_state!(d, state::MomentumGradientDescentState, method::MomentumG
     state.x .+= state.alpha.*state.s .+ method.mu.*state.x_momentum
     retract!(method.manifold, state.x)
 
-    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+    value_gradient!(d, state.x)
 
     lssuccess == false # break on linesearch error
 end

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -371,6 +371,8 @@ function update_state!(d, state::NGMRESState{X,T}, method::AbstractNGMRES) where
     copy!(state.x_previous, state.x_previous_0)
     state.f_x_previous = state.f_x_previous_0
 
+    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+
     lssuccess == false # Break on linesearch error
 end
 

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -255,14 +255,14 @@ function initial_state(method::AbstractNGMRES, options, d, initial_x::AbstractAr
                 @initial_linesearch()...)
 end
 
-nlprecon_post_optimize!(d, state, method) = update_h!(d, state.nlpreconstate, method)
+nlprecon_post_optimize!(d, state, method) = hessian!(d, state.nlpreconstate.x)
 
-nlprecon_post_accelerate!(d, state, method) = update_h!(d, state.nlpreconstate, method)
+nlprecon_post_accelerate!(d, state, method) = hessian!(d, state.nlpreconstate.x)
 
 function nlprecon_post_accelerate!(d, state::NGMRESState{X,T},
                                    method::LBFGS)  where X where T
     state.nlpreconstate.pseudo_iteration += 1
-    update_h!(d, state.nlpreconstate, method)
+    hessian!(d, state.nlpreconstate.x)
 end
 
 
@@ -298,7 +298,7 @@ function update_state!(d, state::NGMRESState{X,T}, method::AbstractNGMRES) where
         return false # Exit on gradient norm convergence
     end
 
-    # Deals with update_h! etc for preconditioner, if needed
+    # Deals with hessian! etc for preconditioner, if needed
     nlprecon_post_optimize!(d, state, method.nlprecon)
 
     # Step 2: Do acceleration calculation
@@ -361,7 +361,7 @@ function update_state!(d, state::NGMRESState{X,T}, method::AbstractNGMRES) where
         # TODO: Move these into `nlprecon_post_accelerate!` ?
         state.nlpreconstate.f_x_previous = state.f_x_previous
         state.nlpreconstate.dphi_0_previous = state.dphi_0_previous
-        # Deals with update_h! etc. for preconditioner, if needed
+        # Deals with hessian! etc. for preconditioner, if needed
         nlprecon_post_accelerate!(d, state, method.nlprecon)
     end
     #=

--- a/src/multivariate/solvers/second_order/krylov_trust_region.jl
+++ b/src/multivariate/solvers/second_order/krylov_trust_region.jl
@@ -17,8 +17,6 @@ KrylovTrustRegion(; initial_radius::Real = 1.0,
                     KrylovTrustRegion(initial_radius, max_radius, eta,
                                   rho_lower, rho_upper, cg_tol)
 
-update_h!(d, state, method::KrylovTrustRegion) = nothing
-
 
 # TODO: support x::Array{T,N} et al.?
 mutable struct KrylovTrustRegionState{T} <: AbstractOptimizerState
@@ -161,16 +159,18 @@ function update_state!(objective::TwiceDifferentiableHV,
         state.x .+= state.s
     end
 
-    return false
-end
-
-
-function update_g!(objective, state::KrylovTrustRegionState, method::KrylovTrustRegion)
     if state.accept_step
         # Update the function value and gradient
         state.f_x_previous = value(objective)
         value_gradient!(objective, state.x)
     end
+
+    return false
+end
+
+
+function update_g!(objective, state::KrylovTrustRegionState, method::KrylovTrustRegion)
+
 end
 
 

--- a/src/multivariate/solvers/second_order/krylov_trust_region.jl
+++ b/src/multivariate/solvers/second_order/krylov_trust_region.jl
@@ -168,12 +168,6 @@ function update_state!(objective::TwiceDifferentiableHV,
     return false
 end
 
-
-function update_g!(objective, state::KrylovTrustRegionState, method::KrylovTrustRegion)
-
-end
-
-
 function assess_convergence(state::KrylovTrustRegionState, d, options)
     if !state.accept_step
         return state.radius < options.x_tol, false, false, false, false

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -63,9 +63,6 @@ function update_state!(d, state::NewtonState, method::Newton)
     # information can be found in the discussion at issue #153.
     T = eltype(state.x)
 
-    # Is this needed here, or shouldn't it be at the end?
-    #update_h!(d, state, method)
-
     if typeof(NLSolversBase.hessian(d)) <: AbstractSparseMatrix
         state.s .= -NLSolversBase.hessian(d)\convert(Vector{T}, gradient(d))
     else
@@ -87,7 +84,7 @@ function update_state!(d, state::NewtonState, method::Newton)
     @. state.x = state.x + state.alpha * state.s
 
     value_gradient!(d, state.x)
-    update_h!(d, state, method)
+    hessian!(d, state.x)
 
     lssuccess == false # break on linesearch error
 end

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -63,7 +63,8 @@ function update_state!(d, state::NewtonState, method::Newton)
     # information can be found in the discussion at issue #153.
     T = eltype(state.x)
 
-    update_h!(d, state, method)
+    # Is this needed here, or shouldn't it be at the end?
+    #update_h!(d, state, method)
 
     if typeof(NLSolversBase.hessian(d)) <: AbstractSparseMatrix
         state.s .= -NLSolversBase.hessian(d)\convert(Vector{T}, gradient(d))
@@ -84,6 +85,10 @@ function update_state!(d, state::NewtonState, method::Newton)
 
     # Update current position # x = x + alpha * s
     @. state.x = state.x + state.alpha * state.s
+
+    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+    update_h!(d, state, method)
+
     lssuccess == false # break on linesearch error
 end
 

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -86,7 +86,7 @@ function update_state!(d, state::NewtonState, method::Newton)
     # Update current position # x = x + alpha * s
     @. state.x = state.x + state.alpha * state.s
 
-    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+    value_gradient!(d, state.x)
     update_h!(d, state, method)
 
     lssuccess == false # break on linesearch error

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -317,6 +317,8 @@ function update_state!(d, state::NewtonTrustRegionState, method::NewtonTrustRegi
         copy!(gradient(d), state.g_previous)
     end
 
+    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
+
     false
 end
 

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -317,8 +317,8 @@ function update_state!(d, state::NewtonTrustRegionState, method::NewtonTrustRegi
         copy!(gradient(d), state.g_previous)
     end
 
-    update_g!(d, state, method) # TODO: Should this be `update_fg!`?
-
+    value_gradient!(d, state.x)
+    hessian!(d, state.x)
     false
 end
 

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -250,6 +250,7 @@ function update_state!(f::F, state::NelderMeadState{T}, method::NelderMead) wher
     end
 
     state.nm_x = nmobjective(state.f_simplex, n, m)
+
     false
 end
 
@@ -277,7 +278,7 @@ end
 
 function initial_convergence(d, state::NelderMeadState, method::NelderMead, initial_x, options)
     nmobjective(state.f_simplex, state.m, length(initial_x)) < options.g_tol
-end 
+end
 
 function trace!(tr, d, state, iteration, method::NelderMead, options)
     dt = Dict()


### PR DESCRIPTION
These functions where made to fix some of the problems now handled in *Differentiable, but weren't removed when we updated. I like it much better that `update_state!` clearly shows when g, etc is updated.