### PR TITLE
Fix JET tests

### DIFF
--- a/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl
+++ b/src/multivariate/solvers/constrained/ipnewton/ipnewton.jl
@@ -128,7 +128,7 @@ function initial_state(
 ) where {T}
     # Check feasibility of the initial state
     mc = nconstraints(constraints)
-    constr_c = fill(T(NaN), mc)
+    constr_c = fill!(Vector{T}(undef, mc), NaN)
     # TODO: When we change to `value!` from NLSolversBase instead of c!
     # we can also update `initial_convergence` for ConstrainedOptimizer in interior.jl
     constraints.c!(constr_c, initial_x)
@@ -149,7 +149,7 @@ function initial_state(
     Hd = zeros(Int8, n)
 
     # More constraints
-    constr_J = fill(T(NaN), mc, n)
+    constr_J = fill!(Matrix{T}(undef, mc, n), NaN)
     gtilde = copy(g)
     constraints.jacobian!(constr_J, initial_x)
     μ = T(1)

--- a/src/multivariate/solvers/first_order/l_bfgs.jl
+++ b/src/multivariate/solvers/first_order/l_bfgs.jl
@@ -172,7 +172,7 @@ function initial_state(method::LBFGS, options::Options, d, initial_x::AbstractAr
         initial_x, # Maintain current state in state.x
         copy(initial_x), # Maintain previous state in state.x_previous
         copy(gradient(d)), # Store previous gradient in state.g_previous
-        fill(T(NaN), method.m), # state.rho
+        fill!(Vector{T}(undef, method.m), NaN), # state.rho
         [similar(initial_x) for i = 1:method.m], # Store changes in position in state.dx_history
         [eltype(gradient(d))(NaN) .* gradient(d) for i = 1:method.m], # Store changes in position in state.dg_history
         T(NaN) * initial_x, # Buffer for new entry in state.dx_history

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -48,16 +48,9 @@ import JET
 
     @testset "JET" begin
         # Check that there are no undefined global references and undefined field accesses
-        res = JET.report_package(Optim; target_defined_modules = true, mode = :typo, toplevel_logger = nothing)
-        reports = JET.get_reports(res)
-        @test_broken isempty(reports)
-        @test length(reports) <= 36
-
+        JET.test_package(Optim; target_defined_modules = true, mode = :typo)
 
         # Analyze methods based on their declared signature
-        res = JET.report_package(Optim; target_defined_modules = true, toplevel_logger = nothing)
-        reports = JET.get_reports(res)
-        @test_broken isempty(reports)
-        @test length(reports) <= 12
+        JET.test_package(Optim; target_defined_modules = true)
     end
 end


### PR DESCRIPTION
As preparation for #1195 (see https://github.com/JuliaNLSolvers/Optim.jl/pull/1195#issuecomment-3564630165).

JET had found two obvious errors (undefined `T` and incorrect function call missing a semicolon), unsafe function calls due to ReverseDiff (loaded in the test) pirating `fill` (could return a `TrackedArray`; fixed by using `fill!` with an explicitly constructed `Array`), and many potentially undefined variables in the `Fminbox` implementation. For now I just unrolled the first iteration, but possibly it could be refactored in some way. 