### PR TITLE
Remove `delta_min` setting of `NewtonTrustRegion`

### DIFF
--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -116,15 +116,6 @@ function optimize(
             stopped = true
         end
 
-        if method isa NewtonTrustRegion
-            # If the trust region radius keeps on reducing we need to stop
-            # because something is wrong. Wrong gradients or a non-differentiability
-            # at the solution could be explanations.
-            if state.delta ≤ method.delta_min
-                stopped = true
-            end
-        end
-
         if hasproperty(state, :g_x) && !all(isfinite, state.g_x)
             options.show_warnings && @warn "Terminated early due to NaN in gradient."
             break

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -262,6 +262,5 @@ Random.seed!(3288)
             NewtonTrustRegion(delta_min = 0.0),
             Optim.Options(show_trace = false, allow_f_increases = false, g_tol = 1e-5),
         )
-
     end
 end


### PR DESCRIPTION
I propose to remove the `delta_min` setting, and in particular its non-zero default value, from the `NewtonTrustRegion` algorithm.

I observed in https://github.com/JuliaStats/Survival.jl/pull/69, that with the default `delta_min` tests fail (termination not due to gradient norm or objective (function) value) whereas with `delta_min = 0` they pass. IMO generally, if the function is not differentiable and optimization fails, it will fail anyway; however, by exiting early due to `delta_min` there'll always be cases where non-optimal values are returned in an otherwise fine optimization.