### PR TITLE
Fix edit link at bottom of each page

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name:        Optim.jl
 repo_url:         https://github.com/JuliaNLSolvers/Optim.jl/
+edit_uri:         edit/master/docs/src/
 site_description: Pure Julia implementations of optimization algorithms.
 site_author:      JuliaNLSolvers
 


### PR DESCRIPTION
Edit links point to
https://github.com/JuliaNLSolvers/Optim.jl/edit/master/docs/
and not to
https://github.com/JuliaNLSolvers/Optim.jl/edit/master/docs/src/