### PR TITLE
Provide overoading point for arrays with custom axes

### DIFF
--- a/src/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/src/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -104,9 +104,9 @@ function initial_state(method::ParticleSwarm, options, d, initial_x::AbstractArr
     c2 = T(2)
     w = T(1)
 
-    X = Array{T,2}(undef, n, n_particles)
-    V = Array{T,2}(undef, n, n_particles)
-    X_best = Array{T,2}(undef, n, n_particles)
+    X = similar_axis(initial_x, n_particles)
+    V = similar_axis(initial_x, n_particles)
+    X_best = similar_axis(initial_x, n_particles)
     dx = zeros(T, n)
     score = zeros(T, n_particles)
     x = copy(initial_x)
@@ -465,11 +465,20 @@ end
 
 function compute_cost!(f,
                        n_particles::Int,
-                       X::Matrix,
+                       X::AbstractMatrix,
                        score::Vector)
 
     for i in 1:n_particles
         score[i] = value(f, X[:, i])
     end
     nothing
+end
+
+"""
+    similar_axis(x, n_particles)
+
+Equivalent to `Base.similar(x, length(x), n_particles)` for `x::Array`. Provide a method of this function to preserve a special axis for subtypes of `AbstractArray`.
+"""
+function similar_axis(x, n_particles)
+    similar(x, length(x), n_particles)
 end


### PR DESCRIPTION
This PR adds a function that can be overloaded for arrays with custom axes, so that these axes are preserved in the `ParticleSwarm`optimization algorithm. The particular use case I have in mind is to formulate my objective function using ComponentArrays.jl, this works for most optimizers, but not for `ParticleSwarm` This PR introduces the function `similar_axes` that can be defined for custom arrays to do something sensible, e.g.,
```julia
julia> Optim.similar_axis(x::ComponentArray, n) = x .* zeros(length(x), n)

julia> a
ComponentVector{Float64}(a = [0.0, 0.0], b = [1.0, 1.0])

julia> f(x) = sum(abs2, x.a)+sum(abs, x.b)
f

julia> optimize(f, a, ParticleSwarm())
 * Status: failure (reached maximum number of iterations)

 * Candidate solution
    Final objective value:     5.214465e-84

 * Found with
    Algorithm:     Particle Swarm

 * Convergence measures
    |x - x'|               = NaN ≰ 0.0e+00
    |x - x'|/|x'|          = NaN ≰ 0.0e+00
    |f(x) - f(x')|         = NaN ≰ 0.0e+00
    |f(x) - f(x')|/|f(x')| = NaN ≰ 0.0e+00
    |g(x)|                 = NaN ≰ 1.0e-08

 * Work counters
    Seconds run:   0  (vs limit Inf)
    Iterations:    1000
    f(x) calls:    5001
    ∇f(x) calls:   0


```