### PR TITLE
Loosen types with ldiv! and dot of InverseDiagonal

### DIFF
--- a/src/multivariate/precon.jl
+++ b/src/multivariate/precon.jl
@@ -51,8 +51,8 @@ end
 mutable struct InverseDiagonal
    diag
 end
-ldiv!(out::Array, P::InverseDiagonal, A::Array) = copyto!(out, A .* P.diag)
-dot(A::Array, P::InverseDiagonal, B::Vector) = dot(A, B ./ P.diag)
+ldiv!(out::AbstractArray, P::InverseDiagonal, A::AbstractArray) = copyto!(out, A .* P.diag)
+dot(A::AbstractArray, P::InverseDiagonal, B::AbstractVector) = dot(A, B ./ P.diag)
 
 #####################################################
 #  [4] Matrix Preconditioner


### PR DESCRIPTION
All that was required to make [this example](https://discourse.julialang.org/t/nonlinear-optimization-help-optim-jump-something-else/47163/2) work was to patch in a method for `ldiv!`. Loosening this type restriction should let even more array types work here. I've tested this and it doesn't look like it introduces any method ambiguities.