### PR TITLE
Use DocumenterCitations.jl

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 NLSolversBase = "d41bc354-129a-5804-8e4c-c37616107c6c"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,3 +9,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 Documenter = "1"
 Literate = "2"
+
+[sources.Optim]
+path = ".."

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,11 @@ if Base.HOME_PROJECT[] !== nothing
     Base.HOME_PROJECT[] = abspath(Base.HOME_PROJECT[])
 end
 
-using Documenter, Optim
+using Optim
+using Documenter
+using DocumenterCitations
+
+bib = CitationBibliography(joinpath(@__DIR__, "src", "refs.bib"); style=:authoryear)
 
 # use include("Rosenbrock.jl") etc
 # Generate examples
@@ -54,7 +58,8 @@ makedocs(
      ],
      "Contributing" => "dev/contributing.md",
      "License" => "LICENSE.md",
-     ]
+     ],
+    plugins = [bib],
 )
 
 deploydocs(

--- a/docs/src/algo/adam_adamax.md
+++ b/docs/src/algo/adam_adamax.md
@@ -20,4 +20,7 @@ AdaMax(; alpha=0.002,
 where `alpha` is the step length or learning parameter. `beta_mean` and `beta_var` are exponential decay parameters for the first and second moments estimates. Setting these closer to 0 will cause past iterates to matter less for the current steps and setting them closer to 1 means emphasizing past iterates more.
 
 ## References
-Kingma, Diederik P., and Jimmy Ba. "Adam: A method for stochastic optimization." arXiv preprint arXiv:1412.6980 (2014).
+
+```@bibliography
+kingma2017
+```

--- a/docs/src/algo/cg.md
+++ b/docs/src/algo/cg.md
@@ -74,3 +74,8 @@ fewer gradient evaluations to reach convergence.
 ## References
 - W. W. Hager and H. Zhang (2006) Algorithm 851: CG_DESCENT, a conjugate gradient method with guaranteed descent. ACM Transactions on Mathematical Software 32: 113-137.
 - W. W. Hager and H. Zhang (2013), The Limited Memory Conjugate Gradient Method. SIAM Journal on Optimization, 23, pp. 2150-2168.
+
+```@bibliography
+hager2006
+hager2013
+```

--- a/docs/src/algo/complex.md
+++ b/docs/src/algo/complex.md
@@ -132,5 +132,7 @@ Automatic differentiation support for complex inputs may come when
 
 ## References
 
- - Sorber, L., Barel, M. V., & Lathauwer, L. D. (2012). Unconstrained optimization of real functions in complex variables. SIAM Journal on Optimization, 22(3), 879-898.
- - Kreutz-Delgado, K. (2009). The complex gradient operator and the CR-calculus. arXiv preprint arXiv:0906.4835.
+```@bibliography
+sorber2012
+kreutz-delgado2009
+```

--- a/docs/src/algo/lbfgs.md
+++ b/docs/src/algo/lbfgs.md
@@ -58,4 +58,7 @@ and is chosen by a linesearch algorithm such that each step gives sufficient des
 
 ## Example
 ## References
-Wright, Stephen, and Jorge Nocedal (2006) "Numerical optimization." Springer
+
+```@bibliography
+nocedal2006
+```

--- a/docs/src/algo/manifolds.md
+++ b/docs/src/algo/manifolds.md
@@ -35,3 +35,8 @@ Implementing new manifolds is as simple as adding methods `project_tangent!(M::Y
 The Geometry of Algorithms with Orthogonality Constraints, Alan Edelman, Tomás A. Arias, Steven T. Smith, SIAM. J. Matrix Anal. & Appl., 20(2), 303–353
 
 Optimization Algorithms on Matrix Manifolds, P.-A. Absil, R. Mahony, R. Sepulchre, Princeton University Press, 2008
+
+```@bibliography
+edelman1998
+absil2008
+```

--- a/docs/src/algo/nelder_mead.md
+++ b/docs/src/algo/nelder_mead.md
@@ -119,3 +119,9 @@ Nelder, John A. and R. Mead (1965). "A simplex method for function minimization"
 Lagarias, Jeffrey C., et al. "Convergence properties of the Nelder--Mead simplex method in low dimensions." SIAM Journal on optimization 9.1 (1998): 112-147.
 
 Gao, Fuchang and Lixing Han (2010). "Implementing the Nelder-Mead simplex algorithm with adaptive parameters". Computational Optimization and Applications [DOI 10.1007/s10589-010-9329-3]
+
+```@bibliography
+nelder1965
+lagarias1998
+gao2012
+```

--- a/docs/src/algo/nelder_mead.md
+++ b/docs/src/algo/nelder_mead.md
@@ -9,9 +9,9 @@ The keywords in the constructor are used to control the following parts of the
 solver:
 
 * `parameters` is a an instance of either `AdaptiveParameters` or `FixedParameters`, and is
-used to generate parameters for the Nelder-Mead Algorithm.
+  used to generate parameters for the Nelder-Mead Algorithm.
 * `initial_simplex` is an instance of `AffineSimplexer`. See more
-details below.
+  details below.
 
 
 ## Description
@@ -113,12 +113,8 @@ and add a method to the `parameters` function. It should take the new type as th
 first positional argument, and the dimensionality of `x` as the second positional argument, and
 return a 4-tuple of parameters. However, it will often be easier to simply supply
 the wanted parameters to `FixedParameters`.
+
 ## References
-Nelder, John A. and R. Mead (1965). "A simplex method for function minimization". Computer Journal 7: 308–313. doi:10.1093/comjnl/7.4.308.
-
-Lagarias, Jeffrey C., et al. "Convergence properties of the Nelder--Mead simplex method in low dimensions." SIAM Journal on optimization 9.1 (1998): 112-147.
-
-Gao, Fuchang and Lixing Han (2010). "Implementing the Nelder-Mead simplex algorithm with adaptive parameters". Computational Optimization and Applications [DOI 10.1007/s10589-010-9329-3]
 
 ```@bibliography
 nelder1965

--- a/docs/src/algo/newton_trust_region.md
+++ b/docs/src/algo/newton_trust_region.md
@@ -58,4 +58,6 @@ res = Optim.optimize(prob.f, prob.g!, prob.h!, prob.initial_x, NewtonTrustRegion
 
 ## References
 
-[1] Nocedal, Jorge, and Stephen Wright. Numerical optimization. Springer Science & Business Media, 2006.
+```@bibliography
+nocedal2006
+```

--- a/docs/src/algo/ngmres.md
+++ b/docs/src/algo/ngmres.md
@@ -163,3 +163,8 @@ Results of Optimization Algorithm
 [1] De Sterck. Steepest descent preconditioning for nonlinear GMRES optimization. NLAA, 2013.
 [2] Washio and Oosterlee. Krylov subspace acceleration for nonlinear multigrid schemes. ETNA, 1997.
 [3] Riseth. Objective acceleration for unconstrained optimization. 2018.
+```@bibliography
+sterck2013
+washio1997
+riseth2019
+```

--- a/docs/src/algo/particle_swarm.md
+++ b/docs/src/algo/particle_swarm.md
@@ -22,4 +22,7 @@ improve the ability to find a global optimum. Of course, this comes a the cost
 of slower convergence, but hopefully converges to the global optimum as a result.
 
 ## References
-[1] Zhan, Zhang, and Chung. Adaptive particle swarm optimization, IEEE Transactions on Systems, Man, and Cybernetics, Part B: CyberneticsVolume 39, Issue 6, 2009, Pages 1362-1381 (2009)
+
+```@bibliography
+zhi-huizhan2009
+```

--- a/docs/src/algo/samin.md
+++ b/docs/src/algo/samin.md
@@ -107,3 +107,8 @@ Results of Optimization Algorithm
 ## References
  - Goffe, et. al. (1994) "Global Optimization of Statistical Functions with Simulated Annealing", Journal of Econometrics, V. 60, N. 1/2.
  - Goffe, William L. (1996) "SIMANN: A Global Optimization Algorithm using Simulated Annealing " Studies in Nonlinear Dynamics & Econometrics, Oct96, Vol. 1 Issue 3.
+
+```@bibliography
+goffe1994
+goffe1996
+```

--- a/docs/src/algo/samin.md
+++ b/docs/src/algo/samin.md
@@ -105,8 +105,6 @@ Results of Optimization Algorithm
 ```
 
 ## References
- - Goffe, et. al. (1994) "Global Optimization of Statistical Functions with Simulated Annealing", Journal of Econometrics, V. 60, N. 1/2.
- - Goffe, William L. (1996) "SIMANN: A Global Optimization Algorithm using Simulated Annealing " Studies in Nonlinear Dynamics & Econometrics, Oct96, Vol. 1 Issue 3.
 
 ```@bibliography
 goffe1994

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,0 +1,242 @@
+@book{absil2008,
+  title = {Optimization Algorithms on Matrix Manifolds},
+  author = {Absil, P.-A.},
+  year = {2008},
+  publisher = {Princeton University Press},
+  address = {Princeton},
+  collaborator = {Mahony, R. and Sepulchre, Rodolphe},
+  isbn = {978-0-691-13298-3 978-1-4008-3024-4},
+  langid = {english}
+}
+
+@article{edelman1998,
+  title = {The Geometry of Algorithms with Orthogonality Constraints},
+  author = {Edelman, Alan and Arias, Tom{\'a}s A. and Smith, Steven T.},
+  year = {1998},
+  month = jan,
+  journal = {SIAM Journal on Matrix Analysis and Applications},
+  volume = {20},
+  number = {2},
+  pages = {303--353},
+  issn = {0895-4798, 1095-7162},
+  doi = {10.1137/S0895479895290954},
+  langid = {english}
+}
+
+@article{gao2012,
+  title = {Implementing the Nelder-Mead Simplex Algorithm with Adaptive Parameters},
+  author = {Gao, Fuchang and Han, Lixing},
+  year = {2012},
+  month = jan,
+  journal = {Computational Optimization and Applications},
+  volume = {51},
+  number = {1},
+  pages = {259--277},
+  issn = {0926-6003, 1573-2894},
+  doi = {10.1007/s10589-010-9329-3},
+  copyright = {http://www.springer.com/tdm},
+  langid = {english}
+}
+
+@article{goffe1994,
+  title = {Global Optimization of Statistical Functions with Simulated Annealing},
+  author = {Goffe, William L. and Ferrier, Gary D. and Rogers, John},
+  year = {1994},
+  month = jan,
+  journal = {Journal of Econometrics},
+  volume = {60},
+  number = {1-2},
+  pages = {65--99},
+  issn = {03044076},
+  doi = {10.1016/0304-4076(94)90038-8},
+  copyright = {https://www.elsevier.com/tdm/userlicense/1.0/},
+  langid = {english}
+}
+
+@article{goffe1996,
+  title = {SIMANN: A Global Optimization Algorithm Using Simulated Annealing},
+  shorttitle = {SIMANN},
+  author = {Goffe, William L.},
+  year = {1996},
+  month = jan,
+  journal = {Studies in Nonlinear Dynamics \& Econometrics},
+  volume = {1},
+  number = {3},
+  issn = {1558-3708},
+  doi = {10.2202/1558-3708.1020}
+}
+
+@article{hager2006,
+  title = {Algorithm 851: CG_DESCENT, a Conjugate Gradient Method with Guaranteed Descent},
+  shorttitle = {Algorithm 851},
+  author = {Hager, William W. and Zhang, Hongchao},
+  year = {2006},
+  month = mar,
+  journal = {ACM Transactions on Mathematical Software},
+  volume = {32},
+  number = {1},
+  pages = {113--137},
+  issn = {0098-3500, 1557-7295},
+  doi = {10.1145/1132973.1132979},
+  langid = {english}
+}
+
+@article{hager2013,
+  title = {The Limited Memory Conjugate Gradient Method},
+  author = {Hager, William W. and Zhang, Hongchao},
+  year = {2013},
+  month = jan,
+  journal = {SIAM Journal on Optimization},
+  volume = {23},
+  number = {4},
+  pages = {2150--2168},
+  issn = {1052-6234, 1095-7189},
+  doi = {10.1137/120898097},
+  langid = {english}
+}
+
+@misc{kingma2017,
+  title = {Adam: A Method for Stochastic Optimization},
+  shorttitle = {Adam},
+  author = {Kingma, Diederik P. and Ba, Jimmy},
+  year = {2017},
+  month = jan,
+  number = {arXiv:1412.6980},
+  eprint = {1412.6980},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.1412.6980},
+  archiveprefix = {arXiv},
+  keywords = {Computer Science - Machine Learning}
+}
+
+@misc{kreutz-delgado2009,
+  title = {The Complex Gradient Operator and the CR-Calculus},
+  author = {Kreutz-Delgado, Ken},
+  year = {2009},
+  publisher = {arXiv},
+  doi = {10.48550/ARXIV.0906.4835},
+  copyright = {arXiv.org perpetual, non-exclusive license},
+  keywords = {Complex Variables (math.CV),FOS: Mathematics,Optimization and Control (math.OC)}
+}
+
+@article{lagarias1998,
+  title = {Convergence Properties of the Nelder--Mead Simplex Method in Low Dimensions},
+  author = {Lagarias, Jeffrey C. and Reeds, James A. and Wright, Margaret H. and Wright, Paul E.},
+  year = {1998},
+  month = jan,
+  journal = {SIAM Journal on Optimization},
+  volume = {9},
+  number = {1},
+  pages = {112--147},
+  issn = {1052-6234, 1095-7189},
+  doi = {10.1137/S1052623496303470},
+  langid = {english}
+}
+
+@article{nelder1965,
+  title = {A Simplex Method for Function Minimization},
+  author = {Nelder, J. A. and Mead, R.},
+  year = {1965},
+  month = jan,
+  journal = {The Computer Journal},
+  volume = {7},
+  number = {4},
+  pages = {308--313},
+  issn = {0010-4620, 1460-2067},
+  doi = {10.1093/comjnl/7.4.308},
+  langid = {english}
+}
+
+@book{nocedal2006,
+  title = {Numerical Optimization},
+  author = {Nocedal, Jorge and Wright, Stephen},
+  year = {2006},
+  series = {Springer Series in Operations Research and Financial Engineering},
+  publisher = {Springer New York},
+  doi = {10.1007/978-0-387-40065-5},
+  copyright = {http://www.springer.com/tdm},
+  isbn = {978-0-387-30303-1},
+  langid = {english}
+}
+
+@article{riseth2019,
+  title = {Objective Acceleration for Unconstrained Optimization},
+  author = {Riseth, Asbj{\o}rn Nilsen},
+  year = {2019},
+  month = jan,
+  journal = {Numerical Linear Algebra with Applications},
+  volume = {26},
+  number = {1},
+  pages = {e2216},
+  issn = {1070-5325, 1099-1506},
+  doi = {10.1002/nla.2216},
+  langid = {english}
+}
+
+@article{sorber2012,
+  title = {Unconstrained Optimization of Real Functions in Complex Variables},
+  author = {Sorber, Laurent and Barel, Marc Van and Lathauwer, Lieven De},
+  year = {2012},
+  month = jan,
+  journal = {SIAM Journal on Optimization},
+  volume = {22},
+  number = {3},
+  pages = {879--898},
+  issn = {1052-6234, 1095-7189},
+  doi = {10.1137/110832124},
+  langid = {english}
+}
+
+@article{sterck2013,
+  title = {Steepest Descent Preconditioning for Nonlinear GMRES Optimization},
+  author = {Sterck, Hans De},
+  year = {2013},
+  month = may,
+  journal = {Numerical Linear Algebra with Applications},
+  volume = {20},
+  number = {3},
+  pages = {453--471},
+  issn = {1070-5325, 1099-1506},
+  doi = {10.1002/nla.1837},
+  copyright = {http://onlinelibrary.wiley.com/termsAndConditions\#vor},
+  langid = {english}
+}
+
+@article{wachter2006,
+  title = {On the Implementation of an Interior-Point Filter Line-Search Algorithm for Large-Scale Nonlinear Programming},
+  author = {W{\"a}chter, Andreas and Biegler, Lorenz T.},
+  year = {2006},
+  month = mar,
+  journal = {Mathematical Programming},
+  volume = {106},
+  number = {1},
+  pages = {25--57},
+  issn = {0025-5610, 1436-4646},
+  doi = {10.1007/s10107-004-0559-y},
+  copyright = {http://www.springer.com/tdm},
+  langid = {english}
+}
+
+@article{washio1997,
+  title = {Krylov Subspace Acceleration for Nonlinear Multigrid Schemes},
+  author = {Washio, T. and Oosterlee, C. W.},
+  year = {1997},
+  journal = {Electronic Transactions on Numerical Analysis},
+  volume = {6},
+  pages = {271--290}
+}
+
+@article{zhi-huizhan2009,
+  title = {Adaptive Particle Swarm Optimization},
+  author = {{Zhi-Hui Zhan} and {Jun Zhang} and {Yun Li} and Chung, H.S.-H.},
+  year = {2009},
+  month = dec,
+  journal = {IEEE Transactions on Systems, Man, and Cybernetics, Part B (Cybernetics)},
+  volume = {39},
+  number = {6},
+  pages = {1362--1381},
+  issn = {1083-4419},
+  doi = {10.1109/TSMCB.2009.2015956},
+  copyright = {https://ieeexplore.ieee.org/Xplorehelp/downloads/license-information/IEEE.html}
+}
+


### PR DESCRIPTION
Currently the references are enumerated at the end of doc pages, but as more references are added (as seen by empty headers on some other doc pages), it'll be useful to have a citation management tool with Documenter.jl.