### PR TITLE
 Fix type of initial_scale in reset_search_direction!

### DIFF
--- a/src/utilities/perform_linesearch.jl
+++ b/src/utilities/perform_linesearch.jl
@@ -15,7 +15,7 @@ function reset_search_direction!(state, d, method::BFGS)
         if method.initial_stepnorm === nothing
             state.invH .= _init_identity_matrix(state.x)
         else
-            initial_scale = method.initial_stepnorm * inv(norm(gradient(d), Inf))
+            initial_scale = T(method.initial_stepnorm) * inv(norm(gradient(d), Inf))
             state.invH .= _init_identity_matrix(state.x, initial_scale)
         end
     else


### PR DESCRIPTION
x-ref https://discourse.julialang.org/t/error-loaderror-methoderror-no-method-matching-init-identity-matrix-componentvector-float32-vector-float32-tuple-axis-float64/112211

I don't really know the implications of this, but I assume this is the fix.