### PR TITLE
Use gradient!(d, x). in perform_linesearch

### DIFF
--- a/src/utilities/perform_linesearch.jl
+++ b/src/utilities/perform_linesearch.jl
@@ -40,13 +40,14 @@ end
 
 function perform_linesearch!(state, method, d)
     # Calculate search direction dphi0
-    gx = gradient!(d, state.x)
+    fx = value_gradient!(d, state.x)
+    gx = gradient(d)
     dphi_0 = real(dot(gx, state.s))
     # reset the direction if it becomes corrupted
     if dphi_0 >= zero(dphi_0) && reset_search_direction!(state, d, method)
         dphi_0 = real(dot(gx, state.s)) # update after direction reset
     end
-    phi_0 = value(d)
+    phi_0 = value!(d, state.x)
 
     # Guess an alpha
     method.alphaguess!(method.linesearch!, state, phi_0, dphi_0, d)


### PR DESCRIPTION
This shouldn't matter, but *if* somehow happened to be calling the objective function in the callback or some other way this would now produce the correct result. Previously, it used the most recent evaluation. Now, it will try to evaluate at state.x and if that was the last point evaluated we'll just use the cached result. This should always be the case unless someone messed with the objective outside. We could even assert that g_calls is constant around the call to be sure to catch it but then users wouldn't be able to call the gradient outside at their own expense of runtime.