### PR TITLE
Use LinearAlgebra.dot(::Array, ::Diagonal, ::Array) in Julia 1.4

### DIFF
--- a/src/multivariate/precon.jl
+++ b/src/multivariate/precon.jl
@@ -45,7 +45,9 @@ dot(A, ::Nothing, B) = dot(A, B)
 #      ldiv!(a, P, b) or mul! for this type, so we do it by hand
 #      TODO: maybe implement this in Base
 ldiv!(out::Array, P::Diagonal, A::Array) = copyto!(out, A ./ P.diag)
-dot(A::Array, P::Diagonal, B::Array) = dot(A, P.diag .* B)
+if VERSION < v"1.4.0-DEV.92"
+    dot(A::Array, P::Diagonal, B::Array) = dot(A, P.diag .* B)
+end
 
 #####################################################
 #  [3] Inverse Diagonal preconditioner


### PR DESCRIPTION
As discussed in https://github.com/JuliaNLSolvers/Optim.jl/pull/749#issuecomment-533347789, I added a `if` block so that `dot(::Array, ::Diagonal, ::Array)` defined in LinearAlgebra would be used in Julia 1.4.

The corresponding function is defined in https://github.com/JuliaLang/julia/commit/2425ae760fb5151c5c7dd0554e87c5fc9e24de73#diff-931712efb02f1f24866de113b19d54a3R645-R647 which gives the version number:

```console
$ contrib/commit-name.sh 2425ae760fb5151c5c7dd0554e87c5fc9e24de73
1.4.0-DEV.92
```