### PR TITLE
Create CompatHelper.yml

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: '00 00 * * *'
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}  # optional
+        run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
Adds the CompatHelper GitHub action workflow to automatically create PRs when a dependency gets a new version that is not covered by the compact section of Optim's `Project.toml`.

I realized adding Optim to a project recently that FillArrays compact was not up to date
```julia
↓ FillArrays v0.10.1 ⇒ v0.9.7
```
and then saw that Optim.jl had no CompatHelper workflow. So this PR adds it, although you will have to [add the secrets](https://github.com/JuliaRegistries/CompatHelper.jl#12-set-up-the-ssh-deploy-key-optional) yourself for this to work I think 😄 