### PR TITLE
Use BackTracking (cubic) as default line search for BFGS

### DIFF
--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -16,7 +16,7 @@ Base.summary(::BFGS) = "BFGS"
 ## Constructor
 ```julia
 BFGS(; alphaguess = LineSearches.InitialStatic(),
-       linesearch = LineSearches.HagerZhang(),
+       linesearch = LineSearches.BackTracking(),
        initial_invH = x -> Matrix{eltype(x)}(I, length(x), length(x)),
        manifold = Flat())
 ```
@@ -37,7 +37,7 @@ approximations as well as the gradient. See also the limited memory variant
  - Shanno, D. F. (1970), Conditioning of quasi-Newton methods for function minimization, Mathematics of Computation, 24 (111): 647–656.
 """
 function BFGS(; alphaguess = LineSearches.InitialStatic(), # TODO: benchmark defaults
-                linesearch = LineSearches.HagerZhang(),  # TODO: benchmark defaults
+                linesearch = LineSearches.BackTracking(),  # TODO: benchmark defaults
                 initial_invH = x -> Matrix{eltype(x)}(I, length(x), length(x)),
                 manifold::Manifold=Flat())
     BFGS(alphaguess, linesearch, initial_invH, manifold)


### PR DESCRIPTION
*Why ?* It's usually faster than HagerZhang and often just as accurate for BFGS. The reason why HagerZhang is used in ConjugateGradient can be found in the relavant papers, but basically we need that extra robustness to not mess with the properties of CGD.

might interest (or I might be interested in their opinion): @anriseth @antoine-levitt @cortner 

*Should:* benchmark more problems including CUTEst and problems with expensive gradients (HZ might (will?) call the gradient in there). The current problems all have very fast objective and gradient evaluations.
```
using Optim
using LineSearches


opti = BFGS(linesearch=HagerZhang())

opti2 = BFGS(linesearch=BackTracking(order=2))

opti3 = BFGS(linesearch=BackTracking(order=3))
using BenchmarkTools
using OptimTestProblems
const MVP = OptimTestProblems.MultivariateProblems

global opts = (("HG",opti), ("BT2", opti2), ("BT3", opti3))
global problemkeys = keys(OptimTestProblems.UnconstrainedProblems.examples)
for key in problemkeys
    global p = OptimTestProblems.UnconstrainedProblems.examples[key]
    println("Problem name: ", key)
    global minv = []
    global timev = []
    for opt in opts
        optname, optspec = opt
    #    println("Optimizing with: ")
    #    println(optname)
        t = @belapsed optimize(MVP.objective($p), MVP.gradient($p), $p.initial_x, $optspec)
        push!(timev, t)
        res = optimize(MVP.objective(p), MVP.gradient(p), p.initial_x, optspec)
        push!(minv, Optim.minimum(res))
    end
    for i = 1:length(opts)
        println("Opt alg: ", first(opts[i]))
        println("time: ", timev[i])
        println("time relative to HG: ", timev[i]/timev[1])
        println("min: ", minv[i])
        println("min relative to HG: ", minv[i]/minv[1])
    end
    printstyled("Fastest choice was: ", first(opts[argmin(timev)]); color=:cyan)
    println("\n")
end
```
gives something like
```
end
Problem name: Rosenbrock
Opt alg: HG
time: 5.0178e-5
time relative to HG: 1.0
min: 1.0186546650990723e-19
min relative to HG: 1.0
Opt alg: BT2
time: 3.1551e-5
time relative to HG: 0.6287815377256966
min: 3.319216760314283e-21
min relative to HG: 0.03258431806221064
Opt alg: BT3
time: 2.1288e-5
time relative to HG: 0.42424967117063256
min: 1.6018893575717171e-22
min relative to HG: 0.001572553891377821
Fastest choice was: BT3

Problem name: Quadratic Diagonal
Opt alg: HG
time: 0.003617004
time relative to HG: 1.0
min: 1.5798776383444688e-17
min relative to HG: 1.0
Opt alg: BT2
time: 0.003780844
time relative to HG: 1.0452971575370111
min: 1.579877529731965e-17
min relative to HG: 0.999999931252585
Opt alg: BT3
time: 0.007369337
time relative to HG: 2.0374146669453506
min: 3.5040136386668893e-19
min relative to HG: 0.02217901914441105
Fastest choice was: HG

Problem name: Hosaki
Opt alg: HG
time: 1.1784e-5
time relative to HG: 1.0
min: -2.3458115761012914
min relative to HG: 1.0
Opt alg: BT2
time: 1.0643e-5
time relative to HG: 0.903173794976239
min: -2.3458115761013074
min relative to HG: 1.0000000000000069
Opt alg: BT3
time: 1.0643e-5
time relative to HG: 0.903173794976239
min: -2.3458115761013074
min relative to HG: 1.0000000000000069
Fastest choice was: BT2

Problem name: Large Polynomial
Opt alg: HG
time: 9.3513e-5
time relative to HG: 1.0
min: 0.0
min relative to HG: NaN
Opt alg: BT2
time: 9.1993e-5
time relative to HG: 0.9837455754814839
min: 0.0
min relative to HG: NaN
Opt alg: BT3
time: 9.2753e-5
time relative to HG: 0.991872787740742
min: 0.0
min relative to HG: NaN
Fastest choice was: BT2

Problem name: Penalty Function I
Opt alg: HG
time: 0.005779224
time relative to HG: 1.0
min: 0.0004512454891351271
min relative to HG: 1.0
Opt alg: BT2
time: 0.008186632
time relative to HG: 1.416562500432584
min: 0.00045124548840244405
min relative to HG: 0.9999999983763094
Opt alg: BT3
time: 0.019642063
time relative to HG: 3.3987370968835955
min: 0.00045124548840214877
min relative to HG: 0.999999998375655
Fastest choice was: HG

Problem name: Beale
Opt alg: HG
time: 0.000107199
time relative to HG: 1.0
min: 2.0009242169674595e-20
min relative to HG: 1.0
Opt alg: BT2
time: 5.1318e-5
time relative to HG: 0.47871715221224076
min: 1.1572834649771584e-19
min relative to HG: 5.78374460743497
Opt alg: BT3
time: 6.2342e-5
time relative to HG: 0.5815539324060858
min: 1.0998290266807247e-18
min relative to HG: 54.96605105552635
Fastest choice was: BT2

Problem name: Extended Rosenbrock
Opt alg: HG
time: 0.017473001
time relative to HG: 1.0
min: 7.868089851411133e-17
min relative to HG: 1.0
Opt alg: BT2
time: 0.030854966
time relative to HG: 1.7658652912570658
min: 3.759038103333674e-16
min relative to HG: 4.777573940210527
Opt alg: BT3
time: 0.010357595
time relative to HG: 0.5927771079507179
min: 7.753972418347734e-19
min relative to HG: 0.009854961705803434
Fastest choice was: BT3

Problem name: Polynomial
Opt alg: HG
time: 0.000113281
time relative to HG: 1.0
min: 1.7995401763620082e-15
min relative to HG: 1.0
Opt alg: BT2
time: 7.2226e-5
time relative to HG: 0.6375826484582586
min: 5.863205818894201e-14
min relative to HG: 32.581688899813244
Opt alg: BT3
time: 5.8161e-5
time relative to HG: 0.5134223744493781
min: 1.7242688209703951e-12
min relative to HG: 958.1718950316612
Fastest choice was: BT3

Problem name: Powell
Opt alg: HG
time: 9.1233e-5
time relative to HG: 1.0
min: 5.671727479874051e-19
min relative to HG: 1.0
Opt alg: BT2
time: 5.0558e-5
time relative to HG: 0.5541635153946489
min: 3.293803885729145e-15
min relative to HG: 5807.408584804375
Opt alg: BT3
time: 5.2839e-5
time relative to HG: 0.5791654335602249
min: 7.155681955171748e-13
min relative to HG: 1.2616406519113379e6
Fastest choice was: BT2

Problem name: Exponential
Opt alg: HG
time: 3.6113e-5
time relative to HG: 1.0
min: 2.0
min relative to HG: 1.0
Opt alg: BT2
time: 3.2312e-5
time relative to HG: 0.8947470440007753
min: 2.0
min relative to HG: 1.0
Opt alg: BT3
time: 3.2692e-5
time relative to HG: 0.9052695705147731
min: 2.0
min relative to HG: 1.0
Fastest choice was: BT2

Problem name: Paraboloid Diagonal
Opt alg: HG
time: 0.033215238
time relative to HG: 1.0
min: 7.873484078063324e-19
min relative to HG: 1.0
Opt alg: BT2
time: 0.012470777
time relative to HG: 0.3754534891485649
min: 5.517456720847251e-19
min relative to HG: 0.7007643206162938
Opt alg: BT3
time: 0.019584662
time relative to HG: 0.5896288324051749
min: 1.299695826685546e-19
min relative to HG: 0.16507251602968098
Fastest choice was: BT2

Problem name: Paraboloid Random Matrix
Opt alg: HG
time: 0.035139872
time relative to HG: 1.0
min: 2.608969144693686e-18
min relative to HG: 1.0
Opt alg: BT2
time: 0.017900655
time relative to HG: 0.5094115026941476
min: 4.345922593447507e-20
min relative to HG: 0.01665762357629474
Opt alg: BT3
time: 0.024461441
time relative to HG: 0.696116394504795
min: 5.262765694971678e-18
min relative to HG: 2.017182037463141
Fastest choice was: BT2

Problem name: Extended Powell
Opt alg: HG
time: 0.038505606
time relative to HG: 1.0
min: 8.407445787174471e-12
min relative to HG: 1.0
Opt alg: BT2
time: 0.027904723
time relative to HG: 0.7246924772460405
min: 9.511744014462201e-12
min relative to HG: 1.1313476476972748
Opt alg: BT3
time: 0.027312468
time relative to HG: 0.709311470127233
min: 2.0080662139122755e-11
min relative to HG: 2.3884378974831733
Fastest choice was: BT3

Problem name: Trigonometric
Opt alg: HG
time: 0.008751516
time relative to HG: 1.0
min: 9.204812773644762e-7
min relative to HG: 1.0
Opt alg: BT2
time: 0.007918635
time relative to HG: 0.9048300888668889
min: 9.20481275209514e-7
min relative to HG: 0.9999999976588745
Opt alg: BT3
time: 0.007799273
time relative to HG: 0.8911910804939395
min: 9.20481275209514e-7
min relative to HG: 0.9999999976588745
Fastest choice was: BT3

Problem name: Fletcher-Powell
Opt alg: HG
time: 6.4623e-5
time relative to HG: 1.0
min: 1.1086633410027674e-27
min relative to HG: 1.0
Opt alg: BT2
time: 3.6113e-5
time relative to HG: 0.5588258050539282
min: 1.6755417055347396e-20
min relative to HG: 1.5113169558030486e7
Opt alg: BT3
time: 3.5352e-5
time relative to HG: 0.5470498119864445
min: 4.898649856547788e-21
min relative to HG: 4.418518837393001e6
Fastest choice was: BT3

Problem name: Parabola
Opt alg: HG
time: 5.9555e-6
time relative to HG: 1.0
min: 0.0
min relative to HG: NaN
Opt alg: BT2
time: 5.575333333333333e-6
time relative to HG: 0.9361654493045644
min: 0.0
min relative to HG: NaN
Opt alg: BT3
time: 5.385166666666667e-6
time relative to HG: 0.9042341812890047
min: 0.0
min relative to HG: NaN
Fastest choice was: BT3

Problem name: Himmelblau
Opt alg: HG
time: 1.4445e-5
time relative to HG: 1.0
min: 5.406316218969265e-25
min relative to HG: 1.0
Opt alg: BT2
time: 1.2924e-5
time relative to HG: 0.8947040498442368
min: 4.149732055152192e-20
min relative to HG: 76757.1094082868
Opt alg: BT3
time: 1.1784e-5
time relative to HG: 0.8157840083073727
min: 8.114485961784766e-22
min relative to HG: 1500.9269959669182
Fastest choice was: BT3
```