### PR TITLE
Fixing extended trace failure for Adam and AdaMax and generalising `alpha` parameter to accept callable object (scheduler)

### DIFF
--- a/src/multivariate/solvers/first_order/adam.jl
+++ b/src/multivariate/solvers/first_order/adam.jl
@@ -55,7 +55,6 @@ function initial_state(method::Adam, options, d, initial_x::AbstractArray{T}) wh
 
     m = copy(gradient(d))
     u = zero(m)
-    a = 1 - β₁
     iter = 0
 
     AdamState(initial_x, # Maintain current state in state.x

--- a/src/multivariate/solvers/first_order/adam.jl
+++ b/src/multivariate/solvers/first_order/adam.jl
@@ -1,11 +1,31 @@
 """
 # Adam
-## Constructor
+## Constant `alpha` case (default) constructor:
+
 ```julia
     Adam(; alpha=0.0001, beta_mean=0.9, beta_var=0.999, epsilon=1e-8)
 ```
+
+## Scheduled `alpha` case constructor:
+
+Alternative to the above (default) usage where `alpha` is a fixed constant for
+all the iterations, the following constructor provides flexibility for `alpha`
+to be a callable object (a scheduler) that maps the current iteration count to
+a value of `alpha` that is to-be used for the current optimization iteraion's
+update step. This helps us in scheduling `alpha` over the iterations as
+desired, using the following usage,
+
+```julia
+    # Let alpha_scheduler be iteration -> alpha value mapping callable object
+    Adam(; alpha=alpha_scheduler, other_kwargs...)
+```
+
 ## Description
-Adam is a gradient based optimizer that choses its search direction by building up estimates of the first two moments of the gradient vector. This makes it suitable for problems with a stochastic objective and thus gradient. The method is introduced in [1] where the related AdaMax method is also introduced, see `?AdaMax` for more information on that method.
+Adam is a gradient based optimizer that choses its search direction by building
+up estimates of the first two moments of the gradient vector. This makes it
+suitable for problems with a stochastic objective and thus gradient. The method
+is introduced in [1] where the related AdaMax method is also introduced, see
+`?AdaMax` for more information on that method.
 
 ## References
 [1] https://arxiv.org/abs/1412.6980

--- a/src/multivariate/solvers/first_order/adamax.jl
+++ b/src/multivariate/solvers/first_order/adamax.jl
@@ -1,16 +1,35 @@
 """
 # AdaMax
-## Constructor
+## Constant `alpha` case (default) constructor:
+
 ```julia
     AdaMax(; alpha=0.002, beta_mean=0.9, beta_var=0.999, epsilon=1e-8)
 ```
+
+## Scheduled `alpha` case constructor:
+
+Alternative to the above (default) usage where `alpha` is a fixed constant for
+all the iterations, the following constructor provides flexibility for `alpha`
+to be a callable object (a scheduler) that maps the current iteration count to
+a value of `alpha` that is to-be used for the current optimization iteraion's
+update step. This helps us in scheduling `alpha` over the iterations as
+desired, using the following usage,
+
+```julia
+    # Let alpha_scheduler be iteration -> alpha value mapping callable object
+    AdaMax(; alpha=alpha_scheduler, other_kwargs...)
+```
+
 ## Description
-AdaMax is a gradient based optimizer that choses its search direction by building up estimates of the first two moments of the gradient vector. This makes it suitable for problems with a stochastic objective and thus gradient. The method is introduced in [1] where the related Adam method is also introduced, see `?Adam` for more information on that method.
+AdaMax is a gradient based optimizer that choses its search direction by
+building up estimates of the first two moments of the gradient vector. This
+makes it suitable for problems with a stochastic objective and thus gradient.
+The method is introduced in [1] where the related Adam method is also
+introduced, see `?Adam` for more information on that method.
 
-
+## References
 [1] https://arxiv.org/abs/1412.6980
 """
-
 struct AdaMax{Tα, T, Tm} <: FirstOrderOptimizer
     α::Tα  
     β₁::T

--- a/test/multivariate/solvers/first_order/adam_adamax.jl
+++ b/test/multivariate/solvers/first_order/adam_adamax.jl
@@ -21,6 +21,7 @@
                     skip = skip,
                     show_name = debug_printing)
 end
+
 @testset "AdaMax" begin
     f(x) = x[1]^4
     function g!(storage, x)
@@ -44,4 +45,52 @@ end
                     skip = skip,
                     show_name=debug_printing,
                     iteration_exceptions = (("Trigonometric", 1_000_000,),))
+end
+
+@testset "Adam-scheduler" begin
+  f(x) = x[1]^4
+  function g!(storage, x)
+      storage[1] = 4 * x[1]^3
+      return
+  end
+
+  initial_x = [1.0]
+  options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=100_000)
+  alpha_scheduler(iter) = 0.0001*(1 + 0.99^iter)
+  results = Optim.optimize(f, g!, initial_x, Adam(alpha=alpha_scheduler), options)
+  @test norm(Optim.minimum(results)) < 1e-6
+  @test summary(results) == "Adam"
+
+  # verifying the alpha values over iterations and also testing extended_trace
+  # this way we test both alpha scheduler and the working of
+  # extended_trace=true option
+
+  options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=1000, extended_trace=true, store_trace=true)
+  results = Optim.optimize(f, g!, initial_x, Adam(alpha=alpha_scheduler), options)
+
+  @test map(iter -> results.trace[iter].metadata["Current step size"], 2:results.iterations+1) == alpha_scheduler.(1:results.iterations)
+end
+
+@testset "AdaMax-scheduler" begin
+  f(x) = x[1]^4
+  function g!(storage, x)
+      storage[1] = 4 * x[1]^3
+      return
+  end
+
+  initial_x = [1.0]
+  options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=100_000)
+  alpha_scheduler(iter) = 0.002*(1 + 0.99^iter)
+  results = Optim.optimize(f, g!, initial_x, AdaMax(alpha=alpha_scheduler), options)
+  @test norm(Optim.minimum(results)) < 1e-6
+  @test summary(results) == "AdaMax"
+
+  # verifying the alpha values over iterations and also testing extended_trace
+  # this way we test both alpha scheduler and the working of
+  # extended_trace=true option
+
+  options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=1000, extended_trace=true, store_trace=true)
+  results = Optim.optimize(f, g!, initial_x, AdaMax(alpha=alpha_scheduler), options)
+
+  @test map(iter -> results.trace[iter].metadata["Current step size"], 2:results.iterations+1) == alpha_scheduler.(1:results.iterations)
 end

--- a/test/multivariate/solvers/first_order/adam_adamax.jl
+++ b/test/multivariate/solvers/first_order/adam_adamax.jl
@@ -66,6 +66,11 @@ end
   # extended_trace=true option
 
   options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=1000, extended_trace=true, store_trace=true)
+  results = Optim.optimize(f, g!, initial_x, Adam(alpha=1e-5), options)
+
+  @test prod(map(iter -> results.trace[iter].metadata["Current step size"], 2:results.iterations+1) .== 1e-5)
+
+  options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=1000, extended_trace=true, store_trace=true)
   results = Optim.optimize(f, g!, initial_x, Adam(alpha=alpha_scheduler), options)
 
   @test map(iter -> results.trace[iter].metadata["Current step size"], 2:results.iterations+1) == alpha_scheduler.(1:results.iterations)
@@ -88,6 +93,11 @@ end
   # verifying the alpha values over iterations and also testing extended_trace
   # this way we test both alpha scheduler and the working of
   # extended_trace=true option
+
+  options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=1000, extended_trace=true, store_trace=true)
+  results = Optim.optimize(f, g!, initial_x, AdaMax(alpha=1e-4), options)
+
+  @test prod(map(iter -> results.trace[iter].metadata["Current step size"], 2:results.iterations+1) .== 1e-4)
 
   options = Optim.Options(show_trace = debug_printing, allow_f_increases=true, iterations=1000, extended_trace=true, store_trace=true)
   results = Optim.optimize(f, g!, initial_x, AdaMax(alpha=alpha_scheduler), options)


### PR DESCRIPTION
This is a small PR for Adam and AdaMax methods (thanks a lot for adding them to `Optim.jl`) to 

- fix issue https://github.com/JuliaNLSolvers/Optim.jl/issues/1096 (when using `extended_trace=true`) by adding `alpha` to the respective `State` structs, so that `common_trace!` works out of the box.
- generalise `alpha` (and effected `update_state!`) for both `Adam` and `AdaMax` such that they can accept a callable object - a function or in particular a scheduler. This helps in using the functionality from [ParameterSchedulers.jl](https://github.com/FluxML/ParameterSchedulers.jl) seamlessly, without adding it as a dependency.