### PR TITLE
Fix SimulatedAnnealing docs

### DIFF
--- a/docs/src/algo/simulated_annealing.md
+++ b/docs/src/algo/simulated_annealing.md
@@ -2,15 +2,13 @@
 ## Constructor
 ```julia
 SimulatedAnnealing(; neighbor = default_neighbor!,
-                    T = default_temperature,
-                    p = kirkpatrick)
+                     temperature = default_temperature)
 ```
 
-The constructor takes three keywords:
+The constructor takes two keywords:
 
 * `neighbor = a!(x_current, x_proposed)`, a mutating function of the current x, and the proposed x
-* `T = b(iteration)`, a function of the current iteration that returns a temperature
-* `p = c(f_proposal, f_current, T)`, a function of the current temperature, current function value and proposed function value that returns an acceptance probability
+* `temperature = b(iteration)`, a function of the current iteration that returns a temperature
 
 ## Description
 Simulated Annealing is a derivative free method for optimization. It is based on
@@ -22,21 +20,21 @@ reasons given above, the algorithm uses terms such as cooling, temperature, and
 acceptance probabilities.
 
 As the constructor shows, a simulated annealing implementation is characterized
-by a temperature, a neighbor function, and
-an acceptance probability. The temperature controls how volatile the changes in
-minimizer candidates are allowed to be, as it enters the acceptance probability.
-For example, the original Kirkpatrick et al. acceptance probability function can be written
-as follows
+by a temperature and a neighbor function. The temperature controls how volatile the changes in
+minimizer candidates are allowed to be: if `T` is the current temperature, and the objective
+values of the current and proposed solutions are `f_current` and `f_proposal`, respectively,
+then the probability that the proposed solution will be accepted is
 ```julia
-p(f_proposal, f_current, T) = exp(-(f_proposal - f_current)/T)
+exp(-(f_proposal - f_current)/T)
 ```
-A high temperature makes it more likely that a draw is accepted, by pushing acceptance
-probability to 1. As in the Metropolis-Hastings
-algorithm, we always accept a smaller function value, but we also sometimes accept a
-larger value. As the temperature decreases, we're more and more likely to only accept
-candidate `x`'s that lowers the function value. To obtain a new `f_proposal`, we need
-a neighbor function. A simple neighbor function adds a standard normal draw to each
-dimension of `x`
+Note that this implies that the proposed solution is guaranteed to be accepted
+if `f_proposal <= f_current`, because this probability becomes larger than 1.
+If conversely `f_proposal > f_current`, there is still a chance that it will
+be accepted, depending on the temperature, with higher temperatures making
+acceptance more likely.
+
+To obtain a new `f_proposal`, we need a neighbor function. A simple neighbor
+function adds a standard normal draw to each dimension of `x`
 ```julia
 function neighbor!(x::Array, x_proposal::Array)
     for i in eachindex(x)
@@ -44,10 +42,7 @@ function neighbor!(x::Array, x_proposal::Array)
     end
 end
 ```
-As we see, it is not really possible
-to disentangle the role of the different components of the algorithm. For example, both the
-functional form of the acceptance function, the temperature and (indirectly) the neighbor
-function determine if the next draw of `x` is accepted or not.
+However, some problems may require custom neighbor functions.
 
 This implementation of Simulated Annealing is a quite simple version of Simulated Annealing
 without many bells and whistles. In Optim.jl, we also have the `SAMIN` algorithm implemented.
@@ -57,4 +52,26 @@ domain.
 
 ## Example
 
+Given a graph adjacency matrix `J`, the [max-cut problem](https://en.wikipedia.org/wiki/Maximum_cut)
+may be solved as follows:
+
+```julia
+maxcut_objective(x::AbstractVector, J::AbstractMatrix{Bool}) = x' * (J * x)
+
+function maxcut_spinflip!(xcurrent::AbstractVector, xproposed::AbstractVector, p::Real)
+    for i in eachindex(xcurrent, xproposed)
+        xproposed[i] = (rand() < p ? -1 : 1) * xcurrent[i]
+    end
+    return xproposed
+end
+
+n = size(J, 1)
+x0 = rand([-1.0, 1.0], n)    # each entry is ±1
+method = SimulatedAnnealing(; neighbor=(xc, xp) -> maxcut_spinflip!(xc, xp, 2/n))
+options = Optim.Options(; iterations = 100_000)
+results = Optim.optimize(x -> maxcut_objective(x, J), x0, method, options)
+```
+
 ## References
+
+Kirkpatrick, S., Gelatt Jr, C. D., & Vecchi, M. P. (1983). Optimization by simulated annealing. Science, 220(4598), 671-680.

--- a/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
+++ b/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
@@ -21,16 +21,13 @@ end
 ## Constructor
 ```julia
 SimulatedAnnealing(; neighbor = default_neighbor!,
-                     temperature = log_temperature,
-                     keep_best::Bool = true)
+                     temperature = log_temperature)
 ```
 
-The constructor takes 3 keywords:
-* `neighbor = a!(x_proposed, x_current)`, a mutating function of the current `x`,
+The constructor takes two keywords:
+* `neighbor = a!(x_current, x_proposed)`, a mutating function of the current `x`,
 and the proposed `x`
-* `T = b(iteration)`, a function of the current iteration that returns a temperature
-* `p = c(f_proposal, f_current, T)`, a function of the current temperature, current
-function value and proposed function value that returns an acceptance probability
+* `temperature = b(iteration)`, a function of the current iteration that returns a temperature
 
 ## Description
 Simulated Annealing is a derivative free method for optimization. It is based on the

--- a/test/multivariate/solvers/zeroth_order/simulated_annealing.jl
+++ b/test/multivariate/solvers/zeroth_order/simulated_annealing.jl
@@ -22,4 +22,38 @@
         extended_trace = true,
     )
     results = Optim.optimize(rosenbrock_s, [0.0, 0.0], SimulatedAnnealing(), options)
+
+    # Max-cut problem, https://en.wikipedia.org/wiki/Maximum_cut
+    maxcut_objective(x::AbstractVector, J::AbstractMatrix{Bool}) = x' * (J * x)
+    function maxcut_spinflip!(xcurrent::AbstractVector, xproposed::AbstractVector, p::Real)
+        for i in eachindex(xcurrent, xproposed)
+            xproposed[i] = (rand() < p ? -1 : 1) * xcurrent[i]
+        end
+        return xproposed
+    end
+    function makeJ(n, p)
+        n * p >= 2 || error("p must be large enough to ensure a connected graph")
+        pbar = p * (1 - 1/n)
+        function randconnect(i, j)
+            j <= i && return false   # only fill in upper triangle
+            j == i+1 && return true  # ensure graph is connected so we can use the Edwards bound
+            return rand() < pbar
+        end
+        J = [randconnect(i, j) for i in 1:n, j in 1:n]
+        J = J .| J'   # make symmetric
+        return J
+    end
+    n, p = 10, 0.2
+    J = makeJ(n, p)
+    edwards_bound = -sum(J) / 4 - (n - 1) / 4
+    method = SimulatedAnnealing(; neighbor=(xc, xp) -> maxcut_spinflip!(xc, xp, 2/n))
+    options = Optim.Options(; iterations = 100_000)
+    x0 = rand([-1.0, 1.0], n)
+    # Ensure the initialization is worse than the Edwards bound
+    while maxcut_objective(x0, J) <= edwards_bound
+        x0 = rand([-1.0, 1.0], n)
+    end
+    results = Optim.optimize(x -> maxcut_objective(x, J), x0, method, options)
+    xf = Optim.minimizer(results)
+    @test maxcut_objective(xf, J) < edwards_bound
 end


### PR DESCRIPTION
`default_neighbor!` uses an argument-ordering that's the opposite of
what's in the docs.

Changing the docs makes this non-breaking, but if the docs are the preferred behavior, then perhaps a breaking change would be in order.