### PR TITLE
add broken test for constrained minimum Gross-Pitaevskii

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "429524aa-4258-5aef-a3af-852621145aeb"
 version = "0.19.7"
 
 [deps]
+BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/multivariate/vortex.jl
+++ b/test/multivariate/vortex.jl
@@ -1,0 +1,64 @@
+# Find a stationary solution to the Gross-Pitaevskii equation by
+# minimizing the energy of a normalised wave function in a rotating
+# frame
+
+@testset "Gross-Pitaveskii vortex" begin
+    C = 10
+    μ = 10
+    Ω = 2*0.575
+    h = 0.2
+    N = 40
+
+    # Finite difference matrices.  ∂ on left is ∂y, ∂' on right is ∂x
+    
+    function op(stencil)
+        mid = (length(stencil)+1)÷2
+        diags = [i-mid=>fill(stencil[i],N-abs(i-mid)) for i = keys(stencil)]
+        BandedMatrix(Tuple(diags), (N,N))
+    end
+    
+    ∂ = (1/h).*op([-1/60, 3/20, -3/4, 0, 3/4, -3/20, 1/60])
+    ∂² = (1/h^2).*op([1/90, -3/20, 3/2, -49/18, 3/2, -3/20, 1/90])
+
+    y = h/2*(1-N:2:N-1)
+    x = y'
+    z = Complex.(x,y)
+    V = r² = abs2.(z)
+    
+    init = Complex.(exp.(-r²/2)/√π)
+    init = conj.(z).*init./sqrt(1 .+ r²)
+    init ./= norm(init)
+    
+    # The energy that the steady state minimizes
+    function E(ψ)
+        Lψ = -∂²*ψ-ψ*∂²+V.*ψ+C*abs2.(ψ).*ψ-1im*Ω*(y.*(ψ*∂')-x.*(∂*ψ))
+        sum(conj.(ψ).*Lψ)/norm(ψ)^2 |> real
+    end
+    
+    # The residual for the GPE, zero in a steady state
+    function rdl(ψ)
+        Lψ = -∂²*ψ-ψ*∂²+V.*ψ+C*abs2.(ψ).*ψ-1im*Ω*(y.*(ψ*∂')-x.*(∂*ψ))
+        E = sum(conj.(ψ).*Lψ)/norm(ψ)^2 |> real
+        norm(Lψ-E*ψ)/norm(ψ)
+    end
+    
+    # break out real and imaginary parts, constraint is unit sphere
+    function reconstruct(xy)
+        n = length(xy) ÷ 2
+        ψ = xy[1:n] + 1im*xy[n+1:end]
+        m = sqrt(n) |> Int
+        ψ = reshape(ψ,m,m)
+    end
+    
+    # norm taken from SOR solution
+    cost(xy) = E(20.31*reconstruct(xy))
+    
+    result = optimize(cost, [real.(init[:]); imag.(init[:])], NelderMead(manifold=Sphere()))
+    ψ₂ = 20.31*reconstruct(result.minimizer)
+    
+    # 3000 steps of successive over-relaxation gets a residual of 1e-3.
+    # The default settings in Optim should beat that.
+    
+    @test_broken rdl(ψ₂) < 1e-3
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,13 @@ import NLSolversBase
 import NLSolversBase: clear!
 import LinearAlgebra: norm, diag, I, Diagonal, dot, eigen, issymmetric, mul!
 import SparseArrays: normalize!, spdiagm
+import BandedMatrices
+import BandedMatrices: BandedMatrix
 
 debug_printing = false
+
+        println("Vortex")
+        @time include("multivariate/vortex.jl)
 
 special_tests = [
     "bigfloat/initial_convergence",
@@ -91,6 +96,7 @@ multivariate_tests = [
     "arbitrary_precision",
     "successive_f_tol",
     "f_increase",
+    "vortex",
 ]
 multivariate_tests = map(s->"./multivariate/"*s*".jl", multivariate_tests)
 


### PR DESCRIPTION
I'm working on ground states for Bose-Einstein condensates.  Antoine Levitt has been encouraging me to explore using the constrained optimisation routines in Optim to find minimum-energy solutions of the Gross-Pitaevskii equation.

The obvious way doesn't work, so I'm submitting it as a broken test case.

I would welcome advice on how to make these modifications:

1. I considered contributing this to OptimTestProblems, but I don't know how to start.

2. BandedMatrices should be added as a test dependency, but again I don't know how that works.

3. I expect that it would be helpful to provide a solution, not just the problem.  My first thought is to put a numerical solution in a JLD file, and an @assert in vortex.jl to show that it solves the problem.  Is there a better way?