### PR TITLE
Typo in the documentation: Update nelder_mead.md

### DIFF
--- a/docs/src/algo/nelder_mead.md
+++ b/docs/src/algo/nelder_mead.md
@@ -97,7 +97,7 @@ Gao and Han (2010). These are based on the dimensionality of the problem, and
 are given by
 
 ```math
-\alpha = 1, \quad \beta = 1+2/n,\quad \gamma =0.75 + 1/2n,\quad \delta = 1-1/n
+\alpha = 1, \quad \beta = 1+2/n,\quad \gamma =0.75 - 1/2n,\quad \delta = 1-1/n
 ```
 
 It is also possible to specify the original parameters from Nelder and Mead (1965)


### PR DESCRIPTION
Corrected a small typo. 

In Gao & Han (2010, p. 269) they recommend using gamma = 1 - 1/(2n)

Fortunately, the code seems correct in ` Optim.jl/src/multivariate/solvers/zeroth_order/
nelder_mead.jl`, line 28