### PR TITLE
Work around upstream issue by running benchmarks on Julia LTS

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -10,9 +10,15 @@ permissions:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        julia:
+          - 'lts'
+          # TODO: Enable when https://github.com/MilesCranmer/AirspeedVelocity.jl/issues/113 is fixed
+          # - '1'
     steps:
       - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:
-          julia-version: '1'
+          julia-version: '${{ matrix.julia }}'
           enable-plots: true
           exeflags: '-O3 --threads=auto'


### PR DESCRIPTION
Workaround for https://github.com/MilesCranmer/AirspeedVelocity.jl/issues/113 which seems to be caused by a bug in Pkg on Julia 1.12.

Note that due to the restrictions of pull_request_target in this PR the action runs with the existing config on the master branch (ie on Julia 1.12) and not the updated config in this PR (on Julia LTS).