### PR TITLE
Remove Literate.jl deprecation from docs/generate.jl

### DIFF
--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -13,11 +13,12 @@ for example in filter!(endswith(".jl"), readdir(EXAMPLEDIR))
     script = Literate.script(input, GENERATEDDIR)
     code = strip(read(script, String))
     mdpost(str) = replace(str, "@__CODE__" => code)
+    execute = !(example in ONLYSTATIC)
     Literate.markdown(
         input,
         GENERATEDDIR,
         postprocess = mdpost,
-        flavor = example in ONLYSTATIC ? CommonMarkFlavor() : DocumenterFlavor(),
+        flavor = execute ? DocumenterFlavor() : CommonMarkFlavor(),
     )
-    Literate.notebook(input, GENERATEDDIR, execute = !(example in ONLYSTATIC))
+    Literate.notebook(input, GENERATEDDIR; execute)
 end

--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -1,5 +1,5 @@
 # generate examples
-import Literate
+import Literate: Literate, CommonMarkFlavor, DocumenterFlavor
 
 # TODO: Remove items from `SKIPFILE` as soon as they run on the latest
 # stable `Optim` (or other dependency)
@@ -17,7 +17,7 @@ for example in filter!(x -> endswith(x, ".jl"), readdir(EXAMPLEDIR))
         input,
         GENERATEDDIR,
         postprocess = mdpost,
-        documenter = !(example in ONLYSTATIC),
+        flavor = example in ONLYSTATIC ? CommonMarkFlavor() : DocumenterFlavor(),
     )
     Literate.notebook(input, GENERATEDDIR, execute = !(example in ONLYSTATIC))
 end

--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -8,7 +8,7 @@ ONLYSTATIC = []
 
 EXAMPLEDIR = joinpath(@__DIR__, "src", "examples")
 GENERATEDDIR = joinpath(@__DIR__, "src", "examples", "generated")
-for example in filter!(x -> endswith(x, ".jl"), readdir(EXAMPLEDIR))
+for example in filter!(endswith(".jl"), readdir(EXAMPLEDIR))
     input = abspath(joinpath(EXAMPLEDIR, example))
     script = Literate.script(input, GENERATEDDIR)
     code = strip(read(script, String))


### PR DESCRIPTION
Running julia with `--depwarn=error` for unrelated reasons, but figured I'd clean up this deprecation while I'm at it.