### PR TITLE
Create benchmark suite

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,0 +1,78 @@
+name: Benchmark a pull request
+
+on:
+  pull_request_target:
+    branches:
+      - master
+
+permissions:
+  pull-requests: write
+
+jobs:
+    generate_plots:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+            - uses: julia-actions/setup-julia@v1
+              with:
+                version: "1"
+            - uses: julia-actions/cache@v1
+            - name: Extract Package Name from Project.toml
+              id: extract-package-name
+              run: |
+                PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
+                echo "::set-output name=package_name::$PACKAGE_NAME"
+            - name: Build AirspeedVelocity
+              env:
+                JULIA_NUM_THREADS: 2
+              run: |
+                # Lightweight build step, as sometimes the runner runs out of memory:
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
+            - name: Add ~/.julia/bin to PATH
+              run: |
+                echo "$HOME/.julia/bin" >> $GITHUB_PATH
+            - name: Run benchmarks
+              run: |
+                echo $PATH
+                ls -l ~/.julia/bin
+                mkdir results
+                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --exeflags="-O3 --threads=auto"
+            - name: Create plots from benchmarks
+              run: |
+                mkdir -p plots
+                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
+            - name: Upload plot as artifact
+              uses: actions/upload-artifact@v4
+              with:
+                name: plots
+                path: plots
+            - name: Create markdown table from benchmarks
+              run: |
+                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+                echo '### Benchmark Results' > body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                cat table.md >> body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                echo '### Benchmark Plots' >> body.md
+                echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
+                echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
+
+            - name: Find Comment
+              uses: peter-evans/find-comment@v2
+              id: fcbenchmark
+              with:
+                issue-number: ${{ github.event.pull_request.number }}
+                comment-author: 'github-actions[bot]'
+                body-includes: Benchmark Results
+
+            - name: Comment on PR
+              uses: peter-evans/create-or-update-comment@v3
+              with:
+                comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
+                issue-number: ${{ github.event.pull_request.number }}
+                body-path: body.md
+                edit-mode: replace

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -21,27 +21,28 @@ tests = (;
         true_phi=() -> [0.0, 16.6],
         domain=() -> LinRange(-15.0, 15.0, 256),
         options=() -> Optim.Options(iterations=10),
-        optimizers=(
-            Adam,
-            AdaMax,
-            BFGS,
-            LBFGS,
-            NGMRES,
-            ConjugateGradient,
-            GradientDescent,
-            MomentumGradientDescent
-        ),
+        optimizers=[
+            :Adam,
+            :AdaMax,
+            :BFGS,
+            :LBFGS,
+            :NGMRES,
+            :ConjugateGradient,
+            :GradientDescent,
+            :MomentumGradientDescent,
+        ],
     )
 )
 
 for order in keys(tests), optimizer in tests[order].optimizers
+    isdefined(@__MODULE__, optimizer) || continue
     SUITE["multivariate"]["solvers"][order][optimizer] = @benchmarkable(
         optimize(loss, init_phi, opt, options),
         setup = (
             test = $(tests[order]);
             init_phi = test.init_phi();
             true_phi = test.true_phi();
-            opt = $(optimizer)();
+            opt = $(eval(optimizer))();
             options = test.options();
             rng = MersenneTwister(0);
             X = collect(test.domain());

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -6,12 +6,8 @@ const SUITE = BenchmarkGroup()
 
 # Example function to optimize
 function gabor(x, phi)
-    # Example from Prince, 2023
-    return (
-        sin(phi[1] + 0.06 * phi[2] * x)
-        *
-        exp(-(phi[1] + 0.06 * phi[1] * x)^2 / 32.0)
-    )
+    # Optimization example from "Understanding Deep Learning"; Prince, 2023
+    return sin(phi[1] + 0.06 * phi[2] * x) * exp(-(phi[1] + 0.06 * phi[1] * x)^2 / 32.0)
 end
 
 tests = (;
@@ -19,8 +15,8 @@ tests = (;
         loss_generator=(X, Y) -> (phi -> sum(i -> (gabor(X[i], phi) - Y[i])^2, eachindex(X, Y))),
         init_phi=() -> [1.0, 6.0],
         true_phi=() -> [0.0, 16.6],
-        domain=() -> LinRange(-15.0, 15.0, 256),
-        options=() -> Optim.Options(iterations=10),
+        domain=() -> LinRange(-15.0, 15.0, 64),
+        options=() -> Optim.Options(iterations=100),
         optimizers=[
             :Adam,
             :AdaMax,

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,58 @@
+using BenchmarkTools
+using Optim
+using Random: MersenneTwister, seed!
+
+const SUITE = BenchmarkGroup()
+
+# Example function to optimize
+function gabor(x, phi)
+    # Example from Prince, 2023
+    return (
+        sin(phi[1] + 0.06 * phi[2] * x)
+        *
+        exp(-(phi[1] + 0.06 * phi[1] * x)^2 / 32.0)
+    )
+end
+
+tests = (;
+    first_order=(;
+        loss_generator=(X, Y) -> (phi -> sum(i -> (gabor(X[i], phi) - Y[i])^2, eachindex(X, Y))),
+        init_phi=() -> [1.0, 6.0],
+        true_phi=() -> [0.0, 16.6],
+        domain=() -> LinRange(-15.0, 15.0, 256),
+        options=() -> Optim.Options(iterations=10),
+        optimizers=(
+            Adam,
+            AdaMax,
+            BFGS,
+            LBFGS,
+            NGMRES,
+            ConjugateGradient,
+            GradientDescent,
+            MomentumGradientDescent
+        ),
+    )
+)
+
+for order in keys(tests), optimizer in tests[order].optimizers
+    SUITE["multivariate"]["solvers"][order][optimizer] = @benchmarkable(
+        optimize(loss, init_phi, opt, options),
+        setup = (
+            test = $(tests[order]);
+            init_phi = test.init_phi();
+            true_phi = test.true_phi();
+            opt = $(optimizer)();
+            options = test.options();
+            rng = MersenneTwister(0);
+            X = collect(test.domain());
+            noise = 0.1 * randn(rng, length(X));
+            Y = map(i -> gabor(X[i], true_phi) + noise[i], eachindex(X, noise));
+            loss = test.loss_generator(X, Y);
+            seed!(1)
+        )
+    )
+end
+
+
+results = run(SUITE)
+


### PR DESCRIPTION
This creates a simple benchmark for catching performance regressions on small, tightly controlled problems. To kick things off I added the multivariate first-order optimizers including `Adam`, `AdaMax`, `BFGS`, `LBFGS`, `NGMRES`, `ConjugateGradient`, `GradientDescent`, and `MomentumGradientDescent`.

The specific benchmark I added is fitting the Gabor function (2 parameters) to a noisy dataset.

It's compatible with any library supporting BenchmarkTools.jl. You can run the benchmark with:

```julia
using Optim
using Pkg
Pkg.activate("benchmark")
include("benchmark/benchmarks.jl")

results = run(SUITE)
@show results
```

I also add a GitHub action to run AirspeedVelocity.jl on this benchmark for any new PR. It will automatically print out the performance and load time comparison of master in a GitHub comment on the PR.

The current benchmarks across revision history are as follows:

|                                                          | benchmarks          | v1.9.2              | v1.8.0              | v1.7.6              |
|:---------------------------------------------------------|:-------------------:|:-------------------:|:-------------------:|:-------------------:|
| multivariate/solvers/first_order/AdaMax                  | 0.212 ± 0.00058 ms  | 0.212 ± 0.00067 ms  |                     |                     |
| multivariate/solvers/first_order/Adam                    | 0.213 ± 0.00058 ms  | 0.212 ± 0.00054 ms  |                     |                     |
| multivariate/solvers/first_order/BFGS                    | 0.0845 ± 0.00029 ms | 0.0843 ± 0.00029 ms | 0.0844 ± 0.00025 ms | 0.0871 ± 0.00033 ms |
| multivariate/solvers/first_order/ConjugateGradient       | 0.273 ± 0.00096 ms  | 0.273 ± 0.0017 ms   | 0.274 ± 0.00093 ms  | 0.291 ± 0.0012 ms   |
| multivariate/solvers/first_order/GradientDescent         | 0.0842 ± 0.00029 ms | 0.0841 ± 0.00029 ms | 0.0841 ± 0.00033 ms | 0.0868 ± 0.00029 ms |
| multivariate/solvers/first_order/LBFGS                   | 0.0853 ± 0.00033 ms | 0.0851 ± 0.00033 ms | 0.085 ± 0.00033 ms  | 0.088 ± 0.00033 ms  |
| multivariate/solvers/first_order/MomentumGradientDescent | 0.0842 ± 0.00033 ms | 0.0841 ± 0.00042 ms | 0.0842 ± 0.00033 ms | 0.0868 ± 0.00029 ms |
| multivariate/solvers/first_order/NGMRES                  | 0.74 ± 0.0034 ms    | 0.741 ± 0.0037 ms   | 0.742 ± 0.0026 ms   | 0.777 ± 0.0031 ms   |
| time_to_load                                             | 0.981 ± 0.009 s     | 0.99 ± 0.0028 s     | 0.98 ± 0.02 s       | 0.364 ± 0.0065 s    |


Meaning there are no immediate performance regressions. However the load time has clearly increased from v1.7 to v1.8 which #1081 will fix.


---


To create this table above, run the following in bash:

```bash
# Install AirspeedVelocity:
julia -e 'using Pkg; pkg"add AirspeedVelocity"; pkg"build AirspeedVelocity"'

# Run benchmark over commit history
benchpkg Optim --rev=benchmarks,v1.9.2,v1.8.0,v1.7.6 -s benchmark/benchmarks.jl --exeflags='--threads=4' --path=.

# Generate the table:
benchpkgtable Optim --rev=benchmarks,v1.9.2,v1.8.0,v1.7.6
```


We can also get the memory:

|                                                          | benchmarks                | v1.9.2                    | v1.8.0                    | v1.7.6                  |
|:---------------------------------------------------------|:-------------------------:|:-------------------------:|:-------------------------:|:-----------------------:|
| multivariate/solvers/first_order/AdaMax                  | 0.064 k allocs: 2.62 kB   | 0.064 k allocs: 2.62 kB   |                           |                         |
| multivariate/solvers/first_order/Adam                    | 0.064 k allocs: 2.62 kB   | 0.064 k allocs: 2.62 kB   |                           |                         |
| multivariate/solvers/first_order/BFGS                    | 0.061 k allocs: 3.44 kB   | 0.061 k allocs: 3.44 kB   | 0.061 k allocs: 3.44 kB   | 0.066 k allocs: 3.83 kB |
| multivariate/solvers/first_order/ConjugateGradient       | 0.207 k allocs: 9.09 kB   | 0.207 k allocs: 9.09 kB   | 0.207 k allocs: 9.09 kB   | 0.23 k allocs: 10.9 kB  |
| multivariate/solvers/first_order/GradientDescent         | 0.054 k allocs: 2.92 kB   | 0.054 k allocs: 2.92 kB   | 0.054 k allocs: 2.92 kB   | 0.059 k allocs: 3.31 kB |
| multivariate/solvers/first_order/LBFGS                   | 0.083 k allocs: 5.48 kB   | 0.083 k allocs: 5.48 kB   | 0.083 k allocs: 5.48 kB   | 0.088 k allocs: 5.88 kB |
| multivariate/solvers/first_order/MomentumGradientDescent | 0.055 k allocs: 3 kB      | 0.055 k allocs: 3 kB      | 0.055 k allocs: 3 kB      | 0.06 k allocs: 3.39 kB  |
| multivariate/solvers/first_order/NGMRES                  | 0.646 k allocs: 0.0444 MB | 0.646 k allocs: 0.0444 MB | 0.646 k allocs: 0.0444 MB | 0.719 k allocs: 0.05 MB |
| time_to_load                                             | 0.19 k allocs: 17.1 kB    | 0.19 k allocs: 17.1 kB    | 0.19 k allocs: 17.1 kB    | 0.19 k allocs: 17.1 kB  

with `--mode=memory` in the `benchpkgtable` command. If you want I can put that table in the GitHub action as well?
