### PR TITLE
Define `eltype` only for type not instance

### DIFF
--- a/src/multivariate/solvers/constrained/ipnewton/interior.jl
+++ b/src/multivariate/solvers/constrained/ipnewton/interior.jl
@@ -101,7 +101,6 @@ Base.isempty(bstate::BarrierStateVars) =
     isempty(bstate.λcE)
 
 Base.eltype(::Type{BarrierStateVars{T}}) where {T} = T
-Base.eltype(sv::BarrierStateVars) = eltype(typeof(sv))
 
 function Base.show(io::IO, b::BarrierStateVars)
     print(io, "BarrierStateVars{$(eltype(b))}:")


### PR DESCRIPTION
Following the Julia docs: https://docs.julialang.org/en/v1/base/collections/#Base.eltype