### PR TITLE
fix for ML example

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.5.0"
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"

--- a/docs/src/examples/maxlikenlm.jl
+++ b/docs/src/examples/maxlikenlm.jl
@@ -21,7 +21,7 @@
 
 using Optim, NLSolversBase
 using LinearAlgebra: diag
-using ForwardDiff: jacobian
+using ForwardDiff
 
 #md # !!! tip
 #md #     Add Optim with the following command at the Julia command prompt:

--- a/docs/src/examples/maxlikenlm.jl
+++ b/docs/src/examples/maxlikenlm.jl
@@ -21,7 +21,7 @@
 
 using Optim, NLSolversBase
 using LinearAlgebra: diag
-using ForwardDiff
+using ForwardDiff: jacobian
 
 #md # !!! tip
 #md #     Add Optim with the following command at the Julia command prompt:


### PR DESCRIPTION
The ML example in the documentation (https://julianlsolvers.github.io/Optim.jl/stable/#examples/generated/maxlikenlm/) has some problems. The t-statistics are not correct, as can be verified by computing the OLS estimates. The error is that the transformation from log sigma to sigma is not correctly done. The Hessian matrix is computed after directly exponentiating the log sigma parameter, while the likelihood function is not prepared to accept sigma rather than log sigma, so the resulting Hessian is not correct. This PR uses the delta method to do the transformation. 