### PR TITLE
Temporary(?) doc generation fix for 1.0

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -237,6 +237,6 @@ println("Literate examples")
 
 
 # Build the docs
-if get(ENV, "TRAVIS_OS_NAME", "") == "linux" && get(ENV, "TRAVIS_JULIA_VERSION", "") == "0.6"
+if get(ENV, "TRAVIS_OS_NAME", "") == "linux" && get(ENV, "TRAVIS_JULIA_VERSION", "") == "1.0"
     include(joinpath(@__DIR__, "../docs/make.jl"))
 end


### PR DESCRIPTION
I assume that `TRAVIS_JULIA_VERSION` is `1.0`.

Maybe we should go towards Julia 1.0 Projects to handle docs. That approach was recently implemented in Literate.jl by @fredrikekre 