### PR TITLE
Tr safeguards

### DIFF
--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -50,7 +50,8 @@ import LinearAlgebra: Diagonal, diag, Hermitian, Symmetric,
                       eigen, BLAS,
                       cholesky, Cholesky, # factorizations
                       I,
-                      svd
+                      svd,
+                      opnorm # for safeguards in newton trust regions
 import SparseArrays: AbstractSparseMatrix
 
 # exported functions and types

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -45,6 +45,27 @@ function calc_p!(lambda::T, min_i, n, qg, H_eig, p) where T
     return nothing
 end
 
+#==
+Returns a tuple of initial safeguarding values for λ. Newton's method might not
+work well without these safeguards when the Hessian is not positive definite.
+==#
+function initial_safeguards(H, gr, delta, lambda)
+    # equations are on p. 560 of [MORESORENSEN]
+    T = eltype(gr)
+    λS = maximum(-diag(H))
+    # they state on the first page that ||⋅|| is the Euclidean norm
+    gr_norm = norm(gr)
+    Hnorm = opnorm(H, 1)
+    λL = max(T(0), λS, gr_norm/delta - Hnorm)
+    λU = gr_norm/delta + Hnorm
+    # p. 558
+    λ = min(max(λ, λL), λU)
+    if λ ≤ λS
+        λ = max(T(1)/1000*λU, sqrt(λL*λU))
+    end
+    λ
+end
+
 # Choose a point in the trust region for the next step using
 # the interative (nearly exact) method of section 4.3 of N&W (2006).
 # This is appropriate for Hessians that you factorize quickly.
@@ -139,6 +160,9 @@ function solve_tr_subproblem!(gr,
                 s[:] = -s + tau * H_eig.vectors[:, 1]
             end
         end
+
+
+        lambda = initial_safeguards(H, gr, delta, lambda)
 
         if !hard_case
             # Algorithim 4.3 of N&W (2006), with s insted of p_l for consistency

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -59,11 +59,11 @@ function initial_safeguards(H, gr, delta, lambda)
     λL = max(T(0), λS, gr_norm/delta - Hnorm)
     λU = gr_norm/delta + Hnorm
     # p. 558
-    λ = min(max(λ, λL), λU)
-    if λ ≤ λS
-        λ = max(T(1)/1000*λU, sqrt(λL*λU))
+    lambda = min(max(lambda, λL), λU)
+    if lambda ≤ λS
+        lambda = max(T(1)/1000*λU, sqrt(λL*λU))
     end
-    λ
+    lambda
 end
 
 # Choose a point in the trust region for the next step using

--- a/test/multivariate/solvers/first_order/ngmres.jl
+++ b/test/multivariate/solvers/first_order/ngmres.jl
@@ -1,3 +1,4 @@
+using Optim, Test
 ## REMEMBER TO UPDATE TESTS FOR BOTH THE N-GMRES and the O-ACCEL TEST SETS
 
 @testset "N-GMRES" begin
@@ -6,7 +7,7 @@
 
     skip = ("Trigonometric", )
     run_optim_tests(solver; skip = skip,
-                    iteration_exceptions = (("Penalty Function I", 10000), ),
+                    iteration_exceptions = (("Penalty Function I", 10000), ("Paraboloid Random Matrix", 10000)),
                     show_name = debug_printing)
 
     # Specialized tests


### PR DESCRIPTION
Use the safeguards from Moré and Sorensen. I have this in "new optim", but thought I'd port it over. It's useful in several cases.

In the positive definite case, the un-safeguarded lambda will subtract a multiple of I from H. This is crazy since a newton step based on PD H is good, it just turned out to be outside of the trust region. If we then subtract something we'll move *further* away from the trust region boundary instead of cloesr to it!. It also tends to make the H_ridged almost singular (although not quite) - just think about the diagonal case, where this will replace an entry with something like `1e-8`! 

Beyond that, there's a chance that for very large eigenvalues, `1e-8` is below the granularity of the floating point numbers, and this can cause an actual eigenvalue to become identically 0.