### PR TITLE
Normalized multidimensional arrays

### DIFF
--- a/docs/src/algo/manifolds.md
+++ b/docs/src/algo/manifolds.md
@@ -20,7 +20,7 @@ All first-order optimization methods are supported.
 
 The following manifolds are currently supported:
 * Flat: Euclidean space, default. Standard unconstrained optimization.
-* Sphere: spherical constraint `||x|| = 1`
+* Sphere: spherical constraint `||x|| = 1`, where `x` is a real or complex array of any dimension.
 * Stiefel: Stiefel manifold of N by n matrices with orthogonal columns, i.e. `X'*X = I`
 
 The following meta-manifolds construct manifolds out of pre-existing ones:

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -66,7 +66,8 @@ project_tangent!(M::Flat, g, x) = g
 """Spherical manifold {|x| = 1}."""
 struct Sphere <: Manifold
 end
-retract!(S::Sphere, x) = normalize!(x)
+retract!(S::Sphere, x) = (x ./= norm(x))
+# dot accepts any iterables
 project_tangent!(S::Sphere,g,x) = (g .-= real(dot(x,g)).*x)
 
 """

--- a/test/multivariate/array.jl
+++ b/test/multivariate/array.jl
@@ -1,3 +1,10 @@
+@testset "normalized array" begin
+    grdt!(buf, _) = (buf .= 0; buf[1] = 1; buf)
+    result = optimize(x->x[1], grdt!, randn(2,2), ConjugateGradient(manifold=Sphere()))
+    @test result.minimizer ≈ [-1 0; 0 0]
+    @test result.minimum ≈ -1
+end
+
 @testset "input types" begin
     f(X) = (10 - X[1])^2 + (0 - X[2])^2 + (0 - X[3])^2 + (5 - X[4])^2
 


### PR DESCRIPTION
The option `Manifold=sphere()` is supposed to handle multidimensional arrays.  This adds a failing test as a reminder that it doesn't yet.