### PR TITLE
Math rendering in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ result = optimize(rosenbrock, zeros(2), BFGS())
 ```
 This minimizes the [Rosenbrock function](https://en.wikipedia.org/wiki/Rosenbrock_function)
 
-<img src="https://user-images.githubusercontent.com/8431156/31627324-2bbc9ebc-b2ad-11e7-916f-857ad8dcb714.gif" title="f(x,y) = (a-x)^2+b(y-x^2)^2" />
+$$
+f(x, y) = (a - x)^2 + b(y - x^2)^2
+$$
 
-with a = 1, b = 100 and the initial values x=0, y=0.
-The minimum is at (a,a^2).
+with $a = 1$, $b = 100$ and the initial values $x=0$, $y=0$.
+The minimum is at $(a,a^2)$.
 
 The above code gives the output
 ```jlcon


### PR DESCRIPTION
Since LaTeX can now be used in the README, I've changed some of the math in the README. This also helps with the rendering of the Rosenbrock function, which on a dark theme is unreadable:

![image](https://github.com/JuliaNLSolvers/Optim.jl/assets/95613936/011a60e7-bcb3-4729-b06b-d98b15f1d7ca)
