### PR TITLE
Multi-threading particle swarm

### DIFF
--- a/src/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/src/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -448,7 +448,7 @@ end
 
 function limit_X!(X, lower, upper, n_particles, n)
     # limit X values to boundaries
-    for i in 1:n_particles
+    Threads.@threads for i in 1:n_particles
         for j in 1:n
             if X[j, i] < lower[j]
               	X[j, i] = lower[j]
@@ -465,7 +465,7 @@ function compute_cost!(f,
                        X::Matrix,
                        score::Vector)
 
-    for i in 1:n_particles
+    Threads.@threads for i in 1:n_particles
         score[i] = value(f, X[:, i])
     end
     nothing

--- a/test/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/test/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -15,7 +15,7 @@
     lower = [-100.0]
     n_particles = 4
     options = Optim.Options(iterations=100)
-    res = Optim.optimize(f_s, initial_x, ParticleSwarm(lower, upper, n_particles),
+    res = Optim.optimize(f_s, initial_x, ParticleSwarm(lower, upper, n_particles,false),
                          options)
     @test norm(Optim.minimizer(res) - [5.0]) < 0.1
 
@@ -24,12 +24,12 @@
     upper = [20., 20.]
     n_particles = 5
     options = Optim.Options(iterations=300)
-    res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles),
+    res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles,false),
                              options)
     @test norm(Optim.minimizer(res) - [1.0, 1.0]) < 0.1
     @suppress_out begin
         options = Optim.Options(iterations=300, show_trace=true, extended_trace=true, store_trace=true)
-        res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles), options)
+        res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles,false), options)
         @test summary(res) == "Particle Swarm"
         res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(n_particles = n_particles), options)
         @test summary(res) == "Particle Swarm"


### PR DESCRIPTION
I added `Threads.@threads` in two spots: `compute_cost!` and `limit_X!`. The speedup on my particular problem was approximately 3x going from 1 thread to 6, the bulk of which comes from parallel execution of the cost function.

The user does not have to do anything additional, just needs to start up julia with multiple threads.

I have not run any further tests, and I am not sure how well threading would work on every problem. If there is IO or something else funky inside the cost function (calls to a RNG?), there could be an issue with multi-threading (from what I read on the recent blog post on the homepage).

I am on julia v1.3.0-alpha.