### PR TITLE
Don't use Function signatures.

### DIFF
--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -42,7 +42,7 @@
 #   below.  The default value for alphamax is Inf. See alphamaxfunc
 #   for cgdescent and alphamax for linesearch_hz.
 
-struct ConjugateGradient{Tf, T, Tprep<:Union{Function, Nothing}, IL, L} <: FirstOrderOptimizer
+struct ConjugateGradient{Tf, T, Tprep, IL, L} <: FirstOrderOptimizer
     eta::Tf
     P::T
     precondprep!::Tprep

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -1,4 +1,4 @@
-struct GradientDescent{IL, L, T, Tprep<:Union{Function, Nothing}} <: FirstOrderOptimizer
+struct GradientDescent{IL, L, T, Tprep} <: FirstOrderOptimizer
     alphaguess!::IL
     linesearch!::L
     P::T

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -77,7 +77,7 @@ function twoloop!(s,
     return
 end
 
-struct LBFGS{T, IL, L, Tprep<:Union{Function, Nothing}} <: FirstOrderOptimizer
+struct LBFGS{T, IL, L, Tprep} <: FirstOrderOptimizer
     m::Int
     alphaguess!::IL
     linesearch!::L

--- a/src/univariate/optimize/interface.jl
+++ b/src/univariate/optimize/interface.jl
@@ -1,26 +1,26 @@
 # Univariate Options
-function optimize(f::F,
+function optimize(f,
      lower::T,
      upper::T;
      method = Brent(),
-     rel_tol::Real = sqrt(eps(T)),
-     abs_tol::Real = eps(T),
+     rel_tol::Real = sqrt(eps(float(T))),
+     abs_tol::Real = eps(float(T)),
      iterations::Integer = 1_000,
      store_trace::Bool = false,
      show_trace::Bool = false,
      callback = nothing,
      show_every = 1,
-     extended_trace::Bool = false) where {F<:Function, T <: AbstractFloat}
+     extended_trace::Bool = false) where T <: Real
     show_every = show_every > 0 ? show_every : 1
-    if extended_trace && callback == nothing
+    if extended_trace && callback === nothing
         show_trace = true
     end
 
     show_trace && print_header(method)
-
-    optimize(f, lower, upper, method;
-             rel_tol = T(rel_tol),
-             abs_tol = T(abs_tol),
+    Tf = float(T)
+    optimize(f, Tf(lower), Tf(upper), method;
+             rel_tol = Tf(rel_tol),
+             abs_tol = Tf(abs_tol),
              iterations = iterations,
              store_trace = store_trace,
              show_trace = show_trace,
@@ -29,10 +29,10 @@ function optimize(f::F,
              extended_trace = extended_trace)
 end
 
-function optimize(f::F,
+function optimize(f,
     lower::Union{Integer, Real},
     upper::Union{Integer, Real};
-    kwargs...) where F<:Function
+    kwargs...)
      
     T = promote_type(typeof(lower/1), typeof(upper/1))
     optimize(f,
@@ -41,11 +41,11 @@ function optimize(f::F,
              kwargs...)
 end
 
-function optimize(f::F,
+function optimize(f,
     lower::Union{Integer, Real},
     upper::Union{Integer, Real},
     method::Union{Brent, GoldenSection};
-    kwargs...) where F<:Function
+    kwargs...)
      
     T = promote_type(typeof(lower/1), typeof(upper/1))
     optimize(f,

--- a/src/univariate/solvers/brent.jl
+++ b/src/univariate/solvers/brent.jl
@@ -21,7 +21,7 @@ struct Brent <: UnivariateOptimizer end
 Base.summary(::Brent) = "Brent's Method"
 
 function optimize(
-        f::F, x_lower::T, x_upper::T,
+        f, x_lower::T, x_upper::T,
         mo::Brent;
         rel_tol::T = sqrt(eps(T)),
         abs_tol::T = eps(T),
@@ -30,7 +30,7 @@ function optimize(
         show_trace::Bool = false,
         callback = nothing,
         show_every = 1,
-        extended_trace::Bool = false) where {F <: Function, T <: AbstractFloat}
+        extended_trace::Bool = false) where T <: AbstractFloat
     t0 = time()
     options = (store_trace=store_trace, show_trace=show_trace, show_every=show_every, callback=callback)
     if x_lower > x_upper

--- a/src/univariate/solvers/golden_section.jl
+++ b/src/univariate/solvers/golden_section.jl
@@ -18,7 +18,7 @@ struct GoldenSection <: UnivariateOptimizer end
 
 Base.summary(::GoldenSection) = "Golden Section Search"
 
-function optimize(f::F, x_lower::T, x_upper::T,
+function optimize(f, x_lower::T, x_upper::T,
      mo::GoldenSection;
      rel_tol::T = sqrt(eps(T)),
      abs_tol::T = eps(T),
@@ -28,7 +28,7 @@ function optimize(f::F, x_lower::T, x_upper::T,
      callback = nothing,
      show_every = 1,
      extended_trace::Bool = false,
-     nargs...) where {F<:Function, T <: AbstractFloat}
+     nargs...) where T <: AbstractFloat
     if x_lower > x_upper
         error("x_lower must be less than x_upper")
     end

--- a/test/univariate/optimize/interface.jl
+++ b/test/univariate/optimize/interface.jl
@@ -1,0 +1,24 @@
+@testset "#853" begin
+
+"Model parameter"
+struct yObj
+  p
+end
+
+"Univariable Functor"
+function (s::yObj)(x)
+  return x*s.p
+end
+
+"Multivariable Functor with array input"
+function (s::yObj)(x_v)
+  return x_v[1]*s.p
+end
+
+
+model = yObj(1.0)
+
+Optim.optimize(model, -1, 2, [1.]) # already worked
+Optim.optimize(model, -1, 2) # didn't work
+Optim.optimize(model, -1., 2.) # didn't work
+end


### PR DESCRIPTION
Fixes #853 

Some methods still have Function annotations left over form waay back where `Function` covered most the things that were "callable".