### PR TITLE
Adding support for Manifolds to Nelder-Mead

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Improve handling of alternative number types in univariate optimization
 * Add conditional likelihood example to docs
 * Improve Fminbox trace printing.
+* Support for manifolds in NelderMead.
 
 # Optim v0.17.2 release notes
 * Fix some typos

--- a/docs/src/algo/manifolds.md
+++ b/docs/src/algo/manifolds.md
@@ -29,7 +29,7 @@ The following meta-manifolds construct manifolds out of pre-existing ones:
 
 See `test/multivariate/manifolds.jl` for usage examples.
 
-Implementing new manifolds is as simple as adding methods `project_tangent!(M::YourManifold,g,x)` and `retract!(M::YourManifold,x)`. If you implement another manifold or optimization method, please contribute a PR!
+Implementing new manifolds is as simple as adding methods `project_tangent!(M::YourManifold,g,x)` and `retract!(M::YourManifold,x)`.  Nedler-Mead only requires `retract!`. If you implement another manifold or optimization method, please contribute a PR!
 
 ## References
 The Geometry of Algorithms with Orthogonality Constraints, Alan Edelman, Tomás A. Arias, Steven T. Smith, SIAM. J. Matrix Anal. & Appl., 20(2), 303–353

--- a/docs/src/algo/nelder_mead.md
+++ b/docs/src/algo/nelder_mead.md
@@ -3,7 +3,8 @@ Nelder-Mead is currently the standard algorithm when no derivatives are provided
 ## Constructor
 ```julia
 NelderMead(; parameters = AdaptiveParameters(),
-             initial_simplex = AffineSimplexer())
+             initial_simplex = AffineSimplexer(),
+             manifold = Flat())
 ```
 The keywords in the constructor are used to control the following parts of the
 solver:

--- a/test/multivariate/manifolds.jl
+++ b/test/multivariate/manifolds.jl
@@ -55,3 +55,11 @@
         @test minpow[:,2] == minprod[n+1:2n]
     end
 end
+
+@testset "Manifolds zeroth_order" begin
+    A = ones(2,2)    
+    fmanif(x) = dot(x,A*x)
+    res = Optim.optimize(fmanif, [1.0;0.0], NelderMead(manifold=Optim.Sphere()))
+    @test Optim.converged(res)
+    @test Optim.minimum(res) < 1e-3
+end


### PR DESCRIPTION
I did this in the obvious way: retract! is applied to every vector created by Nelder-Mead. I have found this very useful for doing optimization over complicated manifolds. I used to handle optimizations of this sort by using an objective function of the form x -> obj( retract (x)).  But, this causes Nelder-Mead to operate in the wrong space. Using the manifold approach has sped up some of my code a lot, and has allowed it to converge in situations that failed before.
