### PR TITLE
Define `Base.summary` with `IO` argument

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -1,4 +1,4 @@
-Base.summary(r::OptimizationResults) = summary(r.method) # might want to do more here than just return summary of the method used
+Base.summary(io::IO, r::OptimizationResults) = summary(io, r.method) # might want to do more here than just return summary of the method used
 minimizer(r::OptimizationResults) = r.minimizer
 minimum(r::OptimizationResults) = r.minimum
 iterations(r::OptimizationResults) = r.iterations

--- a/src/maximize.jl
+++ b/src/maximize.jl
@@ -68,7 +68,7 @@ maximizer(r::MaximizationWrapper) = minimizer(res(r))
 maximum(r::Union{UnivariateOptimizationResults,MultivariateOptimizationResults}) =
     throw(MethodError())
 maximum(r::MaximizationWrapper) = -minimum(res(r))
-Base.summary(r::MaximizationWrapper) = summary(res(r))
+Base.summary(io::IO, r::MaximizationWrapper) = summary(io, res(r))
 
 for api_method in (
     :lower_bound,
@@ -101,8 +101,10 @@ for api_method in (
 end
 
 function Base.show(io::IO, r::MaximizationWrapper{<:UnivariateOptimizationResults})
-    @printf io "Results of Maximization Algorithm\n"
-    @printf io " * Algorithm: %s\n" summary(r)
+    println(io, "Results of Maximization Algorithm")
+    print(io, " * Algorithm: ")
+    summary(io, r)
+    println(io)
     @printf io " * Search Interval: [%f, %f]\n" lower_bound(r) upper_bound(r)
     @printf io " * Maximizer: %e\n" maximizer(r)
     @printf io " * Maximum: %e\n" maximum(r)
@@ -117,8 +119,11 @@ end
 function Base.show(io::IO, r::MaximizationWrapper{<:MultivariateOptimizationResults})
     take = Iterators.take
 
-    @printf io "Results of Optimization Algorithm\n"
-    @printf io " * Algorithm: %s\n" summary(r.res)
+    println(io, "Results of Optimization Algorithm")
+    print(io, " * Algorithm: ")
+    summary(io, r.res)
+    println(io)
+
     if length(join(initial_state(r), ",")) < 40
         @printf io " * Starting Point: [%s]\n" join(initial_state(r), ",")
     else

--- a/src/multivariate/solvers/constrained/fminbox.jl
+++ b/src/multivariate/solvers/constrained/fminbox.jl
@@ -232,7 +232,11 @@ function Fminbox(
     Fminbox(method, promote(mu0, mufactor)..., precondprep) # default optimizer
 end
 
-Base.summary(F::Fminbox) = "Fminbox with $(summary(F.method))"
+function Base.summary(io::IO, F::Fminbox)
+    print(io, "Fminbox with ")
+    summary(io, F.method)
+    return
+end
 
 # barrier_method() constructs an optimizer to solve the barrier problem using m = Fminbox.method as the reference.
 # Essentially it only updates the P and precondprep fields of `m`.

--- a/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl
+++ b/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl
@@ -5,7 +5,7 @@ struct IPNewton{F,Tμ<:Union{Symbol,Number}} <: IPOptimizer{F}
     # TODO: μ0, and show_linesearch were originally in options
 end
 
-Base.summary(::IPNewton) = "Interior Point Newton"
+Base.summary(io::IO, ::IPNewton) = print(io, "Interior Point Newton")
 
 promote_objtype(method::IPNewton, x, autodiff, inplace::Bool, f::TwiceDifferentiable) = f
 promote_objtype(method::IPNewton, x, autodiff, inplace::Bool, f) =

--- a/src/multivariate/solvers/constrained/samin.jl
+++ b/src/multivariate/solvers/constrained/samin.jl
@@ -56,7 +56,7 @@ end
 #     * 2 = summary every temperature change, without param values
 #     * 3 = summary every temperature change, with param values
 #         covered by the trial values. 1: start decreasing temperature immediately
-Base.summary(::SAMIN) = "SAMIN"
+Base.summary(io::IO, ::SAMIN) = print(io, "SAMIN")
 
 function optimize(
     obj_fn,

--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -12,7 +12,7 @@ struct AcceleratedGradientDescent{IL,L} <: FirstOrderOptimizer
     manifold::Manifold
 end
 
-Base.summary(::AcceleratedGradientDescent) = "Accelerated Gradient Descent"
+Base.summary(io::IO, ::AcceleratedGradientDescent) = print(io, "Accelerated Gradient Descent")
 
 function AcceleratedGradientDescent(;
     alphaguess = LineSearches.InitialPrevious(), # TODO: investigate good defaults

--- a/src/multivariate/solvers/first_order/adam.jl
+++ b/src/multivariate/solvers/first_order/adam.jl
@@ -40,7 +40,7 @@ end
 # could use epsilon = T->sqrt(eps(T)) and input the promoted type
 Adam(; alpha = 0.0001, beta_mean = 0.9, beta_var = 0.999, epsilon = 1e-8) =
     Adam(alpha, beta_mean, beta_var, epsilon, Flat())
-Base.summary(::Adam) = "Adam"
+Base.summary(io::IO, ::Adam) = print(io, "Adam")
 function default_options(method::Adam)
     (; allow_f_increases = true, iterations = 10_000)
 end

--- a/src/multivariate/solvers/first_order/adamax.jl
+++ b/src/multivariate/solvers/first_order/adamax.jl
@@ -39,7 +39,7 @@ struct AdaMax{Tα,T,Tm} <: FirstOrderOptimizer
 end
 AdaMax(; alpha = 0.002, beta_mean = 0.9, beta_var = 0.999, epsilon = sqrt(eps(Float64))) =
     AdaMax(alpha, beta_mean, beta_var, epsilon, Flat())
-Base.summary(::AdaMax) = "AdaMax"
+Base.summary(io::IO, ::AdaMax) = print(io, "AdaMax")
 function default_options(method::AdaMax)
     (; allow_f_increases = true, iterations = 10_000)
 end

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -10,7 +10,7 @@ struct BFGS{IL,L,H,T,TM} <: FirstOrderOptimizer
     manifold::TM
 end
 
-Base.summary(::BFGS) = "BFGS"
+Base.summary(io::IO, ::BFGS) = print(io, "BFGS")
 
 """
 # BFGS

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -51,7 +51,7 @@ struct ConjugateGradient{Tf,T,Tprep,IL,L} <: FirstOrderOptimizer
     manifold::Manifold
 end
 
-Base.summary(::ConjugateGradient) = "Conjugate Gradient"
+Base.summary(io::IO, ::ConjugateGradient) = print(io, "Conjugate Gradient")
 
 """
 # Conjugate Gradient Descent

--- a/src/multivariate/solvers/first_order/gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/gradient_descent.jl
@@ -6,7 +6,7 @@ struct GradientDescent{IL,L,T,Tprep} <: FirstOrderOptimizer
     manifold::Manifold
 end
 
-Base.summary(::GradientDescent) = "Gradient Descent"
+Base.summary(io::IO, ::GradientDescent) = print(io, "Gradient Descent")
 
 """
 # Gradient Descent

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -133,7 +133,7 @@ function LBFGS(;
     LBFGS(Int(m), _alphaguess(alphaguess), linesearch, P, precondprep, manifold, scaleinvH0)
 end
 
-Base.summary(::LBFGS) = "L-BFGS"
+Base.summary(io::IO, ::LBFGS) = print(io, "L-BFGS")
 
 mutable struct LBFGSState{Tx,Tdx,Tdg,T,G} <: AbstractOptimizerState
     x::Tx

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -8,7 +8,7 @@ struct MomentumGradientDescent{Tf,IL,L} <: FirstOrderOptimizer
     manifold::Manifold
 end
 
-Base.summary(::MomentumGradientDescent) = "Momentum Gradient Descent"
+Base.summary(io::IO, ::MomentumGradientDescent) = print(io, "Momentum Gradient Descent")
 
 function MomentumGradientDescent(;
     mu::Real = 0.01,

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -29,8 +29,18 @@ struct OACCEL{IL,Tp,TPrec<:AbstractOptimizer,L} <: AbstractNGMRES
 end
 
 
-Base.summary(s::NGMRES) = "Nonlinear GMRES preconditioned with $(summary(s.nlprecon))"
-Base.summary(s::OACCEL) = "O-ACCEL preconditioned with $(summary(s.nlprecon))"
+function Base.summary(io::IO, s::NGMRES)
+    print(io, "Nonlinear GMRES preconditioned with ")
+    summary(io, s.nlprecon)
+    print(io, ")")
+    return
+end
+function Base.summary(io::IO, s::OACCEL)
+    print(io, "O-ACCEL preconditioned with ")
+    summary(io, s.nlprecon)
+    print(io, ")")
+    return
+end
 
 """
 # N-GMRES

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -27,7 +27,7 @@ function Newton(;
     Newton(_alphaguess(alphaguess), linesearch)
 end
 
-Base.summary(::Newton) = "Newton's Method"
+Base.summary(io::IO, ::Newton) = print(io, "Newton's Method")
 
 mutable struct NewtonState{Tx,T,F<:Cholesky} <: AbstractOptimizerState
     x::Tx

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -275,7 +275,7 @@ NewtonTrustRegion(;
     use_fg,
 )
 
-Base.summary(::NewtonTrustRegion) = "Newton's Method (Trust Region)"
+Base.summary(io::IO, ::NewtonTrustRegion) = print(io, "Newton's Method (Trust Region)")
 
 mutable struct NewtonTrustRegionState{Tx,T,G} <: AbstractOptimizerState
     x::Tx

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -85,7 +85,7 @@ function NelderMead(; kwargs...)
     end
 end
 
-Base.summary(::NelderMead) = "Nelder-Mead"
+Base.summary(io::IO, ::NelderMead) = print(io, "Nelder-Mead")
 
 # centroid except h-th vertex
 function centroid!(c::AbstractArray{T}, simplex, h = 0) where {T}

--- a/src/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/src/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -36,7 +36,7 @@ reaches the maximum number of iterations set in Optim.Options(iterations=x)`.
 ParticleSwarm(; lower = [], upper = [], n_particles = 0) =
     ParticleSwarm(lower, upper, n_particles)
 
-Base.summary(::ParticleSwarm) = "Particle Swarm"
+Base.summary(io::IO, ::ParticleSwarm) = print(io, "Particle Swarm")
 
 mutable struct ParticleSwarmState{Tx,T} <: ZerothOrderState
     x::Tx

--- a/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
+++ b/src/multivariate/solvers/zeroth_order/simulated_annealing.jl
@@ -43,7 +43,7 @@ SimulatedAnnealing(;
     keep_best::Bool = true,
 ) = SimulatedAnnealing(neighbor, temperature, keep_best)
 
-Base.summary(::SimulatedAnnealing) = "Simulated Annealing"
+Base.summary(io::IO, ::SimulatedAnnealing) = print(io, "Simulated Annealing")
 
 mutable struct SimulatedAnnealingState{Tx,T} <: ZerothOrderState
     x::Tx

--- a/src/types.jl
+++ b/src/types.jl
@@ -341,38 +341,32 @@ function Base.show(io::IO, tr::OptimizationTrace)
 end
 
 function Base.show(io::IO, r::MultivariateOptimizationResults)
-    take = Iterators.take
-
+    print(io, " * Status: ")
     if converged(r)
-        status_string = "success"
+        print(io, "success")
     else
-        status_string = "failure"
+        print(io, "failure")
     end
     if iteration_limit_reached(r)
-        status_string *= " (reached maximum number of iterations)"
-    end
-    if f_increased(r) && !iteration_limit_reached(r)
-        status_string *= " (objective increased between iterations)"
+        print(io, " (reached maximum number of iterations)")
+    elseif f_increased(r)
+        print(io, " (objective increased between iterations)")
     end
     if isa(r.stopped_by.ls_failed, Bool) && r.stopped_by.ls_failed
-        status_string *= " (line search failed)"
+        print(io, " (line search failed)")
     end
     if time_run(r) > time_limit(r)
-        status_string *= " (exceeded time limit of $(time_limit(r)))"
+        print(io, " (exceeded time limit of ", time_limit(r), ")")
     end
 
-    @printf io " * Status: %s\n\n" status_string
+    println(io, "\n\n * Candidate solution")
+    @printf io "    Final objective value:     %e" minimum(r)
 
-    @printf io " * Candidate solution\n"
-    @printf io "    Final objective value:     %e\n" minimum(r)
-    @printf io "\n"
+    println(io, "\n\n * Found with")
+    print(io, "    Algorithm:     ")
+    summary(io, r)
 
-    @printf io " * Found with\n"
-    @printf io "    Algorithm:     %s\n" summary(r)
-
-
-    @printf io "\n"
-    @printf io " * Convergence measures\n"
+    println(io, "\n\n * Convergence measures")
     if isa(r.method, NelderMead)
         @printf io "    √(Σ(yᵢ-ȳ)²)/n %s %.1e\n" g_converged(r) ? "≤" : "≰" g_tol(r)
     else

--- a/src/univariate/printing.jl
+++ b/src/univariate/printing.jl
@@ -39,17 +39,19 @@ function Base.show(io::IO, t::OptimizationState{<:Real,GoldenSection})
 end
 
 function Base.show(io::IO, r::UnivariateOptimizationResults)
+    println(io, "Results of Optimization Algorithm")
 
-    status_string = ""
+    print(io, " * Status: ")
     if time_run(r) > time_limit(r)
-        status_string *= "failure (exceeded time limit of $(time_limit(r)))"
+        println(io, "failure (exceeded time limit of ", time_limit(r), ")")
     else
-        status_string = "success"
+        println(io, "success")
     end
 
-    @printf io "Results of Optimization Algorithm\n"
-    @printf io " * Status: %s\n" status_string
-    @printf io " * Algorithm: %s\n" summary(r)
+    print(io, " * Algorithm: ")
+    summary(io, r)
+    println(io)
+
     @printf io " * Search Interval: [%f, %f]\n" lower_bound(r) upper_bound(r)
     @printf io " * Minimizer: %e\n" minimizer(r)
     @printf io " * Minimum: %e\n" minimum(r)

--- a/src/univariate/solvers/brent.jl
+++ b/src/univariate/solvers/brent.jl
@@ -18,7 +18,7 @@ R. P. Brent (2002) Algorithms for Minimization Without Derivatives. Dover editio
 """
 struct Brent <: UnivariateOptimizer end
 
-Base.summary(::Brent) = "Brent's Method"
+Base.summary(io::IO, ::Brent) = print(io, "Brent's Method")
 
 function optimize(
     f,

--- a/src/univariate/solvers/golden_section.jl
+++ b/src/univariate/solvers/golden_section.jl
@@ -16,7 +16,7 @@ https://en.wikipedia.org/wiki/Golden-section_search
 """
 struct GoldenSection <: UnivariateOptimizer end
 
-Base.summary(::GoldenSection) = "Golden Section Search"
+Base.summary(io::IO, ::GoldenSection) = print(io, "Golden Section Search")
 
 function optimize(
     f,

--- a/test/general/api.jl
+++ b/test/general/api.jl
@@ -122,7 +122,7 @@
     )
     res_ext = optimize(f, g!, h!, initial_x, BFGS(), options_ext)
 
-    @test summary(res) == "BFGS"
+    test_summary(res, "BFGS")
     @test Optim.minimum(res) ≈ 1.2580194638225255
     @test Optim.minimizer(res) ≈ [-0.116688, 0.0031153] rtol = 0.001
     @test Optim.iterations(res) == 10
@@ -236,7 +236,7 @@ end
 @testset "Univariate API" begin
     f(x) = 2x^2 + 3x + 1
     res = optimize(f, -2.0, 1.0, GoldenSection())
-    @test summary(res) == "Golden Section Search"
+    test_summary(res, "Golden Section Search")
     @test Optim.minimum(res) ≈ -0.125
     @test Optim.minimizer(res) ≈ -0.749999994377939
     @test Optim.iterations(res) == 38

--- a/test/multivariate/complex.jl
+++ b/test/multivariate/complex.jl
@@ -59,7 +59,7 @@
                 display(res)
                 println("########################")
             end
-            ressum = summary(res) # Just check that no errors arise when doing display(res)
+            test_summary(res) # Just check that no errors arise when doing display(res)
             @test typeof(fcomplex(x0)) == typeof(Optim.minimum(res))
             @test eltype(x0) == eltype(Optim.minimizer(res))
             @test Optim.converged(res)

--- a/test/multivariate/solvers/constrained/fminbox.jl
+++ b/test/multivariate/solvers/constrained/fminbox.jl
@@ -56,7 +56,7 @@
         debug_printing && printstyled("Solver: ", summary(_optimizer), "\n", color = :green)
         results = optimize(_objective, l, u, initial_x, Fminbox(_optimizer))
         @test Optim.converged(results)
-        @test summary(results) == "Fminbox with $(summary(_optimizer))"
+        test_summary(results, "Fminbox with $(summary(_optimizer))")
         opt_x = Optim.minimizer(results)
         NLSolversBase.gradient!(_objective, opt_x)
         g = NLSolversBase.gradient(_objective)

--- a/test/multivariate/solvers/constrained/ipnewton/constraints.jl
+++ b/test/multivariate/solvers/constrained/ipnewton/constraints.jl
@@ -671,7 +671,7 @@
             minval = NLSolversBase.value(df, prob.solutions)
 
             results = optimize(df, constraints, prob.initial_x, method, options)
-            @test isa(summary(results), String)
+            test_summary(results)
             @test Optim.converged(results)
             @test Optim.minimum(results) < minval + sqrt(eps(minval))
 
@@ -686,7 +686,7 @@
 
             results =
                 optimize(MVP.objective(prob), constraints, prob.initial_x, method, options)
-            @test isa(summary(results), String)
+            test_summary(results)
             @test Optim.converged(results)
             @test Optim.minimum(results) < minval + sqrt(eps(minval))
         end
@@ -714,7 +714,7 @@
         minval = NLSolversBase.value(df, xsol)
 
         results = optimize(df, constraints, [12, 14.0], method, options)
-        @test isa(Optim.summary(results), String)
+        test_summary(results)
         @test Optim.converged(results)
         @test Optim.minimum(results) < minval + sqrt(eps(minval))
 

--- a/test/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/test/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -9,7 +9,7 @@
     options = Optim.Options(show_trace = debug_printing, allow_f_increases = true)
     results = Optim.optimize(f, g!, initial_x, AcceleratedGradientDescent(), options)
     @test norm(Optim.minimum(results)) < 1e-6
-    @test summary(results) == "Accelerated Gradient Descent"
+    test_summary(results, "Accelerated Gradient Descent")
 
     # TODO: Check why skip problems fail
     skip = (

--- a/test/multivariate/solvers/first_order/adam_adamax.jl
+++ b/test/multivariate/solvers/first_order/adam_adamax.jl
@@ -13,7 +13,7 @@
     )
     results = Optim.optimize(f, g!, initial_x, Adam(), options)
     @test norm(Optim.minimum(results)) < 1e-6
-    @test summary(results) == "Adam"
+    test_summary(results, "Adam")
 
     # TODO: Check why skip problems fail
     skip = (
@@ -52,7 +52,7 @@ end
     )
     results = Optim.optimize(f, g!, initial_x, AdaMax(), options)
     @test norm(Optim.minimum(results)) < 1e-6
-    @test summary(results) == "AdaMax"
+    test_summary(results, "AdaMax")
 
     # TODO: Check why skip problems fail
     skip = (
@@ -95,7 +95,7 @@ end
     alpha_scheduler(iter) = 0.0001 * (1 + 0.99^iter)
     results = Optim.optimize(f, g!, initial_x, Adam(alpha = alpha_scheduler), options)
     @test norm(Optim.minimum(results)) < 1e-6
-    @test summary(results) == "Adam"
+    test_summary(results, "Adam")
 
     # verifying the alpha values over iterations and also testing extended_trace
     # this way we test both alpha scheduler and the working of
@@ -148,7 +148,7 @@ end
     alpha_scheduler(iter) = 0.002 * (1 + 0.99^iter)
     results = Optim.optimize(f, g!, initial_x, AdaMax(alpha = alpha_scheduler), options)
     @test norm(Optim.minimum(results)) < 1e-6
-    @test summary(results) == "AdaMax"
+    test_summary(results, "AdaMax")
 
     # verifying the alpha values over iterations and also testing extended_trace
     # this way we test both alpha scheduler and the working of

--- a/test/multivariate/solvers/first_order/gradient_descent.jl
+++ b/test/multivariate/solvers/first_order/gradient_descent.jl
@@ -40,7 +40,7 @@
     @test_throws ErrorException Optim.x_trace(results)
     @test Optim.g_converged(results)
     @test norm(Optim.minimizer(results) - [5.0]) < 0.01
-    @test summary(results) == "Gradient Descent"
+    test_summary(results, "Gradient Descent")
 
     function f_gd_2(x)
         eta = 0.9

--- a/test/multivariate/solvers/second_order/newton.jl
+++ b/test/multivariate/solvers/second_order/newton.jl
@@ -43,7 +43,7 @@
     @test_throws ErrorException Optim.x_trace(results)
     @test Optim.g_converged(results)
     @test norm(Optim.minimizer(results) - [0.0, 0.0]) < 0.01
-    @test summary(results) == "Newton's Method"
+    test_summary(results, "Newton's Method")
 
     @testset "newton in concave region" begin
         prob = MultivariateProblems.UnconstrainedProblems.examples["Himmelblau"]

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -158,7 +158,7 @@ Random.seed!(3288)
         @test length(results.trace) == 0
         @test Optim.g_converged(results)
         @test norm(Optim.minimizer(results) - [5.0]) < 0.01
-        @test summary(results) == "Newton's Method (Trust Region)"
+        test_summary(results, "Newton's Method (Trust Region)")
 
         eta = 0.9
 

--- a/test/multivariate/solvers/zeroth_order/particle_swarm.jl
+++ b/test/multivariate/solvers/zeroth_order/particle_swarm.jl
@@ -42,12 +42,12 @@
         ParticleSwarm(lower, upper, n_particles),
         options,
     )
-    @test summary(res) == "Particle Swarm"
+    test_summary(res, "Particle Swarm")
     res = Optim.optimize(
         rosenbrock_s,
         initial_x,
         ParticleSwarm(n_particles = n_particles),
         options,
     )
-    @test summary(res) == "Particle Swarm"
+    test_summary(res, "Particle Swarm")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,6 +108,22 @@ input_tuple(method::Optim.SecondOrderOptimizer, prob) = (
     (MVP.objective(prob), MVP.gradient(prob), MVP.hessian(prob)),
 )
 
+function test_summary(x, ref::String)
+    @test summary(x) == ref
+    io = IOBuffer()
+    summary(io, x)
+    @test String(take!(io)) == ref
+    return
+end
+function test_summary(x)
+    summary_x = summary(x)
+    @test summary_x isa String
+    io = IOBuffer()
+    summary(io, x)
+    @test String(take!(io)) == summary_x
+    return
+end
+
 function run_optim_tests(
     method,
     problems = MultivariateProblems.UnconstrainedProblems.examples;
@@ -159,7 +175,7 @@ function run_optim_tests(
 
                 # Loop over appropriate input combinations of f, g!, and h!
                 results = Optim.optimize(input..., prob.initial_x, method, options)
-                @test isa(summary(results), String)
+                test_summary(results)
                 show_res && println(results)
                 show_itcalls &&
                     printstyled("Iterations: $(Optim.iterations(results))\n", color = :red)
@@ -252,7 +268,7 @@ function run_optim_tests_constrained(
             infvec = fill(Inf, size(prob.initial_x))
             constraints = TwiceDifferentiableConstraints(-infvec, infvec)
             results = optimize(df, constraints, prob.initial_x, method, options)
-            @test isa(Optim.summary(results), String)
+            test_summary(results)
             show_res && println(results)
             show_itcalls &&
                 printstyled("Iterations: $(Optim.iterations(results))\n", color = :red)

--- a/test/univariate/solvers/brent.jl
+++ b/test/univariate/solvers/brent.jl
@@ -14,7 +14,7 @@
     @test Optim.minimizer(result) == 4.0
     @test Optim.minimum(result) == 2.0
     @test_throws ErrorException optimize(identity, 2.0, 1.0, Brent())
-    @test summary(result) == "Brent's Method"
+    test_summary(result, "Brent's Method")
 
     ## corner cases - largely flat functions
     result = optimize(x -> sign(x), -2, 2)


### PR DESCRIPTION
To fix inconsistencies such as

```julia
julia> using Optim

julia> summary(AcceleratedGradientDescent())
"Accelerated Gradient Descent"

julia> summary(stdout, AcceleratedGradientDescent())
AcceleratedGradientDescent{LineSearches.InitialPrevious{Float64}, LineSearches.HagerZhang{Float64, Base.RefValue{Bool}}}
```