### PR TITLE
Fixes for OptimTestProblems.UnconstrainedProblems

### DIFF
--- a/docs/src/algo/newton_trust_region.md
+++ b/docs/src/algo/newton_trust_region.md
@@ -52,7 +52,7 @@ Finally, we only accept a point if its decrease is appreciable compared to the q
 
 ```julia
 using Optim, OptimTestProblems
-prob = OptimTestProblems.UnconstrainedProblems.examples["Rosenbrock"];
+prob = UnconstrainedProblems.examples["Rosenbrock"];
 res = Optim.optimize(prob.f, prob.g!, prob.h!, prob.initial_x, NewtonTrustRegion())
 ```
 

--- a/docs/src/algo/ngmres.md
+++ b/docs/src/algo/ngmres.md
@@ -51,7 +51,7 @@ First, we try to optimize using `GradientDescent`.
 
 ```julia
 using Optim, OptimTestProblems
-UP = OptimTestProblems.UnconstrainedProblems
+UP = UnconstrainedProblems
 prob = UP.examples["Extended Rosenbrock"]
 optimize(UP.objective(prob), UP.gradient(prob), prob.initial_x, GradientDescent())
 ```

--- a/docs/src/algo/samin.md
+++ b/docs/src/algo/samin.md
@@ -31,7 +31,7 @@ This example shows a successful minimization:
 ```julia
 julia> using Optim, OptimTestProblems
 
-julia> prob = OptimTestProblems.UnconstrainedProblems.examples["Rosenbrock"];
+julia> prob = UnconstrainedProblems.examples["Rosenbrock"];
 
 julia> res = Optim.optimize(prob.f, fill(-100.0, 2), fill(100.0, 2), prob.initial_x, SAMIN(), Optim.Options(iterations=10^6))
 ================================================================================
@@ -70,7 +70,7 @@ rt=0.5, is too rapid:
 ```julia
 julia> using Optim, OptimTestProblems
 
-julia> prob = OptimTestProblems.UnconstrainedProblems.examples["Rosenbrock"];
+julia> prob = UnconstrainedProblems.examples["Rosenbrock"];
 julia> res = Optim.optimize(prob.f, fill(-100.0, 2), fill(100.0, 2), prob.initial_x, SAMIN(rt=0.5), Optim.Options(iterations=10^6))
 ================================================================================
 SAMIN results

--- a/docs/src/user/tipsandtricks.md
+++ b/docs/src/user/tipsandtricks.md
@@ -166,8 +166,8 @@ by all the function evaluations required to do the central finite differences ca
 ## Separating time spent in Optim's code and user provided functions
 Consider the Rosenbrock problem.
 ```julia
-using Optim
-prob = Optim.UnconstrainedProblems.examples["Rosenbrock"];
+using Optim, OptimTestProblems
+prob = UnconstrainedProblems.examples["Rosenbrock"];
 ```
 Say we optimize this function, and look at the total run time of `optimize` using
 the Newton Trust Region method, and we are surprised that it takes a long time to run.
@@ -204,8 +204,8 @@ being 1000. Alternatively, it is possible to put a soft limit on the run time of
 the optimization procedure by setting the `time_limit` keyword in the `Optim.Options`
 constructor.
 ```julia
-using Optim
-problem = Optim.UnconstrainedProblems.examples["Rosenbrock"]
+using Optim, OptimTestProblems
+problem = UnconstrainedProblems.examples["Rosenbrock"]
 
 f = problem.f
 initial_x = problem.initial_x
@@ -223,8 +223,8 @@ This will stop after about three seconds. If it is more important that we stop b
 is reached, it is possible to use a callback with a simple model for predicting how much
 time will have passed when the next iteration is over. Consider the following code
 ```julia
-using Optim
-problem = Optim.UnconstrainedProblems.examples["Rosenbrock"]
+using Optim, OptimTestProblems
+problem = UnconstrainedProblems.examples["Rosenbrock"]
 
 f = problem.f
 initial_x = problem.initial_x


### PR DESCRIPTION
All examples with UnconstrainedProblems now correctly refer to
the package OptimTestProblems.