### PR TITLE
Breaking tests with Complex input

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -239,7 +239,8 @@ function Base.show(io::IO, r::MultivariateOptimizationResults)
 
     @printf io " * Candidate solution\n"
     nx = length(minimizer(r))
-    str_x_elements = [@sprintf "%.2e" _x for _x in take(minimizer(r), min(nx, 3))]
+    str_x_elements = [repr(_x, context=:compact => true)
+        for _x in take(minimizer(r), min(nx, 3))]
     if nx >= 4
         push!(str_x_elements, " ...")
     end
@@ -252,7 +253,8 @@ function Base.show(io::IO, r::MultivariateOptimizationResults)
     @printf io " * Found with\n"
     @printf io "    Algorithm:     %s\n" summary(r)
     nx = length(initial_state(r))
-    str_x_elements = [@sprintf "%.2e" _x for _x in take(initial_state(r), min(nx, 3))]
+    str_x_elements = [repr(_x, context=:compact => true)
+        for _x in take(initial_state(r), min(nx, 3))]
     if nx >= 4
         push!(str_x_elements, " ...")
     end

--- a/test/general/complex.jl
+++ b/test/general/complex.jl
@@ -1,0 +1,11 @@
+# Regression tests for features that forgot about complex numbers
+
+@testset "display complex result" begin
+    grdt!(buf,u) = copyto!(buf, 2u)
+    result = optimize(z->abs2.(z)[], grdt!, Complex.(randn(1)), ConjugateGradient())
+    @test repr(result) isa String
+end
+
+@testset "default solver accepts complex" begin
+    @test optimize(z->abs2.(z)[], Complex.(randn(1)))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using Test
 using Optim
+
+include("general/complex.jl")
+
 using OptimTestProblems
 using OptimTestProblems.MultivariateProblems
 const MVP = MultivariateProblems


### PR DESCRIPTION
This adds two tests, that currently throw errors for the following reasons:

1. (I think) The `show` or `repr` method for solutions tries to `@printf` complex numbers.

2. The default solver attempts to sort complex numbers.
