### PR TITLE
Implement `show` for Optim.options

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -90,9 +90,9 @@ end
 function Base.show(io::IO, o::Optim.Options)
     for k in fieldnames(typeof(o))
         if isnothing(getfield(o, k))
-            println(io, k, " = nothing")
+            @printf io "%24s = %s\n" k "nothing"
         else
-            println(k, " = ", getfield(o, k))
+            @printf io "%24s = %s\n" k getfield(o, k)
         end
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -87,6 +87,16 @@ function Options(;
         Int(show_every), callback, Float64(time_limit))
 end
 
+function Base.show(io::IO, o::Optim.Options)
+    for k in fieldnames(typeof(o))
+        if isnothing(getfield(o, k))
+            println(io, k, " = nothing")
+        else
+            println(k, " = ", getfield(o, k))
+        end
+    end
+end
+
 function print_header(options::Options)
     if options.show_trace
         @printf "Iter     Function value   Gradient norm \n"

--- a/src/types.jl
+++ b/src/types.jl
@@ -89,10 +89,11 @@ end
 
 function Base.show(io::IO, o::Optim.Options)
     for k in fieldnames(typeof(o))
-        if isnothing(getfield(o, k))
+        v = getfield(o, k)
+        if v isa Nothing
             @printf io "%24s = %s\n" k "nothing"
         else
-            @printf io "%24s = %s\n" k getfield(o, k)
+            @printf io "%24s = %s\n" k v
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -243,3 +243,8 @@ end
 
 println("Literate examples")
 @time include("examples.jl")
+
+@testset "show method for options" begin
+    o = Optim.Options()
+    @test o == @show o
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,5 +246,5 @@ println("Literate examples")
 
 @testset "show method for options" begin
     o = Optim.Options()
-    @test o == @show o
+    @test occursin(" = ", sprint(show, o))
 end


### PR DESCRIPTION
I just tried adding the function in the REPL, so maybe there needs more work, but at least it helps giving a somewhat more readable output. Example:
```julia
julia> myoptions = Optim.Options(x_tol = 1e-10)
x_tol = 1.0e-10
f_tol = 0.0
g_tol = 1.0e-8
outer_x_tol = 0.0
outer_f_tol = 0.0
outer_g_tol = 1.0e-8
f_calls_limit = 0
g_calls_limit = 0
h_calls_limit = 0
allow_f_increases = false
allow_outer_f_increases = false
successive_f_tol = 0
iterations = 1000
outer_iterations = 1000
store_trace = false
show_trace = false
extended_trace = false
show_every = 1
callback = nothing
time_limit = NaN
```