### PR TITLE
pass options arg through to fminbox

### DIFF
--- a/src/multivariate/solvers/constrained/fminbox.jl
+++ b/src/multivariate/solvers/constrained/fminbox.jl
@@ -151,7 +151,7 @@ function optimize(f,
                   options = Options(); inplace = true, autodiff = :finite) where T<:AbstractFloat
 
     od = OnceDifferentiable(f, initial_x, zero(T); autodiff = autodiff)
-    optimize(od, l, u, initial_x, F)
+    optimize(od, l, u, initial_x, F, options)
 end
 
 function optimize(


### PR DESCRIPTION
I noticed my f_calls_limit option was not respected. Before this change, the below example calls f 1157 times, after the change it calls f 287 times.

```
import Optim

f(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
x0 = [2.0, 2.0]
lowerbounds = [1.0, 1.0]
upperbounds = [3.0, 3.0]

result = Optim.optimize(
  f,
  lowerbounds,
  upperbounds,
  x0,
  Optim.Fminbox(Optim.NelderMead()),
  Optim.Options(f_calls_limit=100)
)
println(result.f_calls)
```