### PR TITLE
Define private `dot` function to avoid type-piracy

### DIFF
--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -44,9 +44,10 @@ import NLSolversBase: NonDifferentiable, OnceDifferentiable, TwiceDifferentiable
 # var for NelderMead
 import StatsBase: var
 
+import LinearAlgebra
 import LinearAlgebra: Diagonal, diag, Hermitian, Symmetric,
                       rmul!, mul!, ldiv!,
-                      dot, norm, normalize!,
+                      norm, normalize!,
                       eigen, BLAS,
                       cholesky, Cholesky, # factorizations
                       I,
@@ -117,6 +118,7 @@ export optimize, maximize, # main function
        ## Non-linear constraints
        IPNewton
 
+dot(x, y) = LinearAlgebra.dot(x, y)
 
 include("types.jl") # types used throughout
 include("Manifolds.jl") # code to handle manifold constraints


### PR DESCRIPTION
As of https://github.com/JuliaLang/julia/pull/32739, Julia has 3-arg `dot` function. Using Optim master with Julia 1.4-DEV produces a warning

> `WARNING: Method definition dot(Any, Any, Any) in module LinearAlgebra at /.../stdlib/v1.4/LinearAlgebra/src/generic.jl:903 overwritten in module Optim at /.../Optim/src/multivariate/precon.jl:23.`

This PR fixes the warning by defining a private function `Optim.dot`.