### PR TITLE
add `Options(options; kws...)` for inheriting from an existing options set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Optim"
 uuid = "429524aa-4258-5aef-a3af-852621145aeb"
-version = "1.13.3"
+version = "1.14.0"
 
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Optim"
 uuid = "429524aa-4258-5aef-a3af-852621145aeb"
-version = "1.13.0"
+version = "1.13.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Optim"
 uuid = "429524aa-4258-5aef-a3af-852621145aeb"
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/types.jl
+++ b/src/types.jl
@@ -189,45 +189,19 @@ function Options(;
 end
 
 function Options(o::Options; kws...)
+    fields = fieldnames(typeof(o))
     foreach(keys(kws)) do kw
-        if kw ∉ (:x_abstol, :x_reltol, :f_abstol, :f_reltol, :g_abstol, :outer_x_abstol, 
-                 :outer_x_reltol, :outer_f_abstol, :outer_f_reltol, :outer_g_abstol,
-                 :f_calls_limit, :g_calls_limit, :h_calls_limit, :allow_f_increases,
-                 :allow_outer_f_increases, :successive_f_tol, :iterations,
-                 :outer_iterations, :store_trace, :trace_simplex, :show_trace,
-                 :extended_trace, :show_warnings, :show_every, :callback, :time_limit)
+        if kw ∉ fields
             error(lazy"`$kw` is not a valid keyword argument of `Options(opts; kws...)`")
         end
     end
-    Options(
-        get(kws, :x_abstol,                o.x_abstol),
-        get(kws, :x_reltol,                o.x_reltol),
-        get(kws, :f_abstol,                o.f_abstol),
-        get(kws, :f_reltol,                o.f_reltol),
-        get(kws, :g_abstol,                o.g_abstol),
-        get(kws, :outer_x_abstol,          o.outer_x_abstol),
-        get(kws, :outer_x_reltol,          o.outer_x_reltol),
-        get(kws, :outer_f_abstol,          o.outer_f_abstol),
-        get(kws, :outer_f_reltol,          o.outer_f_reltol),
-        get(kws, :outer_g_abstol,          o.outer_g_abstol),
-        get(kws, :f_calls_limit,           o.f_calls_limit),
-        get(kws, :g_calls_limit,           o.g_calls_limit),
-        get(kws, :h_calls_limit,           o.h_calls_limit),
-        get(kws, :allow_f_increases,       o.allow_f_increases),
-        get(kws, :allow_outer_f_increases, o.allow_outer_f_increases),
-        get(kws, :successive_f_tol,        o.successive_f_tol),
-        get(kws, :iterations,              o.iterations),
-        get(kws, :outer_iterations,        o.outer_iterations),
-        get(kws, :store_trace,             o.store_trace),
-        get(kws, :trace_simplex,           o.trace_simplex),
-        get(kws, :show_trace,              o.show_trace),
-        get(kws, :extended_trace,          o.extended_trace),
-        get(kws, :show_warnings,           o.show_warnings),
-        get(kws, :show_every,              o.show_every),
-        get(kws, :callback,                o.callback),
-        get(kws, :time_limit,              o.time_limit),
-    )
+    newargs = ntuple(Val(nfields(o))) do i
+        field = fields[i]
+        get(kws, field, getfield(o, field))
+    end
+    return Options(newargs...)
 end
+
 _show_helper(output, k, v) = output * "$k = $v, "
 _show_helper(output, k, ::Nothing) = output
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,7 +9,11 @@ abstract type AbstractOptimizerState end
 abstract type ZerothOrderState <: AbstractOptimizerState end
 
 """
-Configurable options with defaults (values 0 and NaN indicate unlimited):
+    Options(; opts...)
+
+Specify configurable optimizer options `opts...`. Unspecified options are set to the default
+values below (values 0 and NaN indicate unlimited):
+
 ```
 x_abstol::Real = 0.0,
 x_reltol::Real = 0.0,
@@ -37,7 +41,19 @@ show_every::Int = 1,
 callback = nothing,
 time_limit = NaN
 ```
-See http://julianlsolvers.github.io/Optim.jl/stable/#user/config/
+
+It is also possible to pass a previously defined `Options` argument as the first argument,
+i.e., as:
+
+```jl
+    Options(inherit_options; opts...)
+```
+
+Default values for unspecified `opts` will then be "inherited" from `inherit_options`. This
+can be used to modify a subset of options in a previously defined `Options` variable.
+
+For more information on individual options, see the documentaton at
+http://julianlsolvers.github.io/Optim.jl/stable/#user/config/.
 """
 struct Options{T, TCallback}
     x_abstol::T
@@ -172,6 +188,46 @@ function Options(;
     )
 end
 
+function Options(o::Options; kws...)
+    foreach(keys(kws)) do kw
+        if kw ∉ (:x_abstol, :x_reltol, :f_abstol, :f_reltol, :g_abstol, :outer_x_abstol, 
+                 :outer_x_reltol, :outer_f_abstol, :outer_f_reltol, :outer_g_abstol,
+                 :f_calls_limit, :g_calls_limit, :h_calls_limit, :allow_f_increases,
+                 :allow_outer_f_increases, :successive_f_tol, :iterations,
+                 :outer_iterations, :store_trace, :trace_simplex, :show_trace,
+                 :extended_trace, :show_warnings, :show_every, :callback, :time_limit)
+            error(lazy"`$kw` is not a valid keyword argument of `Options(opts; kws...)`")
+        end
+    end
+    Options(
+        get(kws, :x_abstol,                o.x_abstol),
+        get(kws, :x_reltol,                o.x_reltol),
+        get(kws, :f_abstol,                o.f_abstol),
+        get(kws, :f_reltol,                o.f_reltol),
+        get(kws, :g_abstol,                o.g_abstol),
+        get(kws, :outer_x_abstol,          o.outer_x_abstol),
+        get(kws, :outer_x_reltol,          o.outer_x_reltol),
+        get(kws, :outer_f_abstol,          o.outer_f_abstol),
+        get(kws, :outer_f_reltol,          o.outer_f_reltol),
+        get(kws, :outer_g_abstol,          o.outer_g_abstol),
+        get(kws, :f_calls_limit,           o.f_calls_limit),
+        get(kws, :g_calls_limit,           o.g_calls_limit),
+        get(kws, :h_calls_limit,           o.h_calls_limit),
+        get(kws, :allow_f_increases,       o.allow_f_increases),
+        get(kws, :allow_outer_f_increases, o.allow_outer_f_increases),
+        get(kws, :successive_f_tol,        o.successive_f_tol),
+        get(kws, :iterations,              o.iterations),
+        get(kws, :outer_iterations,        o.outer_iterations),
+        get(kws, :store_trace,             o.store_trace),
+        get(kws, :trace_simplex,           o.trace_simplex),
+        get(kws, :show_trace,              o.show_trace),
+        get(kws, :extended_trace,          o.extended_trace),
+        get(kws, :show_warnings,           o.show_warnings),
+        get(kws, :show_every,              o.show_every),
+        get(kws, :callback,                o.callback),
+        get(kws, :time_limit,              o.time_limit),
+    )
+end
 _show_helper(output, k, v) = output * "$k = $v, "
 _show_helper(output, k, ::Nothing) = output
 

--- a/test/general/types.jl
+++ b/test/general/types.jl
@@ -45,4 +45,14 @@ import Compat.String
     io = IOBuffer()
     res = show(io, MIME"text/plain"(), Optim.Options(x_abstol = 10.0))
     @test String(take!(io)) |> contains("x_abstol = 10.0")
+
+    # inheriting update from previously defined `Options`
+    opts1 = Optim.Options(; x_abstol = 1e-3, f_abstol = 1e-6, iterations = 1000)
+    opts2 = Optim.Options(opts1; x_abstol = 1e-4, f_calls_limit = 100)
+    @test opts2.x_abstol == 1e-4 && opts2.x_abstol != opts1.x_abstol
+    @test opts2.f_calls_limit == 100 && opts2.f_calls_limit != opts1.f_calls_limit
+    @test opts2.f_abstol == opts1.f_abstol == 1e-6
+    @test opts2.iterations == opts1.iterations == 1000
+    @test_throws "not a valid keyword argument" Optim.Options(opts1; invalid_keyword=1)
+    @test Optim.Options(opts1) == opts1
 end


### PR DESCRIPTION
This implements the feature described in #1171. I did not add the deprecated keyword arguments that are possible to pass to the `Optim(; kws..)` constructor; since this would be new API, it seemed unnecessary.

~~The implementation is not very DRY, since it needs to repeat the valid keyword arguments - but cleaner solutions would probably require a dependency like SetFields.jl or Accessors.jl, which doesn't feel warranted for a small feature like this.~~
