### PR TITLE
Initial stepnorm in BFGS

### DIFF
--- a/docs/src/algo/lbfgs.md
+++ b/docs/src/algo/lbfgs.md
@@ -4,9 +4,18 @@ This page contains information about BFGS and its limited memory version L-BFGS.
 ```julia
 BFGS(; alphaguess = LineSearches.InitialStatic(),
        linesearch = LineSearches.HagerZhang(),
-       initial_invH = x -> Matrix{eltype(x)}(I, length(x), length(x)),
-       manifold = Flat()
+       initial_invH = nothing,
+       initial_stepnorm = nothing,
+       manifold = Flat())
 ```
+
+`initial_invH` has a default value of `nothing`. If the user has a specific initial
+matrix they want to supply, it should be supplied as a function of an array similar
+to the initial point `x0`.
+
+If `initial_stepnorm` is set to a number `z`, the initial matrix will be the
+identity matrix scaled by `z` times the sup-norm of the gradient at the initial
+point `x0`.
 
 ```julia
 LBFGS(; m = 10,

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -68,9 +68,11 @@ function initial_state(method::BFGS, options, d, initial_x::AbstractArray{T}) wh
     project_tangent!(method.manifold, gradient(d), initial_x)
 
     if method.initial_invH == nothing
-        invH0 = Matrix{T}(I, length(initial_x), length(initial_x))
-        if !(method.initial_stepnorm == nothing)
-            invH0 .= method.initial_stepnorm*inv(norm(gradient(d), Inf)).*invH0
+        if method.initial_stepnorm == nothing
+            invH0 = Matrix{T}(I, n, n)
+        else
+            initial_scale = method.initial_stepnorm * inv(norm(gradient(d), Inf))
+            invH0 = Matrix{T}(initial_scale*I, n, n)
         end
     else
         invH0 = method.initial_invH(initial_x)

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -2,11 +2,12 @@
 # JMW's dx <=> NW's s
 # JMW's dg <=> NW' y
 
-struct BFGS{IL, L, H<:Function} <: FirstOrderOptimizer
+struct BFGS{IL, L, H, T, TM} <: FirstOrderOptimizer
     alphaguess!::IL
     linesearch!::L
     initial_invH::H
-    manifold::Manifold
+    initial_stepnorm::T
+    manifold::TM
 end
 
 Base.summary(::BFGS) = "BFGS"
@@ -38,9 +39,10 @@ approximations as well as the gradient. See also the limited memory variant
 """
 function BFGS(; alphaguess = LineSearches.InitialStatic(), # TODO: benchmark defaults
                 linesearch = LineSearches.HagerZhang(),  # TODO: benchmark defaults
-                initial_invH = x -> Matrix{eltype(x)}(I, length(x), length(x)),
+                initial_invH = nothing,
+                initial_stepnorm = nothing,
                 manifold::Manifold=Flat())
-    BFGS(alphaguess, linesearch, initial_invH, manifold)
+    BFGS(alphaguess, linesearch, initial_invH, initial_stepnorm, manifold)
 end
 
 mutable struct BFGSState{Tx, Tm, T,G} <: AbstractOptimizerState
@@ -64,6 +66,15 @@ function initial_state(method::BFGS, options, d, initial_x::AbstractArray{T}) wh
     value_gradient!!(d, initial_x)
 
     project_tangent!(method.manifold, gradient(d), initial_x)
+
+    if method.initial_invH == nothing
+        invH0 = Matrix{T}(I, length(initial_x), length(initial_x))
+        if !(method.initial_stepnorm == nothing)
+            invH0 .= method.initial_stepnorm*inv(norm(gradient(d), Inf)).*invH0
+        end
+    else
+        invH0 = method.initial_invH(initial_x)
+    end
     # Maintain a cache for line search results
     # Trace the history of states visited
     BFGSState(initial_x, # Maintain current state in state.x
@@ -73,7 +84,7 @@ function initial_state(method::BFGS, options, d, initial_x::AbstractArray{T}) wh
               similar(initial_x), # Store changes in position in state.dx
               similar(initial_x), # Store changes in gradient in state.dg
               similar(initial_x), # Buffer stored in state.u
-              method.initial_invH(initial_x), # Store current invH in state.invH
+              invH0, # Store current invH in state.invH
               similar(initial_x), # Store current search direction in state.s
               @initial_linesearch()...)
 end

--- a/src/utilities/perform_linesearch.jl
+++ b/src/utilities/perform_linesearch.jl
@@ -8,13 +8,13 @@ function reset_search_direction!(state, d, method::BFGS)
 
     if method.initial_invH == nothing
         if method.initial_stepnorm == nothing
-            state.invH0 .= Matrix{T}(I, n, n)
+            state.invH .= Matrix{T}(I, n, n)
         else
             initial_scale = method.initial_stepnorm * inv(norm(gradient(d), Inf))
-            state.invH0.= Matrix{T}(initial_scale*I, n, n)
+            state.invH.= Matrix{T}(initial_scale*I, n, n)
         end
     else
-        state.invH0 .= method.initial_invH(initial_x)
+        state.invH .= method.initial_invH(initial_x)
     end
 #    copyto!(state.invH, method.initial_invH(state.x))
     state.s .= .-gradient(d)

--- a/src/utilities/perform_linesearch.jl
+++ b/src/utilities/perform_linesearch.jl
@@ -5,16 +5,16 @@ reset_search_direction!(state, d, method) = false # no-op
 function reset_search_direction!(state, d, method::BFGS)
     n = length(state.x)
     T = eltype(state.x)
-    
+
     if method.initial_invH == nothing
         if method.initial_stepnorm == nothing
-            invH0 = Matrix{T}(I, n, n)
+            state.invH0 .= Matrix{T}(I, n, n)
         else
             initial_scale = method.initial_stepnorm * inv(norm(gradient(d), Inf))
-            invH0 = Matrix{T}(initial_scale*I, n, n)
+            state.invH0.= Matrix{T}(initial_scale*I, n, n)
         end
     else
-        invH0 = method.initial_invH(initial_x)
+        state.invH0 .= method.initial_invH(initial_x)
     end
 #    copyto!(state.invH, method.initial_invH(state.x))
     state.s .= .-gradient(d)

--- a/src/utilities/perform_linesearch.jl
+++ b/src/utilities/perform_linesearch.jl
@@ -3,16 +3,19 @@
 reset_search_direction!(state, d, method) = false # no-op
 
 function reset_search_direction!(state, d, method::BFGS)
-
+    n = length(state.x)
+    T = eltype(state.x)
+    
     if method.initial_invH == nothing
-        state.invH = Matrix{eltype(state.x)}(I, length(state.x), length(state.x))
-        if !(method.initial_stepnorm == nothing)
-            state.invH .= method.initial_stepnorm*inv(norm(gradient(d), Inf)).*state.invH
+        if method.initial_stepnorm == nothing
+            invH0 = Matrix{T}(I, n, n)
+        else
+            initial_scale = method.initial_stepnorm * inv(norm(gradient(d), Inf))
+            invH0 = Matrix{T}(initial_scale*I, n, n)
         end
     else
-        state.invH = method.initial_invH(initial_x)
+        invH0 = method.initial_invH(initial_x)
     end
-
 #    copyto!(state.invH, method.initial_invH(state.x))
     state.s .= .-gradient(d)
     return true

--- a/src/utilities/perform_linesearch.jl
+++ b/src/utilities/perform_linesearch.jl
@@ -3,7 +3,17 @@
 reset_search_direction!(state, d, method) = false # no-op
 
 function reset_search_direction!(state, d, method::BFGS)
-    copyto!(state.invH, method.initial_invH(state.x))
+
+    if method.initial_invH == nothing
+        state.invH = Matrix{eltype(state.x)}(I, length(state.x), length(state.x))
+        if !(method.initial_stepnorm == nothing)
+            state.invH .= method.initial_stepnorm*inv(norm(gradient(d), Inf)).*state.invH
+        end
+    else
+        state.invH = method.initial_invH(initial_x)
+    end
+
+#    copyto!(state.invH, method.initial_invH(state.x))
     state.s .= .-gradient(d)
     return true
 end


### PR DESCRIPTION
This is mentioned in N&W. They mention that various pieces of software allow a similar choice, but I'm not sure which ones to be honest.

The reason why it can make sense, as far as I understand it, is because extreme search directions (not final steps!) can really mess up the line search. It can be difficult to reach a useful step size in the allowed number of iterations, or a sub-optimal point can be accepted by the inexact line search.

`BFGS(; initial_stepnorm=z)` will scale the initial identity matrix with the supnorm of the gradient times `z`. That number `z` is usually described as the "usual" or "expected" step size. If the initial step size can be guessed and set to `z` it is potentially possible to either a) avoid too many function evaluations in the first iteration and/or b) avoid a weird step into a "bad" region in the first step.

As everything non-linear, this is not guaranteed to help anyone (say with `z=1`), but it's a convenient thing to be able to set by a user who experiences odd first steps. 