### PR TITLE
Fix manifold value_gradient! call such that it returns both things.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/linux_nightly.yml
+++ b/.github/workflows/linux_nightly.yml
@@ -23,7 +23,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -23,7 +23,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/mac_nightly.yml
+++ b/.github/workflows/mac_nightly.yml
@@ -23,7 +23,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/windows_nightly.yml
+++ b/.github/workflows/windows_nightly.yml
@@ -23,7 +23,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - name: Cache artifacts
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -49,7 +49,7 @@ function NLSolversBase.value_gradient!(obj::ManifoldObjective,x)
     xin = retract(obj.manifold, x)
     value_gradient!(obj.inner_obj,xin)
     project_tangent!(obj.manifold,gradient(obj.inner_obj),xin)
-    return value(obj.inner_obj)
+    return value(obj.inner_obj), gradient(obj.inner_obj)
 end
 
 """Flat Euclidean space {R,C}^N, with projections equal to the identity."""

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -48,9 +48,9 @@ function test_MOI_Test()
             ],
         ),
         exclude = String[
-            "test_nonlinear_constraint_log$",
+            "test_nonlinear_constraint_log",
             # No nonlinear objective.
-            "test_nonlinear_with_scalar_quadratic_function_with_off_diag$",
+            "test_nonlinear_with_scalar_quadratic_function_with_off_diag",
             # No objective
             "test_attribute_SolveTimeSec",
             "test_attribute_RawStatusString",

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -48,6 +48,9 @@ function test_MOI_Test()
             ],
         ),
         exclude = String[
+            "test_nonlinear_constraint_log$",
+            # No nonlinear objective.
+            "test_nonlinear_with_scalar_quadratic_function_with_off_diag$",
             # No objective
             "test_attribute_SolveTimeSec",
             "test_attribute_RawStatusString",

--- a/test/multivariate/solvers/constrained/fminbox.jl
+++ b/test/multivariate/solvers/constrained/fminbox.jl
@@ -142,3 +142,10 @@ end
 @testset "#865" begin
     optimize(x -> sum(x), [0.,0.0], [2.0,2.0], [1.,1.0], Fminbox(NelderMead()))
 end
+
+@testset "#1229" begin
+    # shouldn't throw
+    optimize(sum, [0.1, 0.0], [1.0, 1.0], [0.5, 0.5],)
+    # More directly
+    @test all(Optim.value_gradient!(Optim.ManifoldObjective(Optim.Flat(), OnceDifferentiable(sum, [0.0])), [1.0]) .≈ (1.0, [0.9999999999960525]))
+end


### PR DESCRIPTION
Fixes 1.9 for LineSearches v7.5.1. This fix is also appropriate for older versions of LineSearches as it should be the returned thing, but the ManifoldObjective wasnt used in the problematic manner so I'm not updating the bounds.