### PR TITLE
Nelder mead stopping

### DIFF
--- a/docs/src/algo/nelder_mead.md
+++ b/docs/src/algo/nelder_mead.md
@@ -27,10 +27,10 @@ we can perform one of four actions: reflect, expand, contract, or shrink. Basica
 the goal is to iteratively replace the worst point with a better point. More information
 can be found in Nelder and Mead (1965), Lagarias, et al (1998) or Gao and Han (2010).
 
-The stopping rule is the same as in the original paper, and is the standard
+The stopping rules encompass that of the original paper, and is the standard
 error of the function values at the vertices. To set the tolerance level for this
 convergence criterion, set the `g_tol` level as described in the Configurable Options
-section.
+section. The solver will also stop if one of the objective function evaluations is below the `f_tol` level, or the simplex locations are within `x_tol`. 
 
 When the solver finishes, we return a minimizer which is either the centroid or one of the vertices.
 The function value at the centroid adds a function evaluation, as we need to evaluate the objection

--- a/docs/src/algo/nelder_mead.md
+++ b/docs/src/algo/nelder_mead.md
@@ -27,10 +27,13 @@ we can perform one of four actions: reflect, expand, contract, or shrink. Basica
 the goal is to iteratively replace the worst point with a better point. More information
 can be found in Nelder and Mead (1965), Lagarias, et al (1998) or Gao and Han (2010).
 
-The stopping rules encompass that of the original paper, and is the standard
+The stopping rules includes that of the original paper, and is the standard
 error of the function values at the vertices. To set the tolerance level for this
-convergence criterion, set the `g_tol` level as described in the Configurable Options
-section. The solver will also stop if one of the objective function evaluations is below the `f_tol` level, or the simplex locations are within `x_tol`. 
+convergence criterion, set the `g_abstol` level as described in the Configurable 
+Options section. The solver will also stop if one of the objective function
+evaluations is below the `f_abstol` level, or the simplex locations are within
+`x_abstol` of each other. Set `f_abstol` and `g_abstol` both to zero to
+replicate the functionality descibed in the original paper.
 
 When the solver finishes, we return a minimizer which is either the centroid or one of the vertices.
 The function value at the centroid adds a function evaluation, as we need to evaluate the objection

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -304,9 +304,9 @@ function assess_convergence(state::NelderMeadState, d, options::Options)
   of the objective function evaluated at the vertices of the simplex
   """
     g_converged = state.nm_x <= options.g_abstol
-    f_converged = state.f_lowest <= options.f_tol
+    f_converged = state.f_lowest <= options.f_abstol
     x_converged = all(all(isapprox.(state.simplex[1], i,
-      rtol=options.x_tol)) for i ∈ state.simplex[2:end])
+      rtol=options.x_reltol)) for i ∈ state.simplex[2:end])
     return x_converged, f_converged, g_converged, false
 end
 

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -299,10 +299,6 @@ pick_best_x(f_increased, state::NelderMeadState) = state.x
 pick_best_f(f_increased, state::NelderMeadState, d) = value(d)
 
 function assess_convergence(state::NelderMeadState, d, options::Options)
-    g_converged = state.nm_x <= options.g_abstol # Hijact g_converged for NM stopping criterior
-    return false, false, g_converged, false
-end
-function assess_convergence(state::NelderMeadState, d, options::Options)
   """
   Hijack options.g_abstol for a stopping criterion the standard deviation
   of the objective function evaluated at the vertices of the simplex

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -302,6 +302,17 @@ function assess_convergence(state::NelderMeadState, d, options::Options)
     g_converged = state.nm_x <= options.g_abstol # Hijact g_converged for NM stopping criterior
     return false, false, g_converged, false
 end
+function assess_convergence(state::NelderMeadState, d, options::Options)
+  """
+  Hijack options.g_abstol for a stopping criterion the standard deviation
+  of the objective function evaluated at the vertices of the simplex
+  """
+    g_converged = state.nm_x <= options.g_abstol
+    f_converged = state.f_lowest <= options.f_tol
+    x_converged = all(all(isapprox.(state.simplex[1], i,
+      rtol=options.x_tol)) for i ∈ state.simplex[2:end])
+    return x_converged, f_converged, g_converged, false
+end
 
 function initial_convergence(d, state::NelderMeadState, method::NelderMead, initial_x, options)
     nmobjective(state.f_simplex, state.m, length(initial_x)) < options.g_abstol


### PR DESCRIPTION
Nelder Mead was taking a long time to converge to a value that doesn't fall below the `f_abstol`. Also the vertices of the simplex are within `x_abstol` of each other without exiting. This pull request fixes those problems and keeps the default behaviour **only** if the default "f" and "x" tolerances are changed to zero. These pull request does not pass the test because of this, I think. 