### PR TITLE
WIP: Corrected Stiefel_CholQR

### DIFF
--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -91,7 +91,7 @@ function retract!(S::Stiefel_SVD, X)
 end
 function retract!(S::Stiefel_CholQR, X)
     overlap = X'X
-    X .= X/cholesky(overlap).L
+    X .= X/cholesky(overlap).U
 end
 #For functions depending only on the subspace spanned by X, we always have G = A*X for some A, and so X'G = G'X, and Stiefel == Grassmann
 #Edelman et al. have G .-= X*G'X (2.53), corresponding to a different metric ("canonical metric"). We follow Absil et al. here and use the metric inherited from Nxn matrices.

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -91,7 +91,7 @@ function retract!(S::Stiefel_SVD, X)
 end
 function retract!(S::Stiefel_CholQR, X)
     overlap = X'X
-    X .= X/cholesky(overlap)
+    X .= X/cholesky(overlap).L
 end
 #For functions depending only on the subspace spanned by X, we always have G = A*X for some A, and so X'G = G'X, and Stiefel == Grassmann
 #Edelman et al. have G .-= X*G'X (2.53), corresponding to a different metric ("canonical metric"). We follow Absil et al. here and use the metric inherited from Nxn matrices.

--- a/test/multivariate/manifolds.jl
+++ b/test/multivariate/manifolds.jl
@@ -11,43 +11,47 @@
     # A[2,2] /= 10 #optional: reduce the gap to make the problem artificially harder
     x0 = randn(n,m)+im*randn(n,m)
 
-    manif = Optim.Stiefel()
+    @testset "Stiefel, retraction = $retraction" for retraction in [:SVD,:CholQR]
+        manif = Optim.Stiefel(retraction)
 
-    # AcceleratedGradientDescent should be compatible also, but I haven't been able to make it converge
-    for ls in (Optim.BackTracking,Optim.HagerZhang,Optim.StrongWolfe,Optim.MoreThuente)
-        for method in (Optim.GradientDescent, Optim.ConjugateGradient, Optim.LBFGS, Optim.BFGS,
-                       Optim.NGMRES, Optim.OACCEL)
-            debug_printing && printstyled("Solver: $(summary(method())), linesearch: $(summary(ls()))\n", color=:green)
-            res = Optim.optimize(fmanif, gmanif!, x0, method(manifold=manif,linesearch=ls()), Optim.Options(allow_f_increases=true,g_tol=1e-6))
-            debug_printing && printstyled("Iter\tf-calls\tg-calls\n", color=:green)
-            debug_printing && printstyled("$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n", color=:red)
-            @test Optim.converged(res)
+        # AcceleratedGradientDescent should be compatible also, but I haven't been able to make it converge
+        for ls in (Optim.BackTracking,Optim.HagerZhang,Optim.StrongWolfe,Optim.MoreThuente)
+            for method in (Optim.GradientDescent, Optim.ConjugateGradient, Optim.LBFGS, Optim.BFGS,
+                           Optim.NGMRES, Optim.OACCEL)
+                debug_printing && printstyled("Solver: $(summary(method())), linesearch: $(summary(ls()))\n", color=:green)
+                res = Optim.optimize(fmanif, gmanif!, x0, method(manifold=manif,linesearch=ls()), Optim.Options(allow_f_increases=true,g_tol=1e-6))
+                debug_printing && printstyled("Iter\tf-calls\tg-calls\n", color=:green)
+                debug_printing && printstyled("$(Optim.iterations(res))\t$(Optim.f_calls(res))\t$(Optim.g_calls(res))\n", color=:red)
+                @test Optim.converged(res)
+            end
         end
+        res = Optim.optimize(fmanif, gmanif!, x0, Optim.MomentumGradientDescent(mu=0.0, manifold=manif))
+        @test Optim.converged(res)
     end
-    res = Optim.optimize(fmanif, gmanif!, x0, Optim.MomentumGradientDescent(mu=0.0, manifold=manif))
-    @test Optim.converged(res)
 
-    # Power
-    @views fprod(x) = fmanif(x[:,1]) + fmanif(x[:,2])
-    @views gprod!(stor,x) = (gmanif!(stor[:, 1],x[:, 1]);gmanif!(stor[:, 2],x[:, 2]);stor)
-    m1 = Optim.PowerManifold(Optim.Sphere(), (n,), (2,))
-    Random.seed!(0)
-    x0 = randn(n,2) + im*randn(n,2)
-    res = Optim.optimize(fprod, gprod!, x0, Optim.ConjugateGradient(manifold=m1))
-    @test Optim.converged(res)
-    minpow = Optim.minimizer(res)
+    @testset "Power and Product" begin
+        # Power
+        @views fprod(x) = fmanif(x[:,1]) + fmanif(x[:,2])
+        @views gprod!(stor,x) = (gmanif!(stor[:, 1],x[:, 1]);gmanif!(stor[:, 2],x[:, 2]);stor)
+        m1 = Optim.PowerManifold(Optim.Sphere(), (n,), (2,))
+        Random.seed!(0)
+        x0 = randn(n,2) + im*randn(n,2)
+        res = Optim.optimize(fprod, gprod!, x0, Optim.ConjugateGradient(manifold=m1))
+        @test Optim.converged(res)
+        minpow = Optim.minimizer(res)
 
-    # Product
-    @views fprod(x) = fmanif(x[1:n]) + fmanif(x[n+1:2n])
-    @views gprod!(stor,x) = (gmanif!(stor[1:n],x[1:n]);gmanif!(stor[n+1:2n],x[n+1:2n]);stor)
-    m2 = Optim.ProductManifold(Optim.Sphere(), Optim.Sphere(), (n,), (n,))
-    Random.seed!(0)
-    x0 = randn(2n) + im*randn(2n)
-    res = Optim.optimize(fprod, gprod!, x0, Optim.ConjugateGradient(manifold=m2))
-    @test Optim.converged(res)
-    minprod = Optim.minimizer(res)
+        # Product
+        @views fprod(x) = fmanif(x[1:n]) + fmanif(x[n+1:2n])
+        @views gprod!(stor,x) = (gmanif!(stor[1:n],x[1:n]);gmanif!(stor[n+1:2n],x[n+1:2n]);stor)
+        m2 = Optim.ProductManifold(Optim.Sphere(), Optim.Sphere(), (n,), (n,))
+        Random.seed!(0)
+        x0 = randn(2n) + im*randn(2n)
+        res = Optim.optimize(fprod, gprod!, x0, Optim.ConjugateGradient(manifold=m2))
+        @test Optim.converged(res)
+        minprod = Optim.minimizer(res)
 
-    # results should be exactly equal: same initial guess, same sequence of operations
-    @test minpow[:,1] == minprod[1:n]
-    @test minpow[:,2] == minprod[n+1:2n]
+        # results should be exactly equal: same initial guess, same sequence of operations
+        @test minpow[:,1] == minprod[1:n]
+        @test minpow[:,2] == minprod[n+1:2n]
+    end
 end


### PR DESCRIPTION
Fixes #752

Don't merge yet!

To test the change, I simply repeated the test done for `Stiefel_SVD`. However, the test fails then with

```
Stiefel, retraction = CholQR: Error During Test at /Users/jagot/.julia/dev/Optim/test/multivariate/manifolds.jl:14
  Got exception outside of a @test
  ArgumentError: Search direction is not a direction of descent.
  Stacktrace:
   [1] (::LineSearches.HagerZhang{Float64,Base.RefValue{Bool}})(::Function, ::getfield(LineSearches, Symbol("#ϕdϕ#6")){Optim.ManifoldObjective{OnceDifferentiable{Float64,Array{Complex{Float64},2},Array{Complex{Float64},2}}},Array{Complex{Float64},2},Array{Complex{Float64},2},Array{Complex{Float64},2}}, ::Float64, ::Float64, ::Float64) at /Users/jagot/.julia/packages/LineSearches/WrsMD/src/hagerzhang.jl:120
   [2] HagerZhang at /Users/jagot/.julia/packages/LineSearches/WrsMD/src/hagerzhang.jl:101 [inlined]
   [3] perform_linesearch!(::Optim.ConjugateGradientState{Array{Complex{Float64},2},Float64,Array{Complex{Float64},2}}, ::ConjugateGradient{Float64,Nothing,getfield(Optim, Symbol("##31#33")),LineSearches.InitialHagerZhang{Float64},LineSearches.HagerZhang{Float64,Base.RefValue{Bool}}}, ::Optim.ManifoldObjective{OnceDifferentiable{Float64,Array{Complex{Float64},2},Array{Complex{Float64},2}}}) at /Users/jagot/.julia/dev/Optim/src/utilities/perform_linesearch.jl:53
   [4] update_state!(::OnceDifferentiable{Float64,Array{Complex{Float64},2},Array{Complex{Float64},2}}, ::Optim.ConjugateGradientState{Array{Complex{Float64},2},Float64,Array{Complex{Float64},2}}, ::ConjugateGradient{Float64,Nothing,getfield(Optim, Symbol("##31#33")),LineSearches.InitialHagerZhang{Float64},LineSearches.HagerZhang{Float64,Base.RefValue{Bool}}}) at /Users/jagot/.julia/dev/Optim/src/multivariate/solvers/first_order/cg.jl:155
   [5] optimize(::OnceDifferentiable{Float64,Array{Complex{Float64},2},Array{Complex{Float64},2}}, ::Array{Complex{Float64},2}, ::ConjugateGradient{Float64,Nothing,getfield(Optim, Symbol("##31#33")),LineSearches.InitialHagerZhang{Float64},LineSearches.HagerZhang{Float64,Base.RefValue{Bool}}}, ::Optim.Options{Float64,Nothing}, ::Optim.ConjugateGradientState{Array{Complex{Float64},2},Float64,Array{Complex{Float64},2}}) at /Users/jagot/.julia/dev/Optim/src/multivariate/optimize/optimize.jl:57
   [6] optimize at /Users/jagot/.julia/dev/Optim/src/multivariate/optimize/optimize.jl:33 [inlined]
```