### PR TITLE
restore allocation free maxdiff

### DIFF
--- a/src/utilities/maxdiff.jl
+++ b/src/utilities/maxdiff.jl
@@ -1,3 +1,16 @@
+# generic version for gpu support
 function maxdiff(x::AbstractArray, y::AbstractArray)
     return mapreduce((a, b) -> abs(a - b), max, x, y)
+end
+
+# allocation free version for normal arrays
+function maxdiff(x::Array, y::Array)
+    res = real(zero(x[1] - y[1]))
+    @inbounds for i in 1:length(x)
+        delta = abs(x[i] - y[i])
+        if delta > res
+            res = delta
+        end
+    end
+    return res
 end


### PR DESCRIPTION
The maxdiff function used in assess_convergence allocates which causes a non negligible time increase in a large-ish LBFGS problem for me.

#889 switched maxdiff to a mapreduce based implementation to support gpu arrays.
Unfortunately the mapreduce now allocates for standard arrays.

This change restores the previous allocation free code for normal Arrays while still allowing gpu arrays using mapreduce