### PR TITLE
BFGS GPU Support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PositiveFactorizations = "85a6dd25-e78a-55b7-8502-1745935b8125"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PositiveFactorizations = "85a6dd25-e78a-55b7-8502-1745935b8125"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -49,6 +49,7 @@ import LinearAlgebra
 import LinearAlgebra: Diagonal, diag, Hermitian, Symmetric,
                       rmul!, mul!,
                       norm, normalize!,
+                      diagind,
                       eigen, BLAS,
                       cholesky, Cholesky, # factorizations
                       I,

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -69,10 +69,10 @@ function reset!(method, state::BFGSState, obj, x)
         zx = zero(x)
         if method.initial_stepnorm == nothing
             # Identity matrix of size n x n
-            state.invH = zx * zx' + I
+            state.invH = fill!(similar(x, (n ,n)), 0) + I
         else
             initial_scale = T(method.initial_stepnorm) * inv(norm(gradient(d), Inf))
-            state.invH = zx * zx' + initial_scale * I
+            state.invH = fill!(similar(x, (n ,n)), 0) + initial_scale * I
         end
     else
         state.invH .= method.initial_invH(x)
@@ -89,13 +89,12 @@ function initial_state(method::BFGS, options, d, initial_x::AbstractArray{T}) wh
     project_tangent!(method.manifold, gradient(d), initial_x)
 
     if method.initial_invH == nothing
-        zx = zero(x)
         if method.initial_stepnorm == nothing
             # Identity matrix of size n x n
-            invH0 = zx * zx' + I
+            invH0 = fill!(similar(initial_x, (n ,n)), 0) + I
         else
             initial_scale = T(method.initial_stepnorm) * inv(norm(gradient(d), Inf))
-            invH0 = zx * zx' + initial_scale * I
+            invH0 = fill!(similar(initial_x, (n ,n)), 0) + initial_scale * I
         end
     else
         invH0 = method.initial_invH(initial_x)

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -66,7 +66,6 @@ function reset!(method, state::BFGSState, obj, x)
     project_tangent!(method.manifold, gradient(obj), x)
 
     if method.initial_invH == nothing
-        zx = zero(x)
         if method.initial_stepnorm == nothing
             # Identity matrix of size n x n
             state.invH = fill!(similar(x, (n ,n)), 0) + I


### PR DESCRIPTION
TODO:
- [x] Fails for ArrayPartition type

MWE:
```
using Optim, CUDA
rosenbrock(x) =  (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
result = optimize(rosenbrock, cu(zeros(2)), BFGS())
```

Prev:
```
ERROR: ArgumentError: cannot take the CPU address of a CuArray{Float32, 1}
Stacktrace:
  [1] unsafe_convert(#unused#::Type{Ptr{Float32}}, x::CuArray{Float32, 1})
    @ CUDA ~/.julia/packages/CUDA/mVgLI/src/array.jl:262
  [2] gemv!(trans::Char, alpha::Float32, A::Matrix{Float32}, X::CuArray{Float32, 1}, beta::Float32, Y::CuArray{Float32, 1})
    @ LinearAlgebra.BLAS /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/blas.jl:704
  [3] gemv!(y::CuArray{Float32, 1}, tA::Char, A::Matrix{Float32}, x::CuArray{Float32, 1}, α::Bool, β::Bool)
    @ LinearAlgebra /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/matmul.jl:544
  [4] mul!
    @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/matmul.jl:66 [inlined]
  [5] mul!
    @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/matmul.jl:275 [inlined]
  [6] update_state!(d::OnceDifferentiable{Float32, CuArray{Float32, 1}, CuArray{Float32, 1}}, state::Optim.BFGSState{CuArray{Float32, 1}, Matrix{Float32}, Float32, CuArray{Float32, 1}}, method::BFGS{LineSearches.InitialStatic{Float64}, LineSearches.HagerZhang{Float64, Base.RefValue{Bool}}, Nothing, Nothing, Flat})
    @ Optim ~/testing/Optim.jl/src/multivariate/solvers/first_order/bfgs.jl:119
  [7] optimize(d::OnceDifferentiable{Float32, CuArray{Float32, 1}, CuArray{Float32, 1}}, initial_x::CuArray{Float32, 1}, method::BFGS{LineSearches.InitialStatic{Float64}, LineSearches.HagerZhang{Float64, Base.RefValue{Bool}}, Nothing, Nothing, Flat}, options::Optim.Options{Float64, Nothing}, state::Optim.BFGSState{CuArray{Float32, 1}, Matrix{Float32}, Float32, CuArray{Float32, 1}})
    @ Optim ~/testing/Optim.jl/src/multivariate/optimize/optimize.jl:57
  [8] optimize
    @ ~/testing/Optim.jl/src/multivariate/optimize/optimize.jl:35 [inlined]
  [9] #optimize#87
    @ ~/testing/Optim.jl/src/multivariate/optimize/interface.jl:142 [inlined]
 [10] optimize(f::Function, initial_x::CuArray{Float32, 1}, method::BFGS{LineSearches.InitialStatic{Float64}, LineSearches.HagerZhang{Float64, Base.RefValue{Bool}}, Nothing, Nothing, Flat}, options::Optim.Options{Float64, Nothing}) (repeats 2 times)
    @ Optim ~/testing/Optim.jl/src/multivariate/optimize/interface.jl:141
 [11] top-level scope
    @ REPL[6]:1
```

Curr:
```
    * Status: success

    * Candidate solution
       Final objective value:     1.982578e-05
   
    * Found with
       Algorithm:     BFGS
   
    * Convergence measures
       |x - x'|               = 0.00e+00 ≤ 0.0e+00
       |x - x'|/|x'|          = 0.00e+00 ≤ 0.0e+00
       |f(x) - f(x')|         = 0.00e+00 ≤ 0.0e+00
       |f(x) - f(x')|/|f(x')| = 0.00e+00 ≤ 0.0e+00
       |g(x)|                 = 1.37e-03 ≰ 1.0e-08
   
    * Work counters
       Seconds run:   0  (vs limit Inf)
       Iterations:    47
       f(x) calls:    971
       ∇f(x) calls:   971
```