### PR TITLE
relax type constraints to support Measurements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,10 +27,11 @@ StatsBase = "0.29, 0.30, 0.31, 0.32, 0.33"
 julia = "1.2"
 
 [extras]
+Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 OptimTestProblems = "cec144fc-5a64-5bc6-99fb-dde8f63e154c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "OptimTestProblems", "Random", "RecursiveArrayTools"]
+test = ["Test", "Measurements", "OptimTestProblems", "Random", "RecursiveArrayTools"]

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -101,7 +101,7 @@ function optimize(d::D, initial_x::Tx, method::M,
                  time_limit=stopped_by_time_limit,
                  callback=stopped_by_callback,
                  f_increased=f_incr_pick)
-    return MultivariateOptimizationResults{typeof(method),T,Tx,typeof(x_abschange(state)),Tf,typeof(tr), Bool, typeof(stopped_by)}(method,
+    return MultivariateOptimizationResults{typeof(method),Tx,typeof(x_abschange(state)),Tf,typeof(tr), Bool, typeof(stopped_by)}(method,
                                         initial_x,
                                         pick_best_x(f_incr_pick, state),
                                         pick_best_f(f_incr_pick, state, d),

--- a/src/types.jl
+++ b/src/types.jl
@@ -163,7 +163,7 @@ const OptimizationTrace{Tf, T} = Vector{OptimizationState{Tf, T}}
 
 abstract type OptimizationResults end
 
-mutable struct MultivariateOptimizationResults{O, T, Tx, Tc, Tf, M, Tls, Tsb} <: OptimizationResults
+mutable struct MultivariateOptimizationResults{O, Tx, Tc, Tf, M, Tls, Tsb} <: OptimizationResults
     method::O
     initial_x::Tx
     minimizer::Tx
@@ -171,17 +171,17 @@ mutable struct MultivariateOptimizationResults{O, T, Tx, Tc, Tf, M, Tls, Tsb} <:
     iterations::Int
     iteration_converged::Bool
     x_converged::Bool
-    x_abstol::T
-    x_reltol::T
+    x_abstol::Tf
+    x_reltol::Tf
     x_abschange::Tc
     x_relchange::Tc
     f_converged::Bool
-    f_abstol::T
-    f_reltol::T
+    f_abstol::Tf
+    f_reltol::Tf
     f_abschange::Tc
     f_relchange::Tc
     g_converged::Bool
-    g_abstol::T
+    g_abstol::Tf
     g_residual::Tc
     f_increased::Bool
     trace::M

--- a/test/multivariate/measurements.jl
+++ b/test/multivariate/measurements.jl
@@ -1,0 +1,13 @@
+import Measurements
+@testset "Measurements+Optim" begin
+    #example problem in #823
+    f(x)=(1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+    xmes=zeros(Measurements.Measurement{Float64},2)
+    xfloat = zeros(2)
+    resmes = optimize(f,xmes)
+    resfloat = optimize(f,xfloat)
+    #given an initial value, they should give the exact same answer
+    @test all(Optim.minimizer(resmes) .|> Measurements.value .== Optim.minimizer(resfloat))
+    @test Optim.minimum(resmes) .|> Measurements.value .== Optim.minimum(resfloat)
+    
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,7 @@ multivariate_tests = [
     "arbitrary_precision",
     "successive_f_tol",
     "f_increase",
+    "measurements",
 ]
 multivariate_tests = map(s->"./multivariate/"*s*".jl", multivariate_tests)
 


### PR DESCRIPTION
paves the way to use Optim with Measurements. calculations runs and seems to propagate the uncertainty. fixes #823 . fixing the show problem could be done in two ways:
- trying to use other way of formatting numbers, compatible with `Measurements`.
- displaying only the value. this can be done on a two liner:
```
using Printf,Measurements
Printf.tofloat(x::Measurement) = Printf.tofloat(Measurements.value(x))
```
if the user doesnt want to do this, they can directly use Optim.minimizer(res) or Optim.minimum(res) and not show the summary of the optimization procedure.
as this type relaxation doesnt seem to affect other number types, this is an strict improvement over the current situation.