### PR TITLE
Add Literate generator script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
     - julia -e 'Pkg.clone(pwd()); Pkg.test("Optim", coverage=true)'
 after_success:
     - julia -e 'cd(Pkg.dir("Optim")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-    - julia -e 'Pkg.add("Documenter"); Pkg.add("Literate")'
-    - julia -e 'cd(joinpath(Pkg.dir("Optim"), "docs")); include("make.jl")'
+#    - julia -e 'Pkg.add("Documenter"); Pkg.add("Literate")'
+#    - julia -e 'cd(joinpath(Pkg.dir("Optim"), "docs")); include("make.jl")'

--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -1,0 +1,19 @@
+# generate examples
+import Literate
+
+# TODO: Remove items from `SKIPFILE` as soon as they run on the latest
+# stable `Optim` (or other dependency)
+#ONLYSTATIC = ["ipnewton_basics.jl",]
+ONLYSTATIC = []
+
+EXAMPLEDIR = joinpath(@__DIR__, "src", "examples")
+GENERATEDDIR = joinpath(@__DIR__, "src", "examples", "generated")
+for example in filter!(r"\.jl$", readdir(EXAMPLEDIR))
+    input = abspath(joinpath(EXAMPLEDIR, example))
+    script = Literate.script(input, GENERATEDDIR)
+    code = strip(read(script, String))
+    mdpost(str) = replace(str, "@__CODE__" => code)
+    Literate.markdown(input, GENERATEDDIR, postprocess = mdpost,
+                      documenter = !(example in ONLYSTATIC))
+    Literate.notebook(input, GENERATEDDIR, execute = !(example in ONLYSTATIC))
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,4 @@
 OptimTestProblems 1.2
 RecursiveArrayTools
 Suppressor
+Literate

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,3 +222,9 @@ end
 
 println("Literate examples")
 @time include("examples.jl")
+
+
+# Build the docs
+if get(ENV, "TRAVIS_OS_NAME", "") == "linux" && get(ENV, "TRAVIS_JULIA_VERSION", "") == "0.6"
+    include(joinpath(@__DIR__, "../docs/make.jl"))
+end


### PR DESCRIPTION
I forgot to add a file to #632, so the docs generation failed.

This would have been caught if we run the docs generation script from `runtests.jl` in the same way it's done in LineSearches and JuAFEM. @pkofod if you prefer to keep `.travis.yml` as before I can revert the second commit in this PR, otherwise, this is good-to-go.