### PR TITLE
Add Adam and AdaMax

### DIFF
--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -92,6 +92,8 @@ export optimize, maximize, # main function
        ### Acceleration methods
        AcceleratedGradientDescent,
        MomentumGradientDescent,
+       Adam,
+       AdaMax,
 
        ### Nonlinear GMRES
        NGMRES,
@@ -148,6 +150,8 @@ include("multivariate/solvers/first_order/bfgs.jl")
 include("multivariate/solvers/first_order/l_bfgs.jl")
 
 ## Acceleration methods
+include("multivariate/solvers/first_order/adamax.jl")
+include("multivariate/solvers/first_order/adam.jl")
 include("multivariate/solvers/first_order/accelerated_gradient_descent.jl")
 include("multivariate/solvers/first_order/momentum_gradient_descent.jl")
 

--- a/src/multivariate/solvers/first_order/adam.jl
+++ b/src/multivariate/solvers/first_order/adam.jl
@@ -1,0 +1,91 @@
+"""
+# Adam
+## Constructor
+```julia
+    Adam(; alpha=0.0001, beta_mean=0.9, beta_var=0.999, epsilon=1e-8)
+```
+## Description
+Adam is a gradient based optimizer that choses its search direction by building up estimates of the first two moments of the gradient vector. This makes it suitable for problems with a stochastic objective and thus gradient. The method is introduced in [1] where the related AdaMax method is also introduced, see `?AdaMax` for more information on that method.
+
+## References
+[1] https://arxiv.org/abs/1412.6980
+"""
+struct Adam{T, Tm} <: FirstOrderOptimizer
+    α::T
+    β₁::T
+    β₂::T
+    ϵ::T
+    manifold::Tm
+end
+Adam(; alpha = 0.0001, beta_mean = 0.9, beta_var = 0.999, epsilon = 1e-8) =
+    Adam(alpha, beta_mean, beta_var, epsilon, Flat())
+Base.summary(::Adam) = "Adam"
+
+mutable struct AdamState{Tx, T, Tz, Tm, Tu, Ti} <: AbstractOptimizerState
+    x::Tx
+    x_previous::Tx
+    f_x_previous::T
+    s::Tx
+    z::Tz
+    m::Tm
+    u::Tu
+    iter::Ti
+end
+function reset!(method, state::AdamState, obj, x)
+    value_gradient!!(obj, x)
+end
+function initial_state(method::Adam, options, d, initial_x::AbstractArray{T}) where T
+    initial_x = copy(initial_x)
+
+    value_gradient!!(d, initial_x)
+    α, β₁, β₂ = method.α, method.β₁, method.β₂
+   
+    z = copy(initial_x)
+    m = copy(gradient(d))
+    u = fill(zero(m[1]^2), length(m))
+    a = 1 - β₁
+    iter = 0
+
+    AdamState(initial_x, # Maintain current state in state.x
+                         copy(initial_x), # Maintain previous state in state.x_previous
+                         real(T(NaN)), # Store previous f in state.f_x_previous
+                         similar(initial_x), # Maintain current search direction in state.s
+                         z,
+                         m,
+                         u,
+                         iter)
+end
+
+function update_state!(d, state::AdamState{T}, method::Adam) where T
+    state.iter = state.iter+1
+    value_gradient!(d, state.x)
+    α, β₁, β₂, ϵ = method.α, method.β₁, method.β₂, method.ϵ
+    a = 1 - β₁
+    b = 1 - β₂
+
+    m, u, z = state.m, state.u, state.z
+    v = u
+    m .= β₁ .* m .+ a .* gradient(d)
+    v .= β₂ .* v .+ b .* gradient(d) .^ 2
+    # m̂ = m./(1-β₁^t)
+    # v̂ = v./(1-β₂^t)
+    # x = x .- α*m̂/(sqrt.(v̂+ϵ))
+    αₜ = α * sqrt(1 - β₂^state.iter) / (1 - β₁^state.iter)
+    z .= z .- αₜ .* m ./ (sqrt.(v) .+ ϵ)
+
+    for _i in eachindex(z)
+        # since m and u start at 0, this can happen if the initial gradient is exactly 0
+        # rosenbrock(x) =  (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+        # optimize(rosenbrock, zeros(2), Adam(), Optim.Options(iterations=10000))
+        if isnan(z[_i])
+            z[_i] = state.x[_i]
+        end
+    end
+    state.x .= z
+    # Update current position # x = x + alpha * s
+    false # break on linesearch error
+end
+
+function trace!(tr, d, state, iteration, method::Adam, options, curr_time=time())
+  common_trace!(tr, d, state, iteration, method, options, curr_time)
+end

--- a/src/multivariate/solvers/first_order/adam.jl
+++ b/src/multivariate/solvers/first_order/adam.jl
@@ -67,11 +67,15 @@ function update_state!(d, state::AdamState{T}, method::Adam) where T
     v = u
     m .= β₁ .* m .+ a .* gradient(d)
     v .= β₂ .* v .+ b .* gradient(d) .^ 2
-    # m̂ = m./(1-β₁^t)
-    # v̂ = v./(1-β₂^t)
-    # x = x .- α*m̂/(sqrt.(v̂+ϵ))
-    αₜ = α * sqrt(1 - β₂^state.iter) / (1 - β₁^state.iter)
-    z .= z .- αₜ .* m ./ (sqrt.(v) .+ ϵ)
+    #  m̂ = m./(1-β₁^state.iter)
+    # v̂ = v./(1-β₂^state.iter)
+    #@. z = z - α*m̂/(sqrt(v̂+ϵ))
+    @. z = z - α*m/(1-β₁^state.iter)/(sqrt(v./(1-β₂^state.iter)+ϵ))
+
+    # not quite the same because epsilon is in the sqrt
+    # not sure where I got this from
+    #    αₜ = α * sqrt(1 - β₂^state.iter) / (1 - β₁^state.iter)
+    #    z .= z .- αₜ .* m ./ (sqrt.(v .+ ϵ) )
 
     for _i in eachindex(z)
         # since m and u start at 0, this can happen if the initial gradient is exactly 0

--- a/src/multivariate/solvers/first_order/adam.jl
+++ b/src/multivariate/solvers/first_order/adam.jl
@@ -20,6 +20,9 @@ end
 Adam(; alpha = 0.0001, beta_mean = 0.9, beta_var = 0.999, epsilon = 1e-8) =
     Adam(alpha, beta_mean, beta_var, epsilon, Flat())
 Base.summary(::Adam) = "Adam"
+function default_options(method::Adam)
+    (; allow_f_increases = true, iterations=10_000)
+end
 
 mutable struct AdamState{Tx, T, Tz, Tm, Tu, Ti} <: AbstractOptimizerState
     x::Tx

--- a/src/multivariate/solvers/first_order/adamax.jl
+++ b/src/multivariate/solvers/first_order/adamax.jl
@@ -21,6 +21,9 @@ end
 AdaMax(; alpha = 0.002, beta_mean = 0.9, beta_var = 0.999) =
     AdaMax(alpha, beta_mean, beta_var, Flat())
 Base.summary(::AdaMax) = "AdaMax"
+function default_options(method::AdaMax)
+    (; allow_f_increases = true, iterations=10_000)
+end
 
 
 mutable struct AdaMaxState{Tx, T, Tz, Tm, Tu, Ti} <: AbstractOptimizerState

--- a/src/multivariate/solvers/first_order/adamax.jl
+++ b/src/multivariate/solvers/first_order/adamax.jl
@@ -1,0 +1,86 @@
+"""
+    AdaMax(; alpha=0.002, beta_mean=0.9, beta_var=0.999)
+# Adam
+## Constructor
+```julia
+    AdaMax(; alpha=0.002, beta_mean=0.9, beta_var=0.999)
+```
+## Description
+AdaMax is a gradient based optimizer that choses its search direction by building up estimates of the first two moments of the gradient vector. This makes it suitable for problems with a stochastic objective and thus gradient. The method is introduced in [1] where the related Adam method is also introduced, see `?Adam` for more information on that method.
+
+
+[1] https://arxiv.org/abs/1412.6980
+"""
+
+struct AdaMax{T,Tm} <: FirstOrderOptimizer
+    α::T
+    β₁::T
+    β₂::T
+    manifold::Tm
+end
+AdaMax(; alpha = 0.002, beta_mean = 0.9, beta_var = 0.999) =
+    AdaMax(alpha, beta_mean, beta_var, Flat())
+Base.summary(::AdaMax) = "AdaMax"
+
+
+mutable struct AdaMaxState{Tx, T, Tz, Tm, Tu, Ti} <: AbstractOptimizerState
+    x::Tx
+    x_previous::Tx
+    f_x_previous::T
+    s::Tx
+    z::Tz
+    m::Tm
+    u::Tu
+    iter::Ti
+end
+function reset!(method, state::AdaMaxState, obj, x)
+    value_gradient!!(obj, x)
+end
+function initial_state(method::AdaMax, options, d, initial_x::AbstractArray{T}) where T
+    initial_x = copy(initial_x)
+
+    value_gradient!!(d, initial_x)
+    α, β₁, β₂ = method.α, method.β₁, method.β₂
+   
+    z = copy(initial_x)
+    m = copy(gradient(d))
+    u = fill(zero(m[1]^2), length(m))
+    a = 1 - β₁
+    iter = 0
+
+    AdaMaxState(initial_x, # Maintain current state in state.x
+                         copy(initial_x), # Maintain previous state in state.x_previous
+                         real(T(NaN)), # Store previous f in state.f_x_previous
+                         similar(initial_x), # Maintain current search direction in state.s
+                         z,
+                         m,
+                         u,
+                         iter)
+end
+
+function update_state!(d, state::AdaMaxState{T}, method::AdaMax) where T
+    state.iter = state.iter+1
+    value_gradient!(d, state.x)
+    α, β₁, β₂ = method.α, method.β₁, method.β₂
+    a = 1 - β₁
+    m, u, z = state.m, state.u, state.z
+
+    m .= β₁ .* m .+ a .* gradient(d)
+    u .= max.(β₂ .* u, abs.(gradient(d)))
+    z .= z .- (α ./ (1 - β₁^state.iter)) .* m ./ u
+    for _i in eachindex(z)
+        # since m and u start at 0, this can happen if the initial gradient is exactly 0
+        # rosenbrock(x) =  (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+        # optimize(rosenbrock, zeros(2), AdaMax(), Optim.Options(iterations=10000))
+        if isnan(z[_i])
+            z[_i] = state.x[_i]
+        end
+    end
+    state.x .= z
+    # Update current position # x = x + alpha * s
+    false # break on linesearch error
+end
+
+function trace!(tr, d, state, iteration, method::AdaMax, options, curr_time=time())
+  common_trace!(tr, d, state, iteration, method, options, curr_time)
+end

--- a/test/multivariate/solvers/first_order/adam_adamax.jl
+++ b/test/multivariate/solvers/first_order/adam_adamax.jl
@@ -1,0 +1,47 @@
+@testset "Adam" begin
+    f(x) = x[1]^4
+    function g!(storage, x)
+        storage[1] = 4 * x[1]^3
+        return
+    end
+
+    initial_x = [1.0]
+    options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=100_000)
+    results = Optim.optimize(f, g!, initial_x, Adam(), options)
+    @test norm(Optim.minimum(results)) < 1e-6
+    @test summary(results) == "Adam"
+
+    # TODO: Check why skip problems fail
+    skip = ("Large Polynomial", "Parabola", "Paraboloid Random Matrix",
+            "Paraboloid Diagonal", "Penalty Function I", "Polynomial", "Powell",
+             "Extended Powell", "Trigonometric", "Himmelblau", "Rosenbrock", "Extended Rosenbrock", 
+             "Quadratic Diagonal", "Beale", "Fletcher-Powell", "Exponential", 
+             )
+    run_optim_tests(Adam();
+                    skip = skip,
+                    show_name = true)
+end
+@testset "AdaMax" begin
+    f(x) = x[1]^4
+    function g!(storage, x)
+        storage[1] = 4 * x[1]^3
+        return
+    end
+
+    initial_x = [1.0]
+    options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=100_000)
+    results = Optim.optimize(f, g!, initial_x, AdaMax(), options)
+    @test norm(Optim.minimum(results)) < 1e-6
+    @test summary(results) == "AdaMax"
+
+    # TODO: Check why skip problems fail
+    skip = ("Trigonometric", "Large Polynomial", "Parabola", "Paraboloid Random Matrix",
+            "Paraboloid Diagonal", "Extended Rosenbrock", "Penalty Function I", "Beale",
+            "Extended Powell", "Himmelblau", "Large Polynomial", "Polynomial", "Powell",
+            "Exponential", 
+             )
+    run_optim_tests(AdaMax();
+                    skip = skip,
+                    show_name=true,
+                    iteration_exceptions = (("Trigonometric", 1_000_000,),))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ multivariate_tests = [
     "solvers/constrained/samin",
     ## first order
     "solvers/first_order/accelerated_gradient_descent",
+    "solvers/first_order/adam_adamax",
     "solvers/first_order/bfgs",
     "solvers/first_order/cg",
     "solvers/first_order/gradient_descent",


### PR DESCRIPTION
Fixes #1012 

I don't use Adam and AdaMax myself, but I suppose the slow convergence of Adam from `zeros(2)` is sort of expected sometimes? Otherwise it may be good to compare against another implementation.

```
julia> rosenbrock(x) =  (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
rosenbrock (generic function with 1 method)

julia> result = optimize(rosenbrock, ones(2), AdaMax(), Optim.Options(iterations=5000))
 * Status: success

 * Candidate solution
    Final objective value:     5.647600e-17

 * Found with
    Algorithm:     AdaMax

 * Convergence measures
    |x - x'|               = 1.50e-08 ≰ 0.0e+00
    |x - x'|/|x'|          = 1.50e-08 ≰ 0.0e+00
    |f(x) - f(x')|         = NaN ≰ 0.0e+00
    |f(x) - f(x')|/|f(x')| = NaN ≰ 0.0e+00
    |g(x)|                 = 9.95e-09 ≤ 1.0e-08

 * Work counters
    Seconds run:   0  (vs limit Inf)
    Iterations:    4637
    f(x) calls:    4638
    ∇f(x) calls:   4638


julia> result = optimize(rosenbrock, ones(2), Adam(), Optim.Options(iterations=5000))
 * Status: success

 * Candidate solution
    Final objective value:     4.950178e-16

 * Found with
    Algorithm:     Adam

 * Convergence measures
    |x - x'|               = 4.45e-08 ≰ 0.0e+00
    |x - x'|/|x'|          = 4.45e-08 ≰ 0.0e+00
    |f(x) - f(x')|         = NaN ≰ 0.0e+00
    |f(x) - f(x')|/|f(x')| = NaN ≰ 0.0e+00
    |g(x)|                 = 9.94e-09 ≤ 1.0e-08

 * Work counters
    Seconds run:   0  (vs limit Inf)
    Iterations:    590
    f(x) calls:    591
    ∇f(x) calls:   591


julia> result = optimize(rosenbrock, zeros(2), Adam(), Optim.Options(iterations=5000))
 * Status: failure (reached maximum number of iterations)

 * Candidate solution
    Final objective value:     2.899319e-01

 * Found with
    Algorithm:     Adam

 * Convergence measures
    |x - x'|               = 4.62e-01 ≰ 0.0e+00
    |x - x'|/|x'|          = 1.00e+00 ≰ 0.0e+00
    |f(x) - f(x')|         = NaN ≰ 0.0e+00
    |f(x) - f(x')|/|f(x')| = NaN ≰ 0.0e+00
    |g(x)|                 = 1.08e+00 ≰ 1.0e-08

 * Work counters
    Seconds run:   0  (vs limit Inf)
    Iterations:    5000
    f(x) calls:    5001
    ∇f(x) calls:   5001


julia> result = optimize(rosenbrock, zeros(2), AdaMax(), Optim.Options(iterations=5000))
 * Status: success

 * Candidate solution
    Final objective value:     9.309545e-17

 * Found with
    Algorithm:     AdaMax

 * Convergence measures
    |x - x'|               = 1.00e+00 ≰ 0.0e+00
    |x - x'|/|x'|          = 1.00e+00 ≰ 0.0e+00
    |f(x) - f(x')|         = NaN ≰ 0.0e+00
    |f(x) - f(x')|/|f(x')| = NaN ≰ 0.0e+00
    |g(x)|                 = 9.40e-09 ≤ 1.0e-08

 * Work counters
    Seconds run:   0  (vs limit Inf)
    Iterations:    4580
    f(x) calls:    4581
    ∇f(x) calls:   4581
```