### PR TITLE
also show the minimizer

### DIFF
--- a/docs/src/user/config.md
+++ b/docs/src/user/config.md
@@ -41,7 +41,7 @@ In addition to the solver, you can alter the behavior of the Optim package by us
 * `x_tol`: Absolute tolerance in changes of the input vector `x`, in infinity norm. Defaults to `0.0`.
 * `f_tol`: Relative tolerance in changes of the objective value. Defaults to `0.0`.
 * `g_tol`: Absolute tolerance in the gradient, in infinity norm. Defaults to `1e-8`. For gradient free methods, this will control the main convergence tolerance, which is solver specific.
-* `f_calls_limit`: A soft upper limit on the number of objective calls. Defaults to `0` (unlimited). Does not count the objective calls in gradient and hessian estimation.
+* `f_calls_limit`: A soft upper limit on the number of direct objective calls. Defaults to `0` (unlimited). Does not count the objective calls in gradient and hessian estimation.
 * `g_calls_limit`: A soft upper limit on the number of gradient calls. Defaults to `0` (unlimited).
 * `h_calls_limit`: A soft upper limit on the number of Hessian calls. Defaults to `0` (unlimited).
 * `allow_f_increases`: Allow steps that increase the objective value. Defaults to `false`. Note that, when setting this to `true`, the last iterate will be returned as the minimizer even if the objective increased.

--- a/docs/src/user/config.md
+++ b/docs/src/user/config.md
@@ -41,7 +41,7 @@ In addition to the solver, you can alter the behavior of the Optim package by us
 * `x_tol`: Absolute tolerance in changes of the input vector `x`, in infinity norm. Defaults to `0.0`.
 * `f_tol`: Relative tolerance in changes of the objective value. Defaults to `0.0`.
 * `g_tol`: Absolute tolerance in the gradient, in infinity norm. Defaults to `1e-8`. For gradient free methods, this will control the main convergence tolerance, which is solver specific.
-* `f_calls_limit`: A soft upper limit on the number of objective calls. Defaults to `0` (unlimited).
+* `f_calls_limit`: A soft upper limit on the number of objective calls. Defaults to `0` (unlimited). Does not count the objective calls in gradient and hessian estimation.
 * `g_calls_limit`: A soft upper limit on the number of gradient calls. Defaults to `0` (unlimited).
 * `h_calls_limit`: A soft upper limit on the number of Hessian calls. Defaults to `0` (unlimited).
 * `allow_f_increases`: Allow steps that increase the objective value. Defaults to `false`. Note that, when setting this to `true`, the last iterate will be returned as the minimizer even if the objective increased.

--- a/src/types.jl
+++ b/src/types.jl
@@ -256,6 +256,7 @@ function Base.show(io::IO, r::MultivariateOptimizationResults)
     @printf io " * Status: %s\n\n" status_string
 
     @printf io " * Candidate solution\n"
+    println(io, "    Minimizer:     ", minimizer(r))
     @printf io "    Final objective value:     %e\n" minimum(r)
     @printf io "\n"
 


### PR DESCRIPTION
Currently the optimize function does show a candidate solution, but only the minimum of the function is shown. We shall also show the minimizer of the function, such that the provided info is complete.

Looks like this now:

```
 * Status: success (objective increased between iterations)

 * Candidate solution
    Minimizer:     [214.63875045325074, 207.70250063762063, 214.6387496819325, 60.99374379542592, -1.6462211405820447e-10, -2.329416881307505e-9, -2.8537271470976752e-8]
    Final objective value:     8.456923e-13

 * Found with
    Algorithm:     L-BFGS

 * Convergence measures
    |x - x'|               = 2.49e-12 ≤ 1.0e-07
    |x - x'|/|x'|          = 1.16e-14 ≰ 0.0e+00
    |f(x) - f(x')|         = 8.45e-19 ≰ 0.0e+00
    |f(x) - f(x')|/|f(x')| = 9.99e-07 ≰ 0.0e+00
    |g(x)|                 = 6.38e-06 ≰ 1.0e-07

 * Work counters
    Seconds run:   0  (vs limit Inf)
    Iterations:    46
    f(x) calls:    228
    ∇f(x) calls:   228
```