### PR TITLE
As default use a minimum trust region radius of 0

### DIFF
--- a/src/multivariate/solvers/constrained/fminbox.jl
+++ b/src/multivariate/solvers/constrained/fminbox.jl
@@ -644,6 +644,7 @@ function optimize(
         x_converged = _x_converged,
         f_converged = _f_converged,
         g_converged = _g_converged,
+        small_trustregion_radius = false,
     )
     termination_code = _termination_code(df, g_residual(g), BoxState(x, f_x, x_previous, f_x_previous), stopped_by, options)
 

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -269,7 +269,7 @@ NewtonTrustRegion(; initial_delta = 1.0,
 The constructor has 7 keywords:
 * `initial_delta`, the initial trust region radius. Defaults to `1.0`.
 * `delta_hat`, the largest allowable trust region radius. Defaults to `100.0`.
-* `delta_min`, the smallest allowable trust region radius. Optimization halts if the updated radius is smaller than this value. Defaults to `sqrt(eps(Float64))`.
+* `delta_min`, the smallest allowable trust region radius. Optimization halts if the updated radius is less than or equal to this value. Defaults to `0.0`.
 * `eta`, when the ratio of actual and predicted reduction is greater than `eta`, accept the step. Defaults to `0.1`.
 * `rho_lower`, when the ratio of actual and predicted reduction is less than `rho_lower`, shrink the trust region. Defaults to `0.25`.
 * `rho_upper`, when the ratio of actual and predicted reduction is greater than `rho_upper` and the proposed step is at the boundary of the trust region, grow the trust region. Defaults to `0.75`.
@@ -291,7 +291,7 @@ trust-region methods in practice.
 function NewtonTrustRegion(;
     initial_delta::Real = 1.0,
     delta_hat::Real = 100.0,
-    delta_min::Real = sqrt(eps(Float64)),
+    delta_min::Real = 0.0,
     eta::Real = 0.1,
     rho_lower::Real = 0.25,
     rho_upper::Real = 0.75,

--- a/src/types.jl
+++ b/src/types.jl
@@ -271,6 +271,8 @@ const OptimizationTrace{Tf,T} = Vector{OptimizationState{Tf,T}}
     GradientNotFinite
     "Hessian was not finite"
     HessianNotFinite
+    "The trust region radius was less than or equal to the minimum radius allowed."
+    SmallTrustRegionRadius
     "For algorithms where the TerminationCode is not yet implemented."
     NotImplemented
 end

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -249,19 +249,23 @@ Random.seed!(3288)
                 )
             end
 
-        @test_throws DomainError Optim.optimize(
+        @test_throws DomainError NewtonTrustRegion(delta_min = -1.0)
+        @test iszero(NewtonTrustRegion().delta_min)
+
+        res = Optim.optimize(
             t -> -ll(t[1]),
             [2.1],
-            NewtonTrustRegion(delta_min = -1.0),
+            NewtonTrustRegion(),
             Optim.Options(show_trace = false, allow_f_increases = false, g_tol = 1e-5),
         )
+        @test Optim.termination_code(res) == Optim.TerminationCode.NoXChange
 
-        Optim.optimize(
+        res = Optim.optimize(
             t -> -ll(t[1]),
             [2.1],
-            NewtonTrustRegion(delta_min = 0.0),
+            NewtonTrustRegion(; delta_min = 1e-8),
             Optim.Options(show_trace = false, allow_f_increases = false, g_tol = 1e-5),
         )
-
+        @test Optim.termination_code(res) == Optim.TerminationCode.SmallTrustRegionRadius
     end
 end


### PR DESCRIPTION
Less drastic alternative to https://github.com/JuliaNLSolvers/Optim.jl/pull/1218 that does not remove the `delta_min` parameter of `NewtonTrustRegion` but instead changes its default value to 0.

Given that this is a dimensional quantity, I think this is a safer default value (related: #1102).