### PR TITLE
Enable BFGS GPU

### DIFF
--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -159,13 +159,9 @@ function update_h!(d, state, method::BFGS)
         c1 = (dx_dg + real(dot(state.dg, state.u))) / (dx_dg' * dx_dg)
         c2 = 1 / dx_dg
 
-        # TODO BLASify this
-        # invH = invH + c1 * (s * s') - c2 * (u * s' + s * u')
-        for i in 1:n
-            @simd for j in 1:n
-                @inbounds state.invH[i, j] += c1 * state.dx[i] * state.dx[j]' - c2 * (state.u[i] * state.dx[j]' + state.u[j]' * state.dx[i])
-            end
-        end
+        mul!(state.invH,vec(state.dx),vec(state.dx)', c1,1)
+        mul!(state.invH,vec(state.u) ,vec(state.dx)',-c2,1)
+        mul!(state.invH,vec(state.dx),vec(state.u)' ,-c2,1)   
     end
 end
 


### PR DESCRIPTION
I hope it isn't rude to open this PR here. This is mostly @vpuri3 's work! I just wasn't sure how to add to his PR, so I just added this one.

The goal of this PR is to enable BFGS to run in the GPU by BLASifying it. 

Currently,

we changed the loop in the current code to

```julia
mul!(state.invH,vec(state.dx),vec(state.dx)', c1,1)
mul!(state.invH,vec(state.u) ,vec(state.dx)',-c2,1)
mul!(state.invH,vec(state.dx),vec(state.u)' ,-c2,1)   
```

You can check that those are equivalent here https://github.com/JuliaNLSolvers/Optim.jl/pull/946#issuecomment-939490884

This works for matrices and manifolds, but one test is still failing. Namely, I am getting a `BoundsError: attempt to access Tuple{Vector{Float64}, Vector{Float64}} at index [3]` error in the array partition testset

https://github.com/JuliaNLSolvers/Optim.jl/blob/01b49c7dc4ec37f97d87118f03877c64e3da9a8c/test/multivariate/array.jl#L57

I will investigate why this is happening, but advice or tips are always welcome. 