### PR TITLE
Make dot definition on Julia version since it's implemented in Julia 1.4

### DIFF
--- a/src/multivariate/precon.jl
+++ b/src/multivariate/precon.jl
@@ -19,8 +19,10 @@
 #  [0] Defaults and aliases for easier reading of the code
 #      these can also be over-written if necessary.
 
+if VERSION < v"1.4.0-DEV.92"
 # an inner product w.r.t. a metric P (=preconditioner)
-dot(x, P, y) = dot(x, mul!(similar(x), P, y))
+    dot(x, P, y) = dot(x, mul!(similar(x), P, y))
+end
 
 # default preconditioner update
 precondprep!(P, x) = nothing


### PR DESCRIPTION
To avoid a precompilation error on Julia 1.4.