### PR TITLE
Use Compat for `dot(x, P, y)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "429524aa-4258-5aef-a3af-852621145aeb"
 version = "0.20.1"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -15,6 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+Compat = "3.2"
 FillArrays = "0.6.2, 0.7, 0.8"
 LineSearches = "7.0.1"
 NLSolversBase = "7.3.1"
@@ -28,8 +30,7 @@ julia = "1"
 OptimTestProblems = "cec144fc-5a64-5bc6-99fb-dde8f63e154c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "OptimTestProblems", "Suppressor", "Random", "RecursiveArrayTools"]
+test = ["Test", "OptimTestProblems", "Random", "RecursiveArrayTools"]

--- a/docs/src/examples/ipnewton_basics.jl
+++ b/docs/src/examples/ipnewton_basics.jl
@@ -166,11 +166,9 @@ res = optimize(df, dfc, x0, IPNewton())
 lc = [0.1^2]
 dfc = TwiceDifferentiableConstraints(con_c!, con_jacobian!, con_h!,
                                      lx, ux, lc, uc)
-@suppress begin                               #src
 res = optimize(df, dfc, x0, IPNewton())
 @test Optim.converged(res)                    #src
 @test Optim.minimum(res) ≈ 0.2966215688829255 #src
-end                                           #src
 
 
 # **Note that the algorithm warns that the Initial guess is not an

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -15,6 +15,8 @@ Besides the help provided at the REPL, it is possible to find help and general
 documentation online at http://julianlsolvers.github.io/Optim.jl/stable/ .
 """
 module Optim
+using Compat                 # for dot(x, P, y) on older Julia versions
+
 using NLSolversBase          # for shared infrastructure in JuliaNLSolvers
 
 using PositiveFactorizations # for globalization strategy in Newton

--- a/src/multivariate/precon.jl
+++ b/src/multivariate/precon.jl
@@ -6,9 +6,6 @@
 #        ldiv!(x, P, b) ->  x = P \ b
 #        dot(x, P, b)  ->  x' P b
 #
-#    If `dot` is not provided, then Optim.jl will try to define it via
-#        dot(x, P, b) = dot(x, mul!(similar(x), P, y))
-#
 #    finally the preconditioner can be updated after each x-update using
 #        precondprep!
 #    but this is passed as an argument at the moment!
@@ -18,11 +15,6 @@
 #####################################################
 #  [0] Defaults and aliases for easier reading of the code
 #      these can also be over-written if necessary.
-
-if VERSION < v"1.4.0-DEV.92"
-# an inner product w.r.t. a metric P (=preconditioner)
-    dot(x, P, y) = dot(x, mul!(similar(x), P, y))
-end
 
 # default preconditioner update
 precondprep!(P, x) = nothing
@@ -45,9 +37,6 @@ dot(A, ::Nothing, B) = dot(A, B)
 #      ldiv!(a, P, b) or mul! for this type, so we do it by hand
 #      TODO: maybe implement this in Base
 ldiv!(out::Array, P::Diagonal, A::Array) = copyto!(out, A ./ P.diag)
-if VERSION < v"1.4.0-DEV.92"
-    dot(A::Array, P::Diagonal, B::Array) = dot(A, P.diag .* B)
-end
 
 #####################################################
 #  [3] Inverse Diagonal preconditioner

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,0 @@
-OptimTestProblems 1.2
-RecursiveArrayTools
-Suppressor

--- a/test/multivariate/solvers/constrained/ipnewton/constraints.jl
+++ b/test/multivariate/solvers/constrained/ipnewton/constraints.jl
@@ -532,19 +532,17 @@
         @test Optim.minimum(results) < minval + sqrt(eps(minval))
 
         # Test the tracing
-        @suppress_out begin
-            # TODO: Update this when show_linesearch becomes part of Optim.Options
-            method = IPNewton(show_linesearch = true)
-            options = Optim.Options(iterations = 2,
-                              show_trace = true, extended_trace=true, store_trace = true;
-                              Optim.default_options(method)...)
-            results = optimize(df,constraints, [12, 14.0], method, options)
+        # TODO: Update this when show_linesearch becomes part of Optim.Options
+        method = IPNewton(show_linesearch = true)
+        options = Optim.Options(iterations = 2,
+                                show_trace = true, extended_trace=true, store_trace = true;
+                                Optim.default_options(method)...)
+        results = optimize(df,constraints, [12, 14.0], method, options)
 
-            io = IOBuffer()
-            show(io, results.trace)
-            @test startswith(String(take!(io)), "Iter     Lagrangian value Function value   Gradient norm    |==constr.|      μ\n------   ---------------- --------------   --------------   --------------   --------\n")
-        end
-
+        io = IOBuffer()
+        show(io, results.trace)
+        @test startswith(String(take!(io)), "Iter     Lagrangian value Function value   Gradient norm    |==constr.|      μ\n------   ---------------- --------------   --------------   --------------   --------\n")
+        
         # TODO: Add test where we start with an infeasible point
     end
 end

--- a/test/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/test/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -27,11 +27,9 @@
     res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles),
                              options)
     @test norm(Optim.minimizer(res) - [1.0, 1.0]) < 0.1
-    @suppress_out begin
-        options = Optim.Options(iterations=300, show_trace=true, extended_trace=true, store_trace=true)
-        res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles), options)
-        @test summary(res) == "Particle Swarm"
-        res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(n_particles = n_particles), options)
-        @test summary(res) == "Particle Swarm"
-    end
+    options = Optim.Options(iterations=300, show_trace=true, extended_trace=true, store_trace=true)
+    res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(lower, upper, n_particles), options)
+    @test summary(res) == "Particle Swarm"
+    res = Optim.optimize(rosenbrock_s, initial_x, ParticleSwarm(n_particles = n_particles), options)
+    @test summary(res) == "Particle Swarm"
 end

--- a/test/multivariate/solvers/zeroth_order/simulated_annealing.jl
+++ b/test/multivariate/solvers/zeroth_order/simulated_annealing.jl
@@ -15,8 +15,6 @@
     results = Optim.optimize(rosenbrock_s, [0.0, 0.0], SimulatedAnnealing(), options)
     @test norm(Optim.minimizer(results) - [1.0, 1.0]) < 0.1
 
-    @suppress_out begin
-        options = Optim.Options(iterations=10, show_trace=true, store_trace=true, extended_trace=true)
-        results = Optim.optimize(rosenbrock_s, [0.0, 0.0], SimulatedAnnealing(), options)
-    end
+    options = Optim.Options(iterations=10, show_trace=true, store_trace=true, extended_trace=true)
+    results = Optim.optimize(rosenbrock_s, [0.0, 0.0], SimulatedAnnealing(), options)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@ using OptimTestProblems
 using OptimTestProblems.MultivariateProblems
 const MVP = MultivariateProblems
 
-using Suppressor
 import PositiveFactorizations: Positive, cholesky # for the IPNewton tests
 using Random
 


### PR DESCRIPTION
This PR replaces the custom fixes for `dot(x, P, Y)` on older Julia versions with the fixes provided by Compat to avoid warnings such as
```julia
WARNING: Method definition dot(Any, Any, Any) in module Compat at /home/travis/.julia/packages/Compat/if8Gv/src/Compat.jl:111 overwritten in module Optim at /home/travis/.julia/packages/Optim/SFpsz/src/multivariate/precon.jl:24
```
with Compat >= 3.2 (see, e.g., [Travis CI tests for MCMCChains](https://travis-ci.org/TuringLang/MCMCChains.jl/jobs/649969906#L438)).

When testing locally Pkg could not resolve the dependencies correctly due to some bound on Compat introduced by Suppressor, hence I removed Suppressor (Suppressor still only uses a REQUIRE file, maybe that's an issue as well?). If the output of the tests seems to be too verbose now, one could maybe adjust the keyword arguments to not print all traces?