### PR TITLE
remove unbound type parameter

### DIFF
--- a/src/univariate/printing.jl
+++ b/src/univariate/printing.jl
@@ -4,7 +4,7 @@ function print_header(method::Brent)
 end
 
 
-function Base.show(io::IO, trace::OptimizationTrace{<:Real, Brent}) where T
+function Base.show(io::IO, trace::OptimizationTrace{<:Real, Brent})
     @printf io "Iter     Function value      Lower bound       Upper bound       Best bound\n"
     @printf io "------   --------------      -----------       -----------       ----------\n"
     for state in trace.states


### PR DESCRIPTION
Unbound type parameters often cause performance issues and run time dispatch.

Issue found using https://github.com/JuliaLang/julia/pull/46608