### PR TITLE
fix BFGS loop order

### DIFF
--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -160,19 +160,9 @@ function update_h!(d, state, method::BFGS)
         c2 = 1 / dx_dg
 
         # invH = invH + c1 * (s * s') - c2 * (u * s' + s * u')
-        if(state.invH isa Array) # i.e. not a CuArray
-            for i in 1:n
-                @simd for j in 1:n
-                    @inbounds state.invH[i, j] += c1 * state.dx[i] * state.dx[j]' -
-                                                  c2 * (state.u[i] * state.dx[j]' +
-                                                        state.u[j]' * state.dx[i])
-                end
-            end
-        else
-            mul!(state.invH,vec(state.dx),vec(state.dx)', c1,1)
-            mul!(state.invH,vec(state.u ),vec(state.dx)',-c2,1)
-            mul!(state.invH,vec(state.dx),vec(state.u )',-c2,1)
-        end
+        mul!(state.invH,vec(state.dx),vec(state.dx)', c1,1)
+        mul!(state.invH,vec(state.u ),vec(state.dx)',-c2,1)
+        mul!(state.invH,vec(state.dx),vec(state.u )',-c2,1)
     end
 end
 


### PR DESCRIPTION
MWE: https://github.com/JuliaNLSolvers/Optim.jl/commit/331a26fd76011b1e4598fc622a86c4cc6797307f#commitcomment-64720042
```julia
using LinearAlgebra, BenchmarkTools

n = 200
A = rand(n,n)
x = rand(n)
u = rand(n)
c1= 1.0
c2= 1.0


function f1!(A,x,u,c1,c2)
  for i in 1:n
    @simd for j in 1:n
      A[i,j] += c1 * x[i] * x[j]
      A[i,j] -= c2 * u[i] * x[j]
      A[i,j] -= c2 * x[i] * u[j]
    end
  end
  return
end

function f2!(A,x,u,c1,c2)
  for i in 1:n
    @simd for j in 1:n
      @inbounds A[i, j] += c1 * x[i] * x[j]' - c2 * (u[i] * x[j]' + u[j]' * x[i])
    end
  end
  return
end 
  
function f3!(A,x,u,c1,c2)
  mul!(A,vec(x),vec(x)', c1,1.0)                  
  mul!(A,vec(u),vec(x)',-c2,1.0)
  mul!(A,vec(x),vec(u)',-c2,1.0)
  return
end
f1!(A,x,u,c1,c2)
f2!(A,x,u,c1,c2)
f3!(A,x,u,c1,c2)

@btime f1!($A,$x,$u,$c1,$c2)
@btime f2!($A,$x,$u,$c1,$c2)
@btime f3!($A,$x,$u,$c1,$c2)
```
```julia
julia> @run t
  19.693 ms (720601 allocations: 11.00 MiB)
  18.030 ms (640601 allocations: 9.78 MiB)
  57.246 μs (0 allocations: 0 bytes)
```