### PR TITLE
Enable CI on Julia 1.2 and 1.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
     - osx
 julia:
     - 1.0
+    - 1.2
+    - 1.3
     - nightly
 matrix:
   allow_failures:


### PR DESCRIPTION
It looks like some issues specific to more recent versions of Julia have sneaked in so I'll open a separate issue here to reveal them and hopefully also resolve them.