### PR TITLE
fix bug in show() when trying to abbreviate singleton arrays

### DIFF
--- a/src/maximize.jl
+++ b/src/maximize.jl
@@ -69,19 +69,20 @@ function Base.show(io::IO, r::MaximizationWrapper{<:UnivariateOptimizationResult
 end
 
 function Base.show(io::IO, r::MaximizationWrapper{<:MultivariateOptimizationResults})
-    first_two(fr) = [x for (i, x) in enumerate(fr)][1:2]
+    take = Iterators.take
 
     @printf io "Results of Optimization Algorithm\n"
     @printf io " * Algorithm: %s\n" summary(r.res)
     if length(join(initial_state(r), ",")) < 40
         @printf io " * Starting Point: [%s]\n" join(initial_state(r), ",")
     else
-        @printf io " * Starting Point: [%s, ...]\n" join(first_two(initial_state(r)), ",")
+        @printf io " * Starting Point: [%s, ...]\n" join(take(initial_state(r),
+2), ",")
     end
     if length(join(maximizer(r), ",")) < 40
         @printf io " * Maximizer: [%s]\n" join(maximizer(r), ",")
     else
-        @printf io " * Maximizer: [%s, ...]\n" join(first_two(maximizer(r)), ",")
+        @printf io " * Maximizer: [%s, ...]\n" join(take(maximizer(r), 2), ",")
     end
     @printf io " * Maximum: %e\n" maximum(r)
     @printf io " * Iterations: %d\n" iterations(r)

--- a/src/types.jl
+++ b/src/types.jl
@@ -166,19 +166,20 @@ function Base.show(io::IO, tr::OptimizationTrace)
 end
 
 function Base.show(io::IO, r::MultivariateOptimizationResults)
-    first_two(fr) = [x for (i, x) in enumerate(fr)][1:2]
+    take = Iterators.take
 
     @printf io "Results of Optimization Algorithm\n"
     @printf io " * Algorithm: %s\n" summary(r)
     if length(join(initial_state(r), ",")) < 40
         @printf io " * Starting Point: [%s]\n" join(initial_state(r), ",")
     else
-        @printf io " * Starting Point: [%s, ...]\n" join(first_two(initial_state(r)), ",")
+        @printf io " * Starting Point: [%s, ...]\n" join(take(initial_state(r),
+2), ",")
     end
     if length(join(minimizer(r), ",")) < 40
         @printf io " * Minimizer: [%s]\n" join(minimizer(r), ",")
     else
-        @printf io " * Minimizer: [%s, ...]\n" join(first_two(minimizer(r)), ",")
+        @printf io " * Minimizer: [%s, ...]\n" join(take(minimizer(r), 2), ",")
     end
     @printf io " * Minimum: %e\n" minimum(r)
     @printf io " * Iterations: %d\n" iterations(r)


### PR DESCRIPTION
A minimal example of what went wrong:

	using Optim

	f(x) = x[1]^2

	x0 = BigFloat[1]
	obj = OnceDifferentiable(f, x0; autodiff = :forward)
	result = optimize(obj, x0, BFGS());
	println(result)   # This bit crashes.

The final print fails, because (i) the minimizer is an array of length 1, and
(ii) because the solution is stored using BigFloats, it does not fit on a
single line and needs to be abbreviated.