### PR TITLE
Fix minor bugs

### DIFF
--- a/joss/Makefile
+++ b/joss/Makefile
@@ -3,7 +3,7 @@ all: paper.pdf
 paper.pdf: paper.md paper.bib latex.template
 	pandoc --filter pandoc-citeproc --bibliography paper.bib  paper.md \
   --template latex.template -o paper.pdf \
-  --latex-engine=xelatex
+  --pdf-engine=xelatex
 
 clean:
 	rm paper.pdf

--- a/src/api.jl
+++ b/src/api.jl
@@ -33,6 +33,7 @@ function x_trace(r::MultivariateOptimizationResults)
 end
 
 function centroid_trace(r::MultivariateOptimizationResults)
+    tr = trace(r)
     if !isa(r.method, NelderMead)
         throw(ArgumentError("There is no centroid involved in optimization using $(r.method). Please use x_trace(...) to grab the points from the trace."))
     end
@@ -40,6 +41,7 @@ function centroid_trace(r::MultivariateOptimizationResults)
     [ state.metadata["centroid"] for state in tr ]
 end
 function simplex_trace(r::MultivariateOptimizationResults)
+    tr = trace(r)
     if !isa(r.method, NelderMead)
         throw(ArgumentError("There is no simplex involved in optimization using $(r.method). Please use x_trace(...) to grab the points from the trace."))
     end


### PR DESCRIPTION
Fixes the following two (unrelated) bugs:
1. simplex_trace and centroid_trace functions are missing call to trace method
2. pandoc has replaced --latex-engine flag with --pdf-engine