### PR TITLE
BUGFIX: Update preconditioner in cg

### DIFF
--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -184,6 +184,7 @@ function update_state!(d, state::ConjugateGradientState, method::ConjugateGradie
     # extra copy, which is probably minimal overhead.
     # -----------------
     # also updates P for the preconditioning step below
+    _apply_precondprep(method, state.x)
     dPd = _inverse_precondition(method, state)
     etak = method.eta * real(dot(state.s, state.g_previous)) / dPd # New in HZ2013
     state.y .= gradient(d) .- state.g_previous


### PR DESCRIPTION
After the formatting of the repository in #1150 , a small error was introduced in the `update_state!` function in the `src/multivariate/solvers/first_order/cg.jl` file: the preconditioner is not updated at every iteration, but only at the first one. The change ensures that the `_apply_precondprep` method is called. Changes:
* [`src/multivariate/solvers/first_order/cg.jl`](diffhunk://#diff-0a73ae73cf3162a4ba402251714e7921cc7521eae370fae3ff1539b469bcd1d1R187): Added a call to `_apply_precondprep(method, state.x)`