### PR TITLE
check for nothing with ===/!== instead of ==/!=

### DIFF
--- a/docs/src/user/tipsandtricks.md
+++ b/docs/src/user/tipsandtricks.md
@@ -64,14 +64,15 @@ For example, here we define a function `fg!` to compute the objective function a
 the gradient, as required:
 
 ```julia
-function fg!(F,G,x)
+function fg!(F, G, x)
   # do common computations here
   # ...
-  if G != nothing
+  if G !== nothing
     # code to compute gradient here
     # writing the result to the vector G
+    # G .= ...
   end
-  if F != nothing
+  if F !== nothing
     # value = ... code to compute objective function
     return value
   end
@@ -91,10 +92,10 @@ Optim.optimize(Optim.only_fg!(fg!), [0., 0.], Optim.LBFGS())
 Similarly, for a computation that requires the Hessian, we can write:
 
 ```julia
-function fgh!(F,G,H,x)
-  G == nothing || # compute gradient and store in G
-  H == nothing || # compute Hessian and store in H
-  F == nothing || return f(x)
+function fgh!(F, G, H, x)
+  G === nothing || # compute gradient and store in G
+  H === nothing || # compute Hessian and store in H
+  F === nothing || return f(x)
   nothing
 end
 

--- a/src/multivariate/optimize/interface.jl
+++ b/src/multivariate/optimize/interface.jl
@@ -10,7 +10,7 @@ function check_kwargs(kwargs, fallback_method)
         end
     end
 
-    if method == nothing
+    if method === nothing
         method = fallback_method
     end
     kws, method

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -38,7 +38,7 @@ function optimize(d::D, initial_x::Tx, method::M,
 
     t0 = time() # Initial time stamp used to control early stopping by options.time_limit
     tr = OptimizationTrace{typeof(value(d)), typeof(method)}()
-    tracing = options.store_trace || options.show_trace || options.extended_trace || options.callback != nothing
+    tracing = options.store_trace || options.show_trace || options.extended_trace || options.callback !== nothing
     stopped, stopped_by_callback, stopped_by_time_limit = false, false, false
     f_limit_reached, g_limit_reached, h_limit_reached = false, false, false
     x_converged, f_converged, f_increased, counter_f_tol = false, false, false, 0

--- a/src/multivariate/solvers/constrained/ipnewton/interior.jl
+++ b/src/multivariate/solvers/constrained/ipnewton/interior.jl
@@ -230,7 +230,7 @@ function optimize(d::AbstractObjective, constraints::AbstractConstraints, initia
     _time = t0
 
     tr = OptimizationTrace{typeof(value(d)), typeof(method)}()
-    tracing = options.store_trace || options.show_trace || options.extended_trace || options.callback != nothing
+    tracing = options.store_trace || options.show_trace || options.extended_trace || options.callback !== nothing
     stopped, stopped_by_callback, stopped_by_time_limit = false, false, false
     f_limit_reached, g_limit_reached, h_limit_reached = false, false, false
     x_converged, f_converged, f_increased, counter_f_tol = false, false, false, 0

--- a/src/multivariate/solvers/constrained/samin.jl
+++ b/src/multivariate/solvers/constrained/samin.jl
@@ -64,7 +64,7 @@ function optimize(obj_fn, lb::AbstractArray, ub::AbstractArray, x::AbstractArray
     d = NonDifferentiable(obj_fn, x)
 
     tr = OptimizationTrace{typeof(value(d)), typeof(method)}()
-    tracing = options.store_trace || options.show_trace || options.extended_trace || options.callback != nothing
+    tracing = options.store_trace || options.show_trace || options.extended_trace || options.callback !== nothing
 
     @unpack nt, ns, rt, neps, f_tol, x_tol, coverage_ok, verbosity = method
     verbose = verbosity > 0

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -73,8 +73,8 @@ function reset!(method, state::BFGSState, obj, x)
     value_gradient!(obj, x)
     project_tangent!(method.manifold, gradient(obj), x)
 
-    if method.initial_invH == nothing
-        if method.initial_stepnorm == nothing
+    if method.initial_invH === nothing
+        if method.initial_stepnorm === nothing
             # Identity matrix of size n x n
             state.invH = _init_identity_matrix(x)
         else
@@ -95,8 +95,8 @@ function initial_state(method::BFGS, options, d, initial_x::AbstractArray{T}) wh
 
     project_tangent!(method.manifold, gradient(d), initial_x)
 
-    if method.initial_invH == nothing
-        if method.initial_stepnorm == nothing
+    if method.initial_invH === nothing
+        if method.initial_stepnorm === nothing
             # Identity matrix of size n x n
             invH0 = _init_identity_matrix(initial_x)
         else

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -108,7 +108,7 @@ function reset!(cg, cgs::ConjugateGradientState, obj, x)
     cgs.x .= x
     cg.precondprep!(cg.P, x)
     ldiv!(cgs.pg, cg.P, gradient(obj))
-    if cg.P != nothing
+    if cg.P !== nothing
         project_tangent!(cg.manifold, cgs.pg, x)
     end
     cgs.s .= -cgs.pg 
@@ -139,7 +139,7 @@ function initial_state(method::ConjugateGradient, options, d, initial_x)
     #    TODO: consider allowing a reference for pg instead of a copy
     method.precondprep!(method.P, initial_x)
     ldiv!(pg, method.P, gradient(d))
-    if method.P != nothing
+    if method.P !== nothing
         project_tangent!(method.manifold, pg, initial_x)
     end
 

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -72,7 +72,7 @@ function update_state!(d, state::GradientDescentState{T}, method::GradientDescen
     method.precondprep!(method.P, state.x)
     ldiv!(state.s, method.P, gradient(d))
     rmul!(state.s, eltype(state.s)(-1))
-    if method.P != nothing
+    if method.P !== nothing
         project_tangent!(method.manifold, state.s, state.x)
     end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -105,25 +105,25 @@ function Options(;
         callback = nothing,
         time_limit = NaN)
     show_every = show_every > 0 ? show_every : 1
-    #if extended_trace && callback == nothing
+    #if extended_trace && callback === nothing
     #    show_trace = true
     #end
-    if !(x_tol == nothing)
+    if !(x_tol === nothing)
         x_abstol = x_tol
     end
-    if !(g_tol == nothing)
+    if !(g_tol === nothing)
         g_abstol = g_tol
     end
-    if !(f_tol == nothing)
+    if !(f_tol === nothing)
         f_reltol = f_tol
     end
-    if !(outer_x_tol == nothing)
+    if !(outer_x_tol === nothing)
         outer_x_abstol = outer_x_tol
     end
-    if !(outer_g_tol == nothing)
+    if !(outer_g_tol === nothing)
         outer_g_abstol = outer_g_tol
     end
-    if !(outer_f_tol == nothing)
+    if !(outer_f_tol === nothing)
         outer_f_reltol = outer_f_tol
     end
     Options(promote(x_abstol, x_reltol, f_abstol, f_reltol, g_abstol, g_reltol, outer_x_abstol, outer_x_reltol, outer_f_abstol, outer_f_reltol, outer_g_abstol, outer_g_reltol)..., f_calls_limit, g_calls_limit, h_calls_limit,

--- a/src/univariate/solvers/brent.jl
+++ b/src/univariate/solvers/brent.jl
@@ -61,7 +61,7 @@ function optimize(
 
     # Trace the history of states visited
     tr = OptimizationTrace{T, typeof(mo)}()
-    tracing = store_trace || show_trace || extended_trace || callback != nothing
+    tracing = store_trace || show_trace || extended_trace || callback !== nothing
     stopped_by_callback = false
     if tracing
         # update trace; callbacks can stop routine early by returning true

--- a/src/univariate/solvers/golden_section.jl
+++ b/src/univariate/solvers/golden_section.jl
@@ -50,7 +50,7 @@ function optimize(f, x_lower::T, x_upper::T,
 
     # Trace the history of states visited
     tr = OptimizationTrace{T, typeof(mo)}()
-    tracing = store_trace || show_trace || extended_trace || callback != nothing
+    tracing = store_trace || show_trace || extended_trace || callback !== nothing
     stopped_by_callback = false
     if tracing
         # update trace; callbacks can stop routine early by returning true

--- a/src/utilities/perform_linesearch.jl
+++ b/src/utilities/perform_linesearch.jl
@@ -12,8 +12,8 @@ function reset_search_direction!(state, d, method::BFGS)
     n = length(state.x)
     T = eltype(state.x)
 
-    if method.initial_invH == nothing
-        if method.initial_stepnorm == nothing
+    if method.initial_invH === nothing
+        if method.initial_stepnorm === nothing
             state.invH .= Matrix{T}(I, n, n)
         else
             initial_scale = method.initial_stepnorm * inv(norm(gradient(d), Inf))

--- a/src/utilities/update.jl
+++ b/src/utilities/update.jl
@@ -18,7 +18,7 @@ function update!(tr::OptimizationTrace{Tf, T},
             flush(stdout)
         end
     end
-    if callback != nothing && (iteration % show_every == 0)
+    if callback !== nothing && (iteration % show_every == 0)
         if store_trace
             stopped = callback(tr)
         else

--- a/test/multivariate/optimize/interface.jl
+++ b/test/multivariate/optimize/interface.jl
@@ -66,14 +66,14 @@ end
       H
     end
     function fg!(F,G,x)
-      G == nothing || g!(G,x)
-      F == nothing || return f(x)
+      G === nothing || g!(G,x)
+      F === nothing || return f(x)
       nothing
     end
     function fgh!(F,G,H,x)
-      G == nothing || g!(G,x)
-      H == nothing || h!(H,x)
-      F == nothing || return f(x)
+      G === nothing || g!(G,x)
+      H === nothing || h!(H,x)
+      F === nothing || return f(x)
       nothing
     end
 

--- a/test/multivariate/optimize/optimize.jl
+++ b/test/multivariate/optimize/optimize.jl
@@ -66,14 +66,14 @@ end
       H[2, 2] = 200.0
     end
     function fg!(F,G,x)
-      G == nothing || g!(G,x)
-      F == nothing || return f(x)
+      G === nothing || g!(G,x)
+      F === nothing || return f(x)
       nothing
     end
     function fgh!(F,G,H,x)
-      G == nothing || g!(G,x)
-      H == nothing || h!(H,x)
-      F == nothing || return f(x)
+      G === nothing || g!(G,x)
+      H === nothing || h!(H,x)
+      F === nothing || return f(x)
       nothing
     end
 


### PR DESCRIPTION
As pointed out in https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/pull/240#discussion_r744598754 - I couldn't find good documentation in base julia beyond a bullet point in https://docs.julialang.org/en/v1/manual/noteworthy-differences/, but there's also https://stackoverflow.com/questions/56852880/comparing-julia-variable-to-nothing-using-or ...

Optim also requires Julia >= 1.2, so if you prefer we could change the checks to `isnothing`/`!isnothing`?