### PR TITLE
Fix implementation of NLSolversBase API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Optim"
 uuid = "429524aa-4258-5aef-a3af-852621145aeb"
-version = "1.13.2"
+version = "1.13.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -41,15 +41,15 @@ function NLSolversBase.gradient(obj::ManifoldObjective, i::Int)
 end
 function NLSolversBase.gradient!(obj::ManifoldObjective, x)
     xin = retract(obj.manifold, x)
-    gradient!(obj.inner_obj, xin)
-    project_tangent!(obj.manifold, gradient(obj.inner_obj), xin)
-    return gradient(obj.inner_obj)
+    g_x = gradient!(obj.inner_obj, xin)
+    project_tangent!(obj.manifold, g_x, xin)
+    return g_x
 end
 function NLSolversBase.value_gradient!(obj::ManifoldObjective, x)
     xin = retract(obj.manifold, x)
-    value_gradient!(obj.inner_obj, xin)
-    project_tangent!(obj.manifold, gradient(obj.inner_obj), xin)
-    return value(obj.inner_obj)
+    f_x, g_x = value_gradient!(obj.inner_obj, xin)
+    project_tangent!(obj.manifold, g_x, xin)
+    return f_x, g_x
 end
 
 """Flat Euclidean space {R,C}^N, with projections equal to the identity."""


### PR DESCRIPTION
Optim does currently not implement the NLSolversBase API correctly, and therefore the package was broken by the latest LineSearches.jl release (previously it ignored any return values, now it uses value and gradient returned from `value_gradient!`).

CI logs on the master branch illustrate the problem: https://github.com/JuliaNLSolvers/Optim.jl/pull/1213/checks#step:6:217