### PR TITLE
Pass optimization state to callbacks

### DIFF
--- a/docs/src/user/config.md
+++ b/docs/src/user/config.md
@@ -51,7 +51,7 @@ In addition to the solver, you can alter the behavior of the Optim package by us
 * `successive_f_tol`: Determines the number of times the objective is allowed to increase across iterations. Defaults to 1.
 * `iterations`: How many iterations will run before the algorithm gives up? Defaults to `1_000`.
 * `time_limit`: A soft upper limit on the total run time. Defaults to `NaN` (unlimited).
-* `callback`: A function to be called during tracing. The return value should be a boolean, where `true` will stop the `optimize` call early. The callback function is called every iteration. If `store_trace` is false, the argument to the callback is of the type  [`OptimizationState`](https://github.com/JuliaNLSolvers/Optim.jl/blob/a1035134ca1f3ebe855f1cde034e32683178225a/src/types.jl#L155), describing the state of the current iteration. If `store_trace` is true, the argument is a list of all the states from the first iteration to the current.
+* `callback`: A function to be called after every iteration. The return value should be a boolean, where `true` will stop the `optimize` call early. The argument to the callback is the state of the optimization algorithm.
 
 !!! tip "Disabling a termination criterion"
     If the `x_abstol`, `x_reltol`, `f_abstol`, `f_reltol`, `g_tol`, or `time_limit` tolerances are set to `NaN` all comparisons will be false internally, and this fact can be used to turn off the check. For example, `x_reltol` defaults to `0`. This does not mean that the check is turned off it only means that we stop at exactly zero change. However, if we set it to `NaN` specifically, the check of the termination criterion is always false and as such we will never stop due to any value of the infinity norm of the vector of relative changes.

--- a/docs/src/user/tipsandtricks.md
+++ b/docs/src/user/tipsandtricks.md
@@ -236,15 +236,17 @@ function very_slow(x)
 end
 
 start_time = time()
-time_to_setup = zeros(1)
-function advanced_time_control(x)
-    println(" * Iteration:       ", x.iteration)
+time_to_setup = Ref(NaN)
+iteration = Ref(-1)
+function advanced_time_control(_)
+    iteration[] += 1
+    println(" * Iteration:       ", iteration[])
     so_far =  time()-start_time
     println(" * Time so far:     ", so_far)
-    if x.iteration == 0
-        time_to_setup .= time()-start_time
+    if iteration[] == 0
+        time_to_setup[] = time()-start_time
     else
-        expected_next_time = so_far + (time()-start_time-time_to_setup[1])/(x.iteration)
+        expected_next_time = so_far + (time()-start_time-time_to_setup[])/iteration[]
         println(" * Next iteration ≈ ", expected_next_time)
         println()
         return expected_next_time < 13 ? false : true

--- a/src/multivariate/optimize/optimize.jl
+++ b/src/multivariate/optimize/optimize.jl
@@ -44,15 +44,15 @@ function optimize(
     options::Options{T,TCallback} = Options(; default_options(method)...),
     state = initial_state(method, options, d, initial_x),
 ) where {D<:AbstractObjective,M<:AbstractOptimizer,Tx<:AbstractArray,T,TCallback}
+    (; callback) = options
 
     t0 = time() # Initial time stamp used to control early stopping by options.time_limit
     tr = OptimizationTrace{typeof(state.f_x),typeof(method)}()
     tracing =
         options.store_trace ||
         options.show_trace ||
-        options.extended_trace ||
-        options.callback !== nothing
-    stopped, stopped_by_callback, stopped_by_time_limit = false, false, false
+        options.extended_trace
+    stopped, stopped_by_time_limit = false, false
     f_limit_reached, g_limit_reached, h_limit_reached = false, false, false
     x_converged, f_converged, f_increased, counter_f_tol = false, false, false, 0
     small_trustregion_radius = false
@@ -65,6 +65,10 @@ function optimize(
     options.show_trace && print_header(method)
     _time = time()
     trace!(tr, d, state, iteration, method, options, _time - t0)
+    # callbacks can stop routine early by returning true
+    stopped_by_callback = callback !== nothing && callback(state)
+    stopped |= stopped_by_callback
+    
     ls_success::Bool = true
     while !converged && !stopped && iteration < options.iterations
         iteration += 1
@@ -91,10 +95,13 @@ function optimize(
         counter_f_tol = f_converged ? counter_f_tol + 1 : 0
         converged = x_converged || g_converged || (counter_f_tol > options.successive_f_tol)
 
+        # update trace
         if tracing
-            # update trace; callbacks can stop routine early by returning true
-            stopped_by_callback =
-                trace!(tr, d, state, iteration, method, options, time() - t0)
+            trace!(tr, d, state, iteration, method, options, time() - t0)
+        end
+        # callbacks can stop routine early by returning true
+        if callback !== nothing
+            stopped_by_callback = callback(state)
         end
 
         # Check time_limit; if none is provided it is NaN and the comparison

--- a/src/multivariate/solvers/constrained/ipnewton/interior.jl
+++ b/src/multivariate/solvers/constrained/ipnewton/interior.jl
@@ -249,6 +249,7 @@ function optimize(
     the univariate `optimize` to one with empty constraints::AbstractConstraints
     ==#
 
+    (; callback) = options
     t0 = time() # Initial time stamp used to control early stopping by options.time_limit
     _time = t0
 
@@ -256,9 +257,8 @@ function optimize(
     tracing =
         options.store_trace ||
         options.show_trace ||
-        options.extended_trace ||
-        options.callback !== nothing
-    stopped, stopped_by_callback, stopped_by_time_limit = false, false, false
+        options.extended_trace
+    stopped, stopped_by_time_limit = false, false
     f_limit_reached, g_limit_reached, h_limit_reached = false, false, false
     x_converged, f_converged, f_increased, counter_f_tol = false, false, false, 0
 
@@ -269,7 +269,13 @@ function optimize(
     iteration = 0
 
     options.show_trace && print_header(method)
-    trace!(tr, d, state, iteration, method, options, t0)
+    # update trace
+    if tracing
+        trace!(tr, d, state, iteration, method, options, t0)
+    end
+    # callbacks can stop routine early by returning true
+    stopped_by_callback = callback !== nothing && callback(state)
+    stopped |= stopped_by_callback
 
     while !converged && !stopped && iteration < options.iterations
         iteration += 1
@@ -302,9 +308,13 @@ function optimize(
         counter_f_tol = f_converged ? counter_f_tol + 1 : 0
         converged = x_converged || g_converged || (counter_f_tol > options.successive_f_tol)
 
+        # update trace
         if tracing
-            # update trace; callbacks can stop routine early by returning true
-            stopped_by_callback = trace!(tr, d, state, iteration, method, options)
+            trace!(tr, d, state, iteration, method, options)
+        end
+        # callbacks can stop routine early by returning true
+        if callback !== nothing
+            stopped_by_callback = callback(state)
         end
 
         # Check time_limit; if none is provided it is NaN and the comparison

--- a/src/multivariate/solvers/constrained/ipnewton/utilities/trace.jl
+++ b/src/multivariate/solvers/constrained/ipnewton/utilities/trace.jl
@@ -51,6 +51,5 @@ function trace!(tr, d, state, iteration, method::IPOptimizer, options, curr_time
         options.store_trace,
         options.show_trace,
         options.show_every,
-        options.callback,
     )
 end

--- a/src/multivariate/solvers/constrained/samin.jl
+++ b/src/multivariate/solvers/constrained/samin.jl
@@ -66,7 +66,7 @@ function optimize(
     method::SAMIN,
     options::Options = Options(),
 ) where {Tx}
-
+    (; callback) = options
     time0 = time() # Initial time stamp used to control early stopping by options.time_limit
 
     hline = "="^80
@@ -78,8 +78,7 @@ function optimize(
     tracing =
         options.store_trace ||
         options.show_trace ||
-        options.extended_trace ||
-        options.callback !== nothing
+        options.extended_trace
 
     (;nt, ns, t0, rt, r_expand, bounds_ratio, neps, coverage_ok, verbosity) = method
     verbose = verbosity > 0
@@ -120,7 +119,7 @@ function optimize(
         options,
         _time - time0,
     )
-    stopped_by_callback = false
+    stopped_by_callback = callback !== nothing && callback((; x, f_x, iteration))
     # main loop, first increase temperature until parameter space covered, then reduce until convergence
     xp = copy(x) # proposal
     while converge == 0
@@ -180,9 +179,9 @@ function optimize(
                         end
                     end
 
+                    # update trace
                     if tracing
-                        # update trace; callbacks can stop routine early by returning true
-                        stopped_by_callback = trace!(
+                        trace!(
                             tr,
                             d,
                             (; x = x_opt, f_x = f_opt, iteration = iteration),
@@ -191,6 +190,10 @@ function optimize(
                             options,
                             time() - time0,
                         )
+                    end
+                    # callbacks can stop routine early by returning true
+                    if callback !== nothing
+                        stopped_by_callback = callback((; x = x_opt, f_x = f_opt, iteration = iteration))
                     end
 
                     # If options.iterations exceeded, terminate the algorithm

--- a/src/multivariate/solvers/first_order/bfgs.jl
+++ b/src/multivariate/solvers/first_order/bfgs.jl
@@ -221,6 +221,5 @@ function trace!(tr, d, state::BFGSState, iteration::Integer, method::BFGS, optio
         options.store_trace,
         options.show_trace,
         options.show_every,
-        options.callback,
     )
 end

--- a/src/multivariate/solvers/first_order/ngmres.jl
+++ b/src/multivariate/solvers/first_order/ngmres.jl
@@ -491,7 +491,6 @@ function trace!(
         options.store_trace,
         options.show_trace,
         options.show_every,
-        options.callback,
     )
 end
 #

--- a/src/multivariate/solvers/second_order/krylov_trust_region.jl
+++ b/src/multivariate/solvers/second_order/krylov_trust_region.jl
@@ -98,7 +98,6 @@ function trace!(
         options.store_trace,
         options.show_trace,
         options.show_every,
-        options.callback,
     )
 end
 

--- a/src/multivariate/solvers/second_order/newton.jl
+++ b/src/multivariate/solvers/second_order/newton.jl
@@ -106,6 +106,5 @@ function trace!(tr, d, state::NewtonState, iteration::Integer, ::Newton, options
         options.store_trace,
         options.show_trace,
         options.show_every,
-        options.callback,
     )
 end

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -492,6 +492,5 @@ function trace!(
         options.store_trace,
         options.show_trace,
         options.show_every,
-        options.callback,
     )
 end

--- a/src/multivariate/solvers/zeroth_order/nelder_mead.jl
+++ b/src/multivariate/solvers/zeroth_order/nelder_mead.jl
@@ -361,7 +361,6 @@ function trace!(
         options.store_trace,
         options.show_trace,
         options.show_every,
-        options.callback,
         options.trace_simplex,
     )
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -119,9 +119,6 @@ function Options(;
     time_limit = NaN,
 )
     show_every = show_every > 0 ? show_every : 1
-    #if extended_trace && callback === nothing
-    #    show_trace = true
-    #end
     if !(x_tol === nothing)
         @warn(
             lazy"x_tol is deprecated. Use x_abstol or x_reltol instead. The provided value ($(x_tol)) will be used as x_abstol.",

--- a/src/univariate/optimize/interface.jl
+++ b/src/univariate/optimize/interface.jl
@@ -14,10 +14,8 @@ function optimize(
     show_every = 1,
     extended_trace::Bool = false,
 ) where {T<:Real}
-    show_every = show_every > 0 ? show_every : 1
-    if extended_trace && callback === nothing
-        show_trace = true
-    end
+    show_every = max(show_every, 1)
+    show_trace |= extended_trace
 
     show_trace && print_header(method)
     Tf = float(T)

--- a/src/univariate/solvers/brent.jl
+++ b/src/univariate/solvers/brent.jl
@@ -73,20 +73,20 @@ function optimize(
 
     # Trace the history of states visited
     tr = OptimizationTrace{T,typeof(mo)}()
-    tracing = store_trace || show_trace || extended_trace || callback !== nothing
-    stopped_by_callback = false
+    state = (
+        new_minimizer = new_minimizer,
+        x_lower = x_lower,
+        x_upper = x_upper,
+        best_bound = best_bound,
+        new_minimum = new_minimum,
+    )
+    # update trace
+    tracing = store_trace || show_trace || extended_trace
     if tracing
-        # update trace; callbacks can stop routine early by returning true
-        state = (
-            new_minimizer = new_minimizer,
-            x_lower = x_lower,
-            x_upper = x_upper,
-            best_bound = best_bound,
-            new_minimum = new_minimum,
-        )
-        stopped_by_callback =
-            trace!(tr, nothing, state, iteration, mo, options, time() - t0)
+        trace!(tr, nothing, state, iteration, mo, options, time() - t0)
     end
+    # callbacks can stop routine early by returning true
+    stopped_by_callback = callback !== nothing && callback(state)
     _time = time() - t0
     while iteration < iterations && !stopped_by_callback && _time < time_limit
 
@@ -183,17 +183,15 @@ function optimize(
                 old_old_minimum = new_f
             end
         end
+
+        state = (; new_minimizer, x_lower, x_upper, best_bound, new_minimum)
+        # update trace
         if tracing
-            # update trace; callbacks can stop routine early by returning true
-            state = (
-                new_minimizer = new_minimizer,
-                x_lower = x_lower,
-                x_upper = x_upper,
-                best_bound = best_bound,
-                new_minimum = new_minimum,
-            )
-            stopped_by_callback =
-                trace!(tr, nothing, state, iteration, mo, options, time() - t0)
+            trace!(tr, nothing, state, iteration, mo, options, time() - t0)
+        end
+        # callbacks can stop routine early by returning true
+        if callback !== nothing
+            stopped_by_callback = callback(state)
         end
         _time = time() - t0
     end

--- a/src/univariate/solvers/golden_section.jl
+++ b/src/univariate/solvers/golden_section.jl
@@ -63,20 +63,20 @@ function optimize(
 
     # Trace the history of states visited
     tr = OptimizationTrace{T,typeof(mo)}()
-    tracing = store_trace || show_trace || extended_trace || callback !== nothing
-    stopped_by_callback = false
+    state = (
+        new_minimizer = new_minimizer,
+        x_lower = x_lower,
+        x_upper = x_upper,
+        best_bound = best_bound,
+        new_minimum = new_minimum,
+    )
+    # update trace
+    tracing = store_trace || show_trace || extended_trace
     if tracing
-        # update trace; callbacks can stop routine early by returning true
-        state = (
-            new_minimizer = new_minimizer,
-            x_lower = x_lower,
-            x_upper = x_upper,
-            best_bound = best_bound,
-            new_minimum = new_minimum,
-        )
-        stopped_by_callback =
-            trace!(tr, nothing, state, iteration, mo, options, time() - t0)
+        trace!(tr, nothing, state, iteration, mo, options, time() - t0)
     end
+    # callbacks can stop routine early by returning true
+    stopped_by_callback = callback !== nothing && callback(state)
 
     _time = time() - t0
 
@@ -121,17 +121,20 @@ function optimize(
             end
         end
 
+        state = (
+            new_minimizer = new_minimizer,
+            x_lower = x_lower,
+            x_upper = x_upper,
+            best_bound = best_bound,
+            new_minimum = new_minimum,
+        )
+        # update trace
         if tracing
-            # update trace; callbacks can stop routine early by returning true
-            state = (
-                new_minimizer = new_minimizer,
-                x_lower = x_lower,
-                x_upper = x_upper,
-                best_bound = best_bound,
-                new_minimum = new_minimum,
-            )
-            stopped_by_callback =
-                trace!(tr, nothing, state, iteration, mo, options, time() - t0)
+            trace!(tr, nothing, state, iteration, mo, options, time() - t0)
+        end
+        # callbacks can stop routine early by returning true
+        if callback !== nothing
+            stopped_by_callback = callback(state)
         end
         _time = time() - t0
     end

--- a/src/utilities/trace.jl
+++ b/src/utilities/trace.jl
@@ -26,6 +26,5 @@ function common_trace!(
         options.store_trace,
         options.show_trace,
         options.show_every,
-        options.callback,
     )
 end

--- a/src/utilities/update.jl
+++ b/src/utilities/update.jl
@@ -7,7 +7,6 @@ function update!(
     store_trace::Bool,
     show_trace::Bool,
     show_every::Int = 1,
-    callback = nothing,
     trace_simplex = false,
 ) where {Tf,T}
     os = OptimizationState{Tf,T}(iteration, f_x, grnorm, dt)
@@ -20,14 +19,5 @@ function update!(
             flush(stdout)
         end
     end
-    if callback !== nothing
-        if store_trace
-            stopped = callback(tr)
-        else
-            stopped = callback(os)
-        end
-    else
-        stopped = false
-    end
-    stopped
+    return nothing
 end

--- a/test/general/callbacks.jl
+++ b/test/general/callbacks.jl
@@ -9,68 +9,90 @@
     d3 = TwiceDifferentiable(f, g!, h!, initial_x)
 
     for method in (NelderMead(), SimulatedAnnealing())
-        ot_count = 0
-        cb = tr -> begin
-            ot_count += 1
+        a = 0
+        cb = _ -> begin
+            a += 1
             false
         end
         options = Optim.Options(callback = cb, show_every = 3, store_trace = true)
         res1 = optimize(f, initial_x, method, options)
-        @test ot_count == 1+res1.iterations
+        @test a == 1+res1.iterations
 
-        os_count_2 = 0
+        b = 0
         cb = os -> begin
-            os_count_2 += 1
+            b += 1
             false
         end
         options = Optim.Options(callback = cb, show_every = 3)
         res2 = optimize(f, initial_x, method, options)
-        @test os_count_2 == 1+res2.iterations
+        @test b == 1+res2.iterations
 
         # Test early stopping by callbacks
-        options = Optim.Options(callback = x -> x.iteration == 5 ? true : false)
+        iteration = -1
+        cb = _ -> begin
+            return (iteration += 1) == 5
+        end
+        options = Optim.Options(callback = cb)
         res3 = optimize(f, zeros(2), NelderMead(), options)
         @test res3.iterations == 5
     end
 
     for method in (BFGS(), ConjugateGradient(), GradientDescent(), MomentumGradientDescent())
-        ot_count = 0
-        cb = tr -> begin
-            ot_count += 1
+        a = 0
+        cb = _ -> begin
+            a += 1
             false
         end
         options = Optim.Options(callback = cb, show_every = 3, store_trace = true)
         res1 = optimize(d2, initial_x, method, options)
-        @test ot_count == 1+res1.iterations
+        @test a == 1+res1.iterations
 
-        os_count = 0
-        cb = os -> begin
-            os_count += 1
+        b = 0
+        cb = _ -> begin
+            b += 1
             false
         end
         options = Optim.Options(callback = cb, show_every = 3)
         res2 = optimize(d2, initial_x, method, options)
-        @test os_count == 1+res2.iterations
+        @test b == 1+res2.iterations
+
+        c = 0
+        cb = _ -> begin
+            c += 1
+            false
+        end
+        options = Optim.Options(callback = cb)
+        res2 = optimize(d2, initial_x, method, options)
+        @test c == 1+res2.iterations
     end
 
     for method in (Newton(),)
-        ot_count = 0
-        cb = tr -> begin
-            ot_count += 1
+        a = 0
+        cb = _ -> begin
+            a += 1
             false
         end
         options = Optim.Options(callback = cb, show_every = 3, store_trace = true)
         res1 = optimize(d3, initial_x, method, options)
-        @test ot_count == 1+res1.iterations
+        @test a == 1+res1.iterations
 
-        os_count = 0
-        cb = os -> begin
-            os_count += 1
+        b = 0
+        cb = _ -> begin
+            b += 1
             false
         end
         options = Optim.Options(callback = cb, show_every = 3)
         res2 = optimize(d3, initial_x, method, options)
-        @test os_count == 1+res2.iterations
+        @test b == 1+res2.iterations
+
+        c = 0
+        cb = _ -> begin
+            c += 1
+            false
+        end
+        options = Optim.Options(callback = cb)
+        res2 = optimize(d3, initial_x, method, options)
+        @test c == 1+res2.iterations
     end
 
     res = optimize(x -> x^2, -5, 5, callback = _ -> true)


### PR DESCRIPTION
In some downstream application I want to define a custom callback that requires information about the current state `x` (and ideally also `f(x)` but I could work around this by closing over the objective function and reevaluating it...) However, currently, that information is not provided to callbacks unless `extended_trace = true`: https://github.com/JuliaNLSolvers/Optim.jl/blob/540c97b28a6e37fae10ec689c83c3dbe9dce2f73/src/utilities/trace.jl#L14-L18 Since users may change the tracing options, this would mean that the callback would be broken when users change this option.

With #1212, the current `x` (and `f(x)` and if available its gradient and/or Hessian) are all included in the state of the optimizer (at least for multivariate optimization problems, univariate ones are a bit special it seems). Hence in this PR I propose to

- fully decouple callbacks from tracing
- forwarding the full state of the optimization algorithm to the callback