### PR TITLE
fix: equality comparison where assignment was likely meant

### DIFF
--- a/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl
+++ b/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl
@@ -282,7 +282,7 @@ function update_state!(d, constraints::TwiceDifferentiableConstraints, state::IP
     # Evaluate the constraints at the new position
     constraints.c!(state.constr_c, state.x)
     constraints.jacobian!(state.constr_J, state.x)
-    state.ev == equality_violation(constraints, state)
+    state.ev = equality_violation(constraints, state)
 
     false
 end


### PR DESCRIPTION
As per #976, it looks like in this code in `IPNewton`:

https://github.com/JuliaNLSolvers/Optim.jl/blob/adc5b277b3f915c25233b45f8f2dd61006815e63/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl#L282-L288

...the line `state.ev == equality_violation(constraints, state)` probably meant assignment, not an equality test:

1. The equality test would make sense if it was the last statement of the function (in order to return `true` or `false`), but it's not, which means that the result of comparison is not used.
2. As I understand it, `state.ev` is supposed to be a number, most likely a floating-point, but comparison of floats for _equality_ [can fail](https://floating-point-gui.de/errors/comparison/), because of rounding errors, so this equality test seems suspicious.

I changed it to assignment, and all tests still pass.


-------

However, it seems like using assignment doesn't change much:

1. `optimize` first calls `update_state!`, which seems to leave `state.ev` unchanged (without my "fix"). Then, however, it immediately calls `update_fg!`: https://github.com/JuliaNLSolvers/Optim.jl/blob/1189ba0347ba567e43d1d4de94588aaf8a9e3ac0/src/multivariate/solvers/constrained/ipnewton/interior.jl#L250-L252
2. `update_fg!`, however, _does_ update `state.ev`: https://github.com/JuliaNLSolvers/Optim.jl/blob/1189ba0347ba567e43d1d4de94588aaf8a9e3ac0/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl#L176-L179
3. So equality violation ends up updated _anyway_...