### PR TITLE
Guard against gbarrier_norm == 0 in computation of initial mu (fixes #1233)

### DIFF
--- a/src/multivariate/solvers/constrained/fminbox.jl
+++ b/src/multivariate/solvers/constrained/fminbox.jl
@@ -267,7 +267,13 @@ function initial_mu(box::BoxBarrier, x::AbstractArray, g_x::AbstractArray, F::Fm
 
     gnorm, gbarrier_norm, mufactor, mu0 = promote(_gnorm, _gbarrier_norm, F.mufactor, F.mu0)
     mu = if isnan(mu0)
-        mufactor * gnorm / gbarrier_norm
+        # Guard against gbarrier_norm == 0 case leading to mu = 0/0, which is NaN
+        if gbarrier_norm > 0
+            mufactor * gnorm / gbarrier_norm
+        else
+             # Presumably, there is no barrier function
+            zero(gnorm)
+        end
     else
         mu0
     end

--- a/test/multivariate/solvers/constrained/fminbox.jl
+++ b/test/multivariate/solvers/constrained/fminbox.jl
@@ -181,6 +181,9 @@
                 Optim.Options(),
             )
         end
+        @testset "Guard against gbarrier_norm == 0 in computation of initial mu #1233" begin
+            optimize(exponential, fill(-Inf,2), fill(Inf,2), initial_x, Fminbox(), Optim.Options())
+        end
     end
 end
 

--- a/test/multivariate/solvers/constrained/fminbox.jl
+++ b/test/multivariate/solvers/constrained/fminbox.jl
@@ -182,7 +182,31 @@
             )
         end
         @testset "Guard against gbarrier_norm == 0 in computation of initial mu #1233" begin
-            optimize(exponential, fill(-Inf,2), fill(Inf,2), initial_x, Fminbox(), Optim.Options())
+            l_inf, u_inf = fill(-Inf, 2), fill(Inf, 2)
+        
+            # gnorm > 0, gbarrier_norm == 0: previously mu = gnorm/0 = Inf
+            res = optimize(exponential, l_inf, u_inf, initial_x, Fminbox(), Optim.Options())
+            @test Optim.converged(res)
+            @test Optim.minimizer(res) ≈ [2.0, 3.0] atol = 1e-3
+                                
+            # gnorm == 0 and gbarrier_norm == 0: previously mu = 0/0 = NaN
+            # ([2.0, 3.0] is the stationary point of `exponential`)
+            res = optimize(exponential, l_inf, u_inf, [2.0, 3.0], Fminbox(), Optim.Options())
+            @test Optim.converged(res)
+            @test Optim.minimizer(res) ≈ [2.0, 3.0]
+        
+            # initial_mu unit tests
+            box_inf = Optim.BoxBarrier(l_inf, u_inf)
+            @test Optim.initial_mu(box_inf, [0.0, 0.0], [1.0, 1.0], Fminbox()) == 0  # Inf case
+            @test Optim.initial_mu(box_inf, [0.0, 0.0], [0.0, 0.0], Fminbox()) == 0  # NaN case
+        
+            # half-bounded box: a single finite bound must still give mu > 0
+            box_half = Optim.BoxBarrier([-Inf, 0.0], [Inf, Inf])
+            @test Optim.initial_mu(box_half, [0.0, 1.0], [1.0, 1.0], Fminbox()) > 0
+        
+            # explicitly non-finite user-supplied mu0 should still throw
+            @test_throws ArgumentError Optim.initial_mu(box_inf, [0.0, 0.0], [1.0, 1.0],
+                                                        Fminbox(LBFGS(); mu0 = Inf))
         end
     end
 end


### PR DESCRIPTION
Fixes #1233 

If both `gnorm == 0` and `gbarrier_norm == 0`, then `mu = 0/0` which evaluates to `NaN`. I.e., this error is produced if all parameters are unbounded. Bug was introduced by removing safety catch in commit 9b664c2f "Re-instate old behavior for Fminbox..." leading up to v2.0.1.

I added back the old safety check and a dedicated test for good measure.