### PR TITLE
Fix example docs and add admonition to mkdocs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,9 @@
 Optim.jl is licensed under the MIT License:
 
 > Copyright (c) 2012: John Myles White, Tim Holy, and other contributors.
-> Copyright (c) 2016: Patrick Kofod Mogensen, John Myles White, Tim Holy, 
->                     and other contributors. 
-> Copyright (c) 2017: Patrick Kofod Mogensen, Asbjørn Nilsen Riseth, 
+> Copyright (c) 2016: Patrick Kofod Mogensen, John Myles White, Tim Holy,
+>                     and other contributors.
+> Copyright (c) 2017: Patrick Kofod Mogensen, Asbjørn Nilsen Riseth,
 >                     John Myles White, Tim Holy, and other contributors.
 >
 > Permission is hereby granted, free of charge, to any person

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,10 +11,14 @@ markdown_extensions:
   - tables
   - fenced_code
   - mdx_math
+  - admonition
 
 extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML
   - assets/mathjaxhelper.js
+
+extra_css:
+  - assets/Documenter.css
 
 docs_dir: 'build'
 
@@ -30,7 +34,7 @@ pages:
         - Manifolds: 'algo/manifolds.md'
         - Tips and tricks: 'user/tipsandtricks.md'
         - Interior point Newton: 'examples/generated/ipnewton_basics.md'
-        - Maximum likelihood estimation: 'examples/generated/ipnewton_basics.md'
+        - Maximum likelihood estimation: 'examples/generated/maxlikenlm.md'
     - Algorithms:
         - Gradient Free:
             - Nelder Mead: 'algo/nelder_mead.md'

--- a/docs/src/examples/ipnewton_basics.jl
+++ b/docs/src/examples/ipnewton_basics.jl
@@ -108,7 +108,7 @@ res = optimize(df, dfc, x0, IPNewton())
 @test Optim.converged(res)                   #src
 @test Optim.minimum(res) < 0.0 + sqrt(eps()) #src
 
-# ### Generic nonlinear constraints
+# ## Generic nonlinear constraints
 
 # We now consider the Rosenbrock problem with a constraint on
 # ```math
@@ -165,11 +165,11 @@ res = optimize(df, dfc, x0, IPNewton())
 lc = [0.1^2]
 dfc = TwiceDifferentiableConstraints(con_c!, con_jacobian!, con_h!,
                                      lx, ux, lc, uc)
-@suppress begin                                   #src
-    res = optimize(df, dfc, x0, IPNewton())
-    @test Optim.converged(res)                    #src
-    @test Optim.minimum(res) ≈ 0.2966215688829255 #src
-end                                               #src
+@suppress begin                               #src
+res = optimize(df, dfc, x0, IPNewton())
+@test Optim.converged(res)                    #src
+@test Optim.minimum(res) ≈ 0.2966215688829255 #src
+end                                           #src
 
 
 # **Note that the algorithm warns that the Initial guess is not an
@@ -178,7 +178,7 @@ end                                               #src
 # fails. We may fix this in the future.
 
 
-# #### Multiple constraints
+# ## Multiple constraints
 # The following example illustrates how to add an additional constraint.
 # In particular, we add a constraint function
 # ```math


### PR DESCRIPTION
I've fixed the following:
- mkdocs got confused with indented code in my IPNewton example
- Correct link to the maximum likelihood example
- Add `admonition` functionality to MkDocs (to enable `tip` blocks etc.)

@pkofod I have noticed two issues with the `windmill` theme:
- The search page does not work https://github.com/gristlabs/mkdocs-windmill/pull/16
- They don't have any CSS code for the admonition blocks, so they don't stand out as much as in other themese / the HTML format from Documenter.