### PR TITLE
Start in interior of variable bounds

### DIFF
--- a/ext/OptimMOIExt.jl
+++ b/ext/OptimMOIExt.jl
@@ -182,11 +182,32 @@ function MOI.add_constraint(
 end
 
 function starting_value(optimizer::Optimizer{T}, i) where {T}
-    if optimizer.starting_values[i] !== nothing
-        return optimizer.starting_values[i]
+    start = optimizer.starting_values[i]
+    v = optimizer.variables
+    if isfinite(v.lower[i])
+        if isfinite(v.upper[i])
+            if !isnothing(start) && v.lower[i] < start < v.upper[i]
+                return start
+            else
+                return (v.lower[i] + v.upper[i]) / 2
+            end
+        else
+            if !isnothing(start) && v.lower[i] < start
+                return start
+            else
+                return v.lower[i] + 1.0
+            end
+        end
     else
-        v = optimizer.variables
-        return min(max(zero(T), v.lower[i]), v.upper[i])
+        if isfinite(v.upper[i])
+            if !isnothing(start) && start < v.upper[i]
+                return start
+            else
+                return v.upper[i] - 1.0
+            end
+        else
+            return something(start, 0.0)
+        end
     end
 end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -2,8 +2,7 @@ module TestOptim
 
 using Test
 import Optim
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -25,10 +24,7 @@ function test_supports_incremental_interface()
 end
 
 function test_MOI_Test()
-    model = MOI.Utilities.CachingOptimizer(
-        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
-        Optim.Optimizer(),
-    )
+    model = MOI.instantiate(Optim.Optimizer, with_cache_type = Float64)
     MOI.set(model, MOI.Silent(), true)
     MOI.Test.runtests(
         model,
@@ -47,26 +43,19 @@ function test_MOI_Test()
                 MOI.ConstraintDual,
             ],
         ),
-        exclude = String[
+        exclude = [
+            # FIXME Incorrect solution
+            r"test_nonlinear_expression_hs071$",
+            # FIXME Starting value is not feasible
+            # See https://github.com/JuliaNLSolvers/Optim.jl/issues/1071
+            r"test_nonlinear_expression_hs071_epigraph$",
+            # FIXME objective off by 1, seems fishy
+            r"test_objective_FEASIBILITY_SENSE_clears_objective$",
             # No objective
-            "test_attribute_SolveTimeSec",
-            "test_attribute_RawStatusString",
-            # FIXME The hessian callback for constraints is called with
-            # `λ = [-Inf, 0.0]` and then we get `NaN`, ...
-            "expression_hs071",
-            # Terminates with `OTHER_ERROR`
-            "test_objective_ObjectiveFunction_duplicate_terms",
-            "test_objective_ObjectiveFunction_constant",
-            "test_objective_ObjectiveFunction_VariableIndex",
-            "test_objective_FEASIBILITY_SENSE_clears_objective",
-            "test_nonlinear_expression_hs109",
-            "test_objective_qp_ObjectiveFunction_zero_ofdiag",
-            "test_objective_qp_ObjectiveFunction_edge_cases",
-            "test_solve_TerminationStatus_DUAL_INFEASIBLE",
-            "test_solve_result_index",
-            "test_modification_transform_singlevariable_lessthan",
-            "test_modification_delete_variables_in_a_batch",
-            "test_modification_delete_variable_with_single_variable_obj",
+            r"test_attribute_SolveTimeSec$",
+            r"test_attribute_RawStatusString$",
+            # Detecting infeasibility not supported
+            r"test_solve_TerminationStatus_DUAL_INFEASIBLE$",
         ],
     )
     return


### PR DESCRIPTION
As highlighted in https://github.com/JuliaNLSolvers/Optim.jl/issues/1071, most tests were failing because the starting point was infeasible.
With this PR, most are now passing.
The remaining ones to investigate are:
* `test_nonlinear_expression_hs071` : this one gives an infeasible solution, not sure if it's due to the fact that the starting values does not satisfy the constraints, no warning is thrown though.
* `test_nonlinear_expression_hs071_epigraph` : the variables are in the interior of the bounds but some of the constraints are not satisfied hence the warning is thrown. Then it converges to an incorrect solution
* `test_objective_FEASIBILITY_SENSE_clears_objective` : this one seems it may be a bug in the MOI wrapper, let me investigate first