### PR TITLE
Convergence criteria: improve docs, add per-component gradient

### DIFF
--- a/docs/src/user/config.md
+++ b/docs/src/user/config.md
@@ -40,7 +40,7 @@ In addition to the solver, you can alter the behavior of the Optim package by us
 
 * `x_tol`: Absolute tolerance in changes of the input vector `x`, in infinity norm. Defaults to `0.0`.
 * `f_tol`: Relative tolerance in changes of the objective value. Defaults to `0.0`.
-* `g_tol`: Absolute tolerance in the gradient, in infinity norm. Defaults to `1e-8`. For gradient free methods, this will control the main convergence tolerance, which is solver specific.
+* `g_tol`: Absolute tolerance in the gradient. If `g_tol` is a scalar (the default), convergence is achieved when `norm(g, Inf) ≤ g_tol`; if `g_tol` is supplied as a vector, then each component must satisfy `abs(g[i]) ≤ g_tol[i]`. Defaults to `1e-8`. For gradient-free methods (e.g., Nelder-Meade), this gets re-purposed to control the main convergence tolerance in a solver-specific manner.
 * `f_calls_limit`: A soft upper limit on the number of objective calls. Defaults to `0` (unlimited).
 * `g_calls_limit`: A soft upper limit on the number of gradient calls. Defaults to `0` (unlimited).
 * `h_calls_limit`: A soft upper limit on the number of Hessian calls. Defaults to `0` (unlimited).

--- a/docs/src/user/config.md
+++ b/docs/src/user/config.md
@@ -35,12 +35,15 @@ Special methods for bounded univariate optimization:
 * `Brent()`
 * `GoldenSection()`
 
-### General Options
+### [General Options](@id config-general)
+
 In addition to the solver, you can alter the behavior of the Optim package by using the following keywords:
 
-* `x_tol`: Absolute tolerance in changes of the input vector `x`, in infinity norm. Defaults to `0.0`.
-* `f_tol`: Relative tolerance in changes of the objective value. Defaults to `0.0`.
-* `g_tol`: Absolute tolerance in the gradient. If `g_tol` is a scalar (the default), convergence is achieved when `norm(g, Inf) ≤ g_tol`; if `g_tol` is supplied as a vector, then each component must satisfy `abs(g[i]) ≤ g_tol[i]`. Defaults to `1e-8`. For gradient-free methods (e.g., Nelder-Meade), this gets re-purposed to control the main convergence tolerance in a solver-specific manner.
+* `x_tol` (alternatively, `x_abstol`): Absolute tolerance in changes of the input vector `x`, in infinity norm. Concretely, if `|x-x'| ≤ x_tol` on successive evaluation points `x` and `x'`, convergence is achieved. Defaults to `0.0`.
+* `x_reltol`: Relative tolerance in changes of the input vector `x`, in infinity norm. Concretely, if `|x-x'| ≤ x_reltol * |x|`, convergence is achieved. Defaults to `0.0`
+* `f_tol` (alternatively, `f_reltol`): Relative tolerance in changes of the objective value. Defaults to `0.0`.
+* `f_abstol`: Absolute tolerance in changes of the objective value. Defaults to `0.0`.
+* `g_tol` (alternatively, `g_abstol`): Absolute tolerance in the gradient. If `g_tol` is a scalar (the default), convergence is achieved when `norm(g, Inf) ≤ g_tol`; if `g_tol` is supplied as a vector, then each component must satisfy `abs(g[i]) ≤ g_tol[i]`. Defaults to `1e-8`. For gradient-free methods (e.g., Nelder-Meade), this gets re-purposed to control the main convergence tolerance in a solver-specific manner.
 * `f_calls_limit`: A soft upper limit on the number of objective calls. Defaults to `0` (unlimited).
 * `g_calls_limit`: A soft upper limit on the number of gradient calls. Defaults to `0` (unlimited).
 * `h_calls_limit`: A soft upper limit on the number of Hessian calls. Defaults to `0` (unlimited).

--- a/docs/src/user/minimization.md
+++ b/docs/src/user/minimization.md
@@ -31,6 +31,12 @@ For better performance and greater precision, you can pass your own gradient fun
 optimize(f, x0, LBFGS(); autodiff = :forward)
 ```
 
+!!! note
+    For most real-world problems, you may want to carefully consider the appropriate convergence criteria.
+    By default, algorithms that support gradients converge if `|g| ≤ 1e-8`. Depending on how your variables are scaled,
+    this may or may not be appropriate. See [configuration](@ref config-general) for more information about your options.
+    Examining traces (`Options(show_trace=true)`) during optimization may provide insight about when convergence is achieved in practice.
+
 For the Rosenbrock example, the analytical gradient can be shown to be:
 ```jl
 function g!(G, x)
@@ -65,7 +71,7 @@ Now we can use Newton's method for optimization by running:
 ```jl
 optimize(f, g!, h!, x0)
 ```
-Which defaults to `Newton()` since a Hessian function was provided. Like gradients, the Hessian function will be ignored if you use a method that does not require it:
+which defaults to `Newton()` since a Hessian function was provided. Like gradients, the Hessian function will be ignored if you use a method that does not require it:
 ```jl
 optimize(f, g!, h!, x0, LBFGS())
 ```
@@ -73,6 +79,12 @@ Note that Optim will not generate approximate Hessians using finite differencing
 because of the potentially low accuracy of approximations to the Hessians. Other
 than Newton's method, none of the algorithms provided by the Optim package employ
 exact Hessians.
+
+As a reminder, it's advised to set your convergence criteria manually based on
+your knowledge of the problem:
+```
+optimize(f, g!, h!, x0, Optim.Options(g_tol = 1e-12))
+```
 
 ## Box Constrained Optimization
 

--- a/src/multivariate/solvers/constrained/fminbox.jl
+++ b/src/multivariate/solvers/constrained/fminbox.jl
@@ -437,11 +437,12 @@ function optimize(
                  callback=stopped_by_callback,
                  f_increased=f_increased && !options.allow_f_increases)
 
+    g_abstol, gabs = g_converge_component(options.g_abstol, df, state)
     return MultivariateOptimizationResults(F, initial_x, minimizer(results), df.f(minimizer(results)),
             iteration, results.iteration_converged,
             results.x_converged, results.x_abstol, results.x_reltol, norm(x - xold), norm(x - xold)/norm(x),
             results.f_converged, results.f_abstol, results.f_reltol, f_abschange(minimum(results), value(dfbox)), f_relchange(minimum(results), value(dfbox)),
-            results.g_converged, results.g_abstol, norm(g, Inf),
+            results.g_converged, T(g_abstol), gabs,
             results.f_increased, results.trace, results.f_calls,
             results.g_calls, results.h_calls, nothing,
             options.time_limit,

--- a/src/utilities/generic.jl
+++ b/src/utilities/generic.jl
@@ -15,3 +15,6 @@ end
     (similar(initial_x), # Buffer of x for line search in state.x_ls
     real(one(T)))             # Keep track of step size in state.alpha
 end
+
+to_eltype(::Type{T}, x::Real) where T = T(x)
+to_eltype(::Type{T}, x::AbstractArray) where T = convert(AbstractVector{T}, x)

--- a/test/general/api.jl
+++ b/test/general/api.jl
@@ -102,6 +102,24 @@
                    initial_x,
                    Newton(),
                    options_g)
+
+    options_gvec = Optim.Options(g_abstol = [1e-4, 1e-8], g_reltol = 0)
+
+    for method in (BFGS(), LBFGS(), Newton())
+        res = optimize(f, g!, h!,
+                       initial_x,
+                       method,
+                       options_gvec)
+        @test Optim.g_converged(res)
+        @test all(abs.(Optim.gradient(d2, res.minimizer)) .≤ options_gvec.g_abstol)
+        str = sprint(show, res)
+        @test occursin(r"|g(x)|.*≤ 1.0e-04", str) || occursin(r"|g(x)|.*≤ 1.0e-08", str)
+        @test occursin(r"|x - x'| .*≰", str)
+        @test occursin(r"|x - x'|/|x'|.*≰", str)
+        @test occursin(r"|f(x) - f(x')| .*≰", str)
+        @test occursin(r"|f(x) - f(x')|/|f(x')|.*≰", str)
+    end
+
     options_sa = Optim.Options(iterations = 10, store_trace = true,
                                show_trace = false)
     res = optimize(f, g!, h!,

--- a/test/general/convergence.jl
+++ b/test/general/convergence.jl
@@ -37,6 +37,9 @@ mutable struct DummyMethodZeroth <: Optim.ZerothOrderOptimizer end
     g_tol = 1e-6
     g_abstol = 1e-6
     @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol, f_tol, g_tol) == (true, true, true, false)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol, f_tol, [g_tol]) == (true, true, true, false)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol, f_tol, g_tol/1000) == (true, true, false, false)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol, f_tol, [g_tol/1000]) == (true, true, false, false)
     # f_increase
     f0, f1 = 1.0, 1.0 + 1e-7
     @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol, f_tol, g_tol) == (true, true, true, true)
@@ -46,8 +49,19 @@ mutable struct DummyMethodZeroth <: Optim.ZerothOrderOptimizer end
 
     @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol, f_tol, g_tol) == (true, false, true, true)
 
+    # Implementation with both abstol and reltol
+    f_tol = 1e-6
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, 0, x_tol, 0, f_tol, g_tol) == (true, true, true, true)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, 0, x_tol, 0, f_tol, [g_tol]) == (true, true, true, true)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol, 0, f_tol, 0, g_tol) == (true, true, true, true)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol, 0, f_tol, 0, [g_tol]) == (true, true, true, true)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, 0, x_tol/1000, 0, f_tol/1000, g_tol/1000) == (false, false, false, true)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, 0, x_tol/1000, 0, f_tol/1000, [g_tol/1000]) == (false, false, false, true)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol/1000, 0, f_tol/1000, 0, g_tol/1000) == (false, false, false, true)
+    @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol/1000, 0, f_tol/1000, 0, [g_tol/1000]) == (false, false, false, true)
+
     f_tol = 1e-6 # rel tol
-    dOpt = DummyOptions(x_tol, f_tol, g_tol, g_abstol)
+    dOpt = DummyOptions(x_tol, f_tol, g_tol, g_abstol)    # FIXME: this isn't used?
     @test Optim.assess_convergence(x1, x0, f1, f0, g, x_tol, f_tol, g_tol) == (true, true, true, true)
 
     f0, f1 = 1.0, 1.0 - 1e-7


### PR DESCRIPTION
This was inspired by #1102, and expands the discussion of convergence criteria in the documentation.

However, it also goes beyond that by optionally allowing the user to specify that the `g_abstol` criterion should change from
```julia
norm(g) <= g_abstol
```
to
```julia
all(abs(g[i]) <= g_abstol[i] for i = 1:n)
```
That is, it avoids taking the norm. As pointed out in #1102 with the scaling of the objective coefficient, it's also the case that scaling the coordinates (e.g., using meters vs kilometers) changes the scaling of the gradient components. Thus, there is an argument to be made that we need a theory of optimization over non-metric vector spaces. I'm not aware of such a theory existing, and basically all the algorithms in this package assume a metric at some place or another. But at least this allows useful convergence criteria to be specified in a scale-invariant manner.

This is fully-opt in: by default `g_abstol = 1e-8`, and that uses the previous criterion. But if you specify, e.g., `g_abstol = [1e-8, 1e-6]` (for an optimization problem with two variables), then you use the new one.

CC @stevengj
