### PR TITLE
Only warn for early stop if `options.show_trace`

### DIFF
--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -95,11 +95,11 @@ function optimize(d::D, initial_x::Tx, method::M,
         end
 
         if g_calls(d) > 0 && !all(isfinite, gradient(d))
-            @warn "Terminated early due to NaN in gradient."
+            options.show_trace && @warn "Terminated early due to NaN in gradient."
             break
         end
         if h_calls(d) > 0 && !(d isa TwiceDifferentiableHV) && !all(isfinite, hessian(d))
-            @warn "Terminated early due to NaN in Hessian."
+            options.show_trace && @warn "Terminated early due to NaN in Hessian."
             break
         end
     end # while


### PR DESCRIPTION
Addresses discussion in https://github.com/JuliaNLSolvers/Optim.jl/pull/1046 with @mohamed82008 

Users of PySR and SymbolicRegression.jl were suddenly getting spammed with warning messages (e.g., https://github.com/MilesCranmer/PySR/discussions/416) so I had to hotfix things to use an earlier Optim.jl.

This PR addresses this so that the warning only shows up if the user requested that level of information with `show_trace = true`. Otherwise the warning does not show. But it will still quit early which I agree is the correct behavior.