### PR TITLE
Include test/multivariate/f_increase.jl

### DIFF
--- a/test/multivariate/f_increase.jl
+++ b/test/multivariate/f_increase.jl
@@ -11,7 +11,10 @@
     for allow in [true, false]
         for alpha in [0.1, 1.0]
             k += 1
-            method = GradientDescent(linesearch=LineSearches.Static(alpha=alpha))
+            method = GradientDescent(
+                alphaguess = LineSearches.InitialStatic(alpha=alpha),
+                linesearch = LineSearches.Static(),
+            )
             opts = Optim.Options(iterations=1,allow_f_increases=allow)
             res = optimize(f, g!, [0.5], method, opts)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,7 @@ multivariate_tests = [
     "fdtime",
     "arbitrary_precision",
     "successive_f_tol",
+    "f_increase",
 ]
 multivariate_tests = map(s->"./multivariate/"*s*".jl", multivariate_tests)
 


### PR DESCRIPTION
While writing #755, I noticed that not all `multivariate/*.jl` were included in the test.  There are now 10 files there:

```console
$ ls -lh1 multivariate/*.jl | wc -l
10
```

Adding `"f_increase"` would match the number:

```console
$ grep --line-number -A11 '## other' runtests.jl
84:    ## other
85-    "array",
86-    "extrapolate",
87-    "lsthrow",
88-    "precon",
89-    "manifolds",
90-    "complex",
91-    "fdtime",
92-    "arbitrary_precision",
93-    "successive_f_tol",
94-    "f_increase",
95-]
```

I also tweaked the test to make it pass.
