### PR TITLE
Fix: linesearch result was not checked in `optimize`

### DIFF
--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -50,12 +50,12 @@ function optimize(d::D, initial_x::Tx, method::M,
     options.show_trace && print_header(method)
     _time = time()
     trace!(tr, d, state, iteration, method, options, _time-t0)
-    ls_success::Bool = true
+    ls_failed::Bool = false
     while !converged && !stopped && iteration < options.iterations
         iteration += 1
 
         ls_failed = update_state!(d, state, method)
-        if !ls_success
+        if ls_failed
             break # it returns true if it's forced by something in update! to stop (eg dx_dg == 0.0 in BFGS, or linesearch errors)
         end
         update_g!(d, state, method) # TODO: Should this be `update_fg!`?
@@ -119,7 +119,7 @@ function optimize(d::D, initial_x::Tx, method::M,
                                         f_calls(d),
                                         g_calls(d),
                                         h_calls(d),
-                                        !ls_success,
+                                        !ls_failed,
                                         options.time_limit,
                                         _time-t0,
                                         )

--- a/test/multivariate/solvers/constrained/fminbox.jl
+++ b/test/multivariate/solvers/constrained/fminbox.jl
@@ -40,7 +40,8 @@
     initial_x = (rand(N) .- 0.5) .* boxl
     for _optimizer in (ConjugateGradient(), GradientDescent(), LBFGS(), BFGS(), NGMRES(), OACCEL())
         debug_printing && printstyled("Solver: ", summary(_optimizer), "\n", color=:green)
-        results = optimize(_objective, l, u, initial_x, Fminbox(_optimizer))
+        opt = Optim.Options(allow_f_increases=true)
+        results = optimize(_objective, l, u, initial_x, Fminbox(_optimizer), opt)
         @test Optim.converged(results)
         @test summary(results) == "Fminbox with $(summary(_optimizer))"
         opt_x = Optim.minimizer(results)


### PR DESCRIPTION
`ls_failed = update_state!(d, state, method)` assigned in `optimize` is never used. IIUC we need to bail out once it has failed and I _think_ the code with this PR does this.

Does this patch make sense?  Locally running the test fails with multivariate Fminbox testset so I'm not sure if there is a bug with this patch or there is a glitch in the test.