### PR TITLE
Support creation of `TwiceDifferentiable` from `IPNewton` methods

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,8 @@ cp(joinpath(@__DIR__, "..", "LICENSE.md"),
 
 #run('mv ../CONTRIBUTING.md ./dev/CONTRIBUTING.md') # TODO: Should we use the $odir/CONTRIBUTING.md file instead?
 makedocs(
-    doctest = false
+    doctest = false,
+    sitename = "Optim"
 )
 
 deploydocs(

--- a/docs/src/examples/ipnewton_basics.jl
+++ b/docs/src/examples/ipnewton_basics.jl
@@ -77,6 +77,9 @@ using Test                 #src
 @test Optim.converged(res)      #src
 @test Optim.minimum(res) ≈ 0.25 #src
 
+# Like the rest of Optim, you can also use `autodiff=:forward` and just pass in
+# `fun`.
+
 # If we only want to set lower bounds, use `ux = fill(Inf, 2)`
 
 ux = fill(Inf, 2)

--- a/src/multivariate/optimize/interface.jl
+++ b/src/multivariate/optimize/interface.jl
@@ -115,6 +115,12 @@ function optimize(f, initial_x::AbstractArray, method::AbstractOptimizer,
     d = promote_objtype(method, initial_x, autodiff, inplace, f)
     optimize(d, initial_x, method, options)
 end
+function optimize(f, c::AbstractConstraints, initial_x::AbstractArray, method::AbstractOptimizer,
+                     options::Options = Options(;default_options(method)...); inplace = true, autodiff = :finite)
+
+    d = promote_objtype(method, initial_x, autodiff, inplace, f)
+    optimize(d, c, initial_x, method, options)
+end
 function optimize(f, g, initial_x::AbstractArray, method::AbstractOptimizer,
          options::Options = Options(;default_options(method)...); inplace = true, autodiff = :finite)
 

--- a/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl
+++ b/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl
@@ -7,6 +7,10 @@ end
 
 Base.summary(::IPNewton) = "Interior Point Newton"
 
+promote_objtype(method::IPNewton, x, autodiff::Symbol, inplace::Bool, f) = TwiceDifferentiable(f, x, real(zero(eltype(x))); autodiff = autodiff)
+promote_objtype(method::IPNewton, x, autodiff::Symbol, inplace::Bool, f, g) = TwiceDifferentiable(f, g, x, real(zero(eltype(x))); inplace = inplace, autodiff = autodiff)
+promote_objtype(method::IPNewton, x, autodiff::Symbol, inplace::Bool, f, g, h) = TwiceDifferentiable(f, g, h, x, real(zero(eltype(x))); inplace = inplace)
+
 # TODO: Add support for InitialGuess from LineSearches
 """
 # Interior-point Newton

--- a/test/multivariate/solvers/constrained/ipnewton/constraints.jl
+++ b/test/multivariate/solvers/constrained/ipnewton/constraints.jl
@@ -507,6 +507,11 @@
             debug_printing && printstyled("f-calls: $(Optim.f_calls(results))\n", color=:red)
             debug_printing && printstyled("g-calls: $(Optim.g_calls(results))\n", color=:red)
             debug_printing && printstyled("h-calls: $(Optim.h_calls(results))\n", color=:red)
+
+            results = optimize(MVP.objective(prob),constraints, prob.initial_x, method, options)
+            @test isa(summary(results), String)
+            @test Optim.converged(results)
+            @test Optim.minimum(results) < minval + sqrt(eps(minval))
         end
 
         # Test constraints on both x and c


### PR DESCRIPTION
This just adds a couple of convenience methods. CC @ChantalJuntao.

I also found I needed to add `sitename` to get the docs to build. Not sure if you want that or not, but I thought I'd offer. Happy to strip that commit from the PR if necessary.