### PR TITLE
 fix(show)!: produce executable string for Options

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -131,7 +131,19 @@ function Options(;
         Int(show_every), callback, Float64(time_limit))
 end
 
+_show_helper(output, k, v) = output * "$k = $v, "
+_show_helper(output, k, ::Nothing) = output
+
 function Base.show(io::IO, o::Optim.Options)
+    content = foldl(fieldnames(typeof(o)), init = "Optim.Options(") do output, k
+        v = getfield(o, k)
+        return _show_helper(output, k, v)
+    end
+    print(io, content)
+    println(io, ")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", o::Optim.Options)
     for k in fieldnames(typeof(o))
         v = getfield(o, k)
         if v isa Nothing

--- a/test/general/types.jl
+++ b/test/general/types.jl
@@ -12,65 +12,38 @@ import Compat.String
 
     prob = MultivariateProblems.UnconstrainedProblems.examples["Rosenbrock"]
     f_prob = MVP.objective(prob)
-    for g_free in (NelderMead(), SimulatedAnnealing())
-        res = Optim.optimize(f_prob, prob.initial_x, g_free)
+    for res in (
+            Optim.optimize(f_prob, prob.initial_x, NelderMead()),
+            Optim.optimize(f_prob, prob.initial_x, SimulatedAnnealing()),
+            Optim.optimize(
+                MVP.objective(prob),
+                MVP.gradient(prob),
+                prob.initial_x,
+                LBFGS()
+            )
+        )
         @test typeof(f_prob(prob.initial_x)) == typeof(Optim.minimum(res))
         @test eltype(prob.initial_x) == eltype(Optim.minimizer(res))
 
         io = IOBuffer()
         show(io, res)
         s = String(take!(io))
+        line_shift = res.method isa Union{SimulatedAnnealing,LBFGS} ? 5 : 1
 
         lines = split(s, '\n')
-        @test lines[1] == "Results of Optimization Algorithm"
-        @test startswith(lines[2], " * Algorithm: ")
-        @test startswith(lines[3], " * Starting Point: ")
-        @test startswith(lines[4], " * Minimizer: [")
-        @test startswith(lines[5], " * Minimum: ")
-        @test startswith(lines[6], " * Iterations: ")
-        @test startswith(lines[7], " * Convergence: ")
-        if res.method == "Nelder-Mead"
-            @test startswith(lines[8], "   *  √(Σ(yᵢ-ȳ)²)/n < 1.0e-08: ")
-            @test startswith(lines[9], "   * Reached Maximum Number of Iterations: ")
-            @test startswith(lines[10], " * Objective Calls: ")
-        elseif res.method == "Simulated Annealing"
-            @test startswith(lines[8], "   * |x - x'| ≤ ")
-            @test startswith(lines[9], "   * |f(x) - f(x')| ≤ 0.0e+00 |f(x)|")
-            @test startswith(lines[10], "   * |g(x)| ≤ ")
-            @test startswith(lines[11], "   * Stopped by an increasing objective:")
-            @test startswith(lines[12], "   * Reached Maximum Number of Iterations: ")
-            @test startswith(lines[13], " * Objective Calls: ")
+        @test lines[4] |> contains("Final objective value")
+        @test lines[7] |> contains("Algorithm")
+        @test lines[9] |> contains("Convergence measures")
+        @test lines[13 + line_shift] |> contains("Iterations")
+        @test lines[14 + line_shift] |> contains("f(x) calls")
+        if res.method isa NelderMead
+            @test lines[10] |> contains("√(Σ(yᵢ-ȳ)²)/n ≤ 1.0e-08")
+        elseif res.method isa Union{SimulatedAnnealing,LBFGS}
+            @test lines[10] |> contains("|x - x'|")
+            @test lines[11] |> contains("|x - x'|/|x'|")
+            @test lines[12] |> contains("|f(x) - f(x')|")
+            @test lines[13] |> contains("|f(x) - f(x')|/|f(x')|")
+            @test lines[14] |> contains("|g(x)|")
         end
-    end
-
-    res = Optim.optimize(MVP.objective(prob), MVP.gradient(prob), prob.initial_x, LBFGS())
-    @test typeof(f_prob(prob.initial_x)) == typeof(Optim.minimum(res))
-    @test eltype(prob.initial_x) == eltype(Optim.minimizer(res))
-
-
-    io = IOBuffer()
-    show(io, res)
-    s = String(take!(io))
-
-    lines = split(s, '\n')
-    @test lines[1] == "Results of Optimization Algorithm"
-    @test startswith(lines[2], " * Algorithm: ")
-    @test startswith(lines[3], " * Starting Point: ")
-    @test startswith(lines[4], " * Minimizer: [")
-    @test startswith(lines[5], " * Minimum: ")
-    @test startswith(lines[6], " * Iterations: ")
-    @test startswith(lines[7], " * Convergence: ")
-    @test startswith(lines[8], "   * |x - x'| ≤ ")
-    @test startswith(lines[9],  "     |x - x'| = ")
-    @test startswith(lines[10], "   * |f(x) - f(x')| ≤ 0.0e+00 |f(x)|:") # TODO: regexp
-    @test startswith(lines[11], "     |f(x) - f(x')| = 7.43e+10 |f(x)|") # TODO: regexp
-    @test startswith(lines[12], "   * |g(x)| ≤ ")
-    @test startswith(lines[13], "     |g(x)| = ")
-    @test startswith(lines[14], "   * Stopped by an increasing objective:")
-    @test startswith(lines[15], "   * Reached Maximum Number of Iterations: ")
-    @test startswith(lines[16], " * Objective Calls: ")
-    @test startswith(lines[17], " * Gradient Calls: ")
-    if res.method in ("Newton's Method", "Newton's Method (Trust Region)")
-        @test startswith(lines[18], " * Hessian Calls: ")
     end
 end

--- a/test/general/types.jl
+++ b/test/general/types.jl
@@ -46,4 +46,8 @@ import Compat.String
             @test lines[14] |> contains("|g(x)|")
         end
     end
+
+    io = IOBuffer()
+    res = show(io, MIME"text/plain"(), Optim.Options(x_abstol = 10.0))
+    @test String(take!(io)) |> contains("x_abstol = 10.0")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ general_tests = [
     "Optim",
     "optimize",
     "type_stability",
-#    "types",
+    "types",
     "counter",
     "maximize",
 ]


### PR DESCRIPTION
Re-implement two-argument Base.show() such that it produces an executable string of Optim.Options() as specified in Base docs [1].

Move previous implementation to three-argument Base.show() which should be human-readable [2].

[1] https://docs.julialang.org/en/v1/base/io-network/#Base.show-Tuple{IO,%20Any}
[2] https://docs.julialang.org/en/v1/base/io-network/#Base.show-Tuple{IO,%20Any,%20Any}

Refs: #915