### PR TITLE
Change order of ldiv and - in sparse Newton.

### DIFF
--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -62,7 +62,7 @@ function update_state!(d, state::NewtonState, method::Newton)
     T = eltype(state.x)
 
     if typeof(NLSolversBase.hessian(d)) <: AbstractSparseMatrix
-        state.s .= -NLSolversBase.hessian(d)\convert(Vector{T}, gradient(d))
+        state.s .= .-(NLSolversBase.hessian(d)\convert(Vector{T}, gradient(d)))
     else
         state.F = cholesky!(Positive, NLSolversBase.hessian(d))
         if typeof(gradient(d)) <: Array


### PR DESCRIPTION
Negating the search direction instead of the whole hessian saves some 
computation and allocations.