### PR TITLE
Fix a use-before-initialisation bug

### DIFF
--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -91,6 +91,12 @@ function optimize(d::D, initial_x::Tx, method::M,
     T = typeof(options.f_tol)
     f_incr_pick = f_increased && !options.allow_f_increases
 
+    if iteration < 2
+        # There is no previous state to compare with.
+        state.x_previous = NaN * initial_x
+        state.f_x_previous = NaN * value(d)
+    end
+
     return MultivariateOptimizationResults(method,
                                         initial_x,
                                         pick_best_x(f_incr_pick, state),


### PR DESCRIPTION
After finding the solution, Optim.optimize() assembles some information, which
includes comparing the solution to the previous iteration.  However, if the
solution was found in one iteration (i.e. the initial guess was right), then
there is no previous guess to compare with.  In this case, Optim.optimize()
crashes, because it tries to use something that has not been initialised.

Here is a simple example that triggers a crash:

	using Optim
	f(x) = x[1]^2
	x0 = BigFloat[0]
	obj = OnceDifferentiable(f, x0; autodiff=:forward)
	result = Optim.optimize(f, x0, BFGS())