### PR TITLE
Update ngmres.jl to increase iterations for Polynomial

### DIFF
--- a/test/multivariate/solvers/first_order/ngmres.jl
+++ b/test/multivariate/solvers/first_order/ngmres.jl
@@ -11,6 +11,7 @@ using Optim, Test
         solver;
         skip = skip,
         iteration_exceptions = (
+            ("Polynomial", 10000), # goes above 3000 iterations on mac
             ("Penalty Function I", 10000),
             ("Paraboloid Random Matrix", 10000),
         ),


### PR DESCRIPTION
On Mac (Also locally for me on Mac) this one runs for 3200-ish iterations before convergence. I don't. know much about this algorithm and think we should maybe remove it, but that's a different story 

https://github.com/JuliaNLSolvers/Optim.jl/pull/1196