### PR TITLE
Remove Compat?

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
 julia 1.0
 PositiveFactorizations 0.2.1
-Compat 0.18.0
 LineSearches 6.0.1
 NLSolversBase 6.1.1
 ForwardDiff 0.5.0

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -30,9 +30,7 @@ import Parameters: @with_kw, # for types where constructors are simply defined
 
 using Printf                 # For printing, maybe look into other options
 
-using Compat                 # for compatibility across multiple julia versions
-import Compat.String         # for remake of strings in v0.7/v1.0
-import Compat.view           # for new views syntax in v0.7/v1.0
+#using Compat                 # for compatibility across multiple julia versions
 
 # for extensions of functions defined in Base.
 import Base: length, push!, show, getindex, setindex!, maximum

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@ using OptimTestProblems
 using OptimTestProblems.MultivariateProblems
 const MVP = MultivariateProblems
 
-using Compat
 using Suppressor
 import PositiveFactorizations: Positive, cholesky # for the IPNewton tests
 using Random


### PR DESCRIPTION
I don't think we're using Compat anywhere, so should be remove it? (at least, remove the two `import` lines?)