### PR TITLE
Move LBFGSB re-implementation / port into Optim

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ ExplicitImports = "1.13.2"
 FillArrays = "0.6.2, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 1"
 ForwardDiff = "0.10, 1"
 JET = "0.9, 0.10, 0.11"
+LBFGSB = "0.4.1"
 LineSearches = "7.7"
 LinearAlgebra = "<0.0.1, 1.6"
 MathOptInterface = "1.17"
@@ -54,6 +55,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LBFGSB = "5be7bae1-8223-5378-bac3-9e7378a2f6e6"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 OptimTestProblems = "cec144fc-5a64-5bc6-99fb-dde8f63e154c"
@@ -64,4 +66,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Aqua", "Distributions", "ExplicitImports", "ForwardDiff", "JET", "MathOptInterface", "Measurements", "OptimTestProblems", "Random", "RecursiveArrayTools", "StableRNGs", "ReverseDiff"]
+test = ["Test", "Aqua", "Distributions", "ExplicitImports", "ForwardDiff", "JET", "LBFGSB", "MathOptInterface", "Measurements", "OptimTestProblems", "Random", "RecursiveArrayTools", "StableRNGs", "ReverseDiff"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,6 +55,7 @@ makedocs(
                 "Conjugate Gradient" => "algo/cg.md",
                 "Gradient Descent" => "algo/gradientdescent.md",
                 "(L-)BFGS" => "algo/lbfgs.md",
+                "L-BFGS-B (box constrained)" => "algo/lbfgsb.md",
                 "Acceleration" => "algo/ngmres.md",
             ],
             "Hessian Required" => [

--- a/docs/src/algo/lbfgsb.md
+++ b/docs/src/algo/lbfgsb.md
@@ -1,0 +1,93 @@
+# L-BFGS-B
+## Constructor
+```julia
+LBFGSB(; m::Integer = 10,
+         linesearch = HZAW(),
+         stepsize = 1.0,
+         clip_subspace::Bool = true)
+```
+The keyword `m` sets how many `(s, y)` correction pairs are stored in the
+limited-memory Hessian approximation. `linesearch` selects one of the line
+searches bundled with the solver (`HZAW()`, the Hager-Zhang approximate-Wolfe
+search, or `MTLS()`, the Moré-Thuente search); these are self-contained and do
+not depend on LineSearches.jl. `stepsize` is the default trial step handed to
+the line search, and `clip_subspace` switches between Fortran-style
+component-wise clamping of the subspace step (`true`) and the paper's
+proportional backtracking (`false`).
+
+## Description
+`LBFGSB` solves problems of the form
+
+```math
+\min_{x} f(x) \quad \text{subject to} \quad l \le x \le u
+```
+
+where the bounds `l` and `u` may be finite, infinite, or equal (a fixed
+variable). It is the limited-memory BFGS algorithm with box constraints of
+Byrd, Lu, Nocedal and Zhu (1995). Unlike `Fminbox`, which wraps an
+unconstrained solver inside a log-barrier loop, `LBFGSB` handles the bounds
+natively and is a bound-constrained optimizer in its own right (a sibling of
+`Fminbox` and `SAMIN`).
+
+Each iteration
+
+1. computes the *generalized Cauchy point* by following the projected gradient
+   and stopping at the first set of bounds that minimizes the limited-memory
+   quadratic model,
+2. minimizes that quadratic model over the variables left free at the Cauchy
+   point, and
+3. performs a line search along the resulting search direction, capped at the
+   distance to the nearest bound so that every iterate stays feasible.
+
+The Hessian approximation is stored in the compact representation
+``B = \theta I - W M W^\top``, which keeps the per-iteration cost linear in the
+number of variables for a fixed memory length `m`.
+
+Convergence is assessed on the infinity norm of the projected gradient
+``\|x - P_{[l,u]}(x - g)\|_\infty`` against `Options.g_abstol`, in addition to
+the usual change-in-`x` and change-in-`f` criteria. This projected-gradient
+norm, not the plain ``\|g\|_\infty``, is what the results summary reports on the
+`|g(x)|` line; the two coincide only when no bound is active. Tolerances, the
+iteration cap, the time limit, and callbacks are all taken from `Optim.Options`.
+
+## Example
+`LBFGSB` is called with lower and upper bounds, which may be given as scalars or
+as arrays. The starting point must be feasible (`l .<= x0 .<= u`).
+
+```julia-repl
+julia> using Optim, OptimTestProblems
+
+julia> prob = UnconstrainedProblems.examples["Rosenbrock"];
+
+julia> optimize(prob.f, fill(-2.0, 2), fill(2.0, 2), prob.initial_x, LBFGSB())
+ * Status: success
+
+ * Candidate solution
+    Final objective value:     5.021329e-17
+
+ * Found with
+    Algorithm:     L-BFGS-B
+
+ * Convergence measures
+    |x - x'|               = 2.67e-08 ≰ 0.0e+00
+    |x - x'|/|x'|          = 2.67e-08 ≰ 0.0e+00
+    |f(x) - f(x')|         = 4.94e-23 ≰ 0.0e+00
+    |f(x) - f(x')|/|f(x')| = 9.84e-07 ≰ 0.0e+00
+    |g(x)|                 = 2.34e-09 ≤ 1.0e-08
+
+ * Work counters
+    Seconds run:   0  (vs limit Inf)
+    Iterations:    40
+    f(x) calls:    99
+    ∇f(x) calls:   99
+    ∇f(x)ᵀv calls: 0
+```
+
+Scalar bounds are broadcast to every coordinate, so the same problem on the box
+``[-2, 2]^2`` can also be written `optimize(prob.f, -2.0, 2.0, prob.initial_x, LBFGSB())`.
+
+## References
+
+```@bibliography
+byrd1995
+```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -9,6 +9,17 @@
   langid = {english}
 }
 
+@article{byrd1995,
+  title = {A Limited Memory Algorithm for Bound Constrained Optimization},
+  author = {Byrd, Richard H. and Lu, Peihuang and Nocedal, Jorge and Zhu, Ciyou},
+  year = {1995},
+  journal = {SIAM Journal on Scientific Computing},
+  volume = {16},
+  number = {5},
+  pages = {1190--1208},
+  doi = {10.1137/0916069}
+}
+
 @article{edelman1998,
   title = {The Geometry of Algorithms with Orthogonality Constraints},
   author = {Edelman, Alan and Arias, Tom{\'a}s A. and Smith, Steven T.},

--- a/src/Optim.jl
+++ b/src/Optim.jl
@@ -130,6 +130,7 @@ export optimize,
 
     ### Multivariate, R^N -> R
     Fminbox,
+    LBFGSB,
     SAMIN,
 
     ## Manifold constraints
@@ -186,6 +187,8 @@ include("multivariate/solvers/first_order/ngmres.jl")
 # Constrained optimization
 ## Box constraints
 include("multivariate/solvers/constrained/fminbox.jl")
+include("multivariate/solvers/constrained/lbfgsb.jl")
+include("multivariate/solvers/constrained/simple_lbfgsb.jl")
 include("multivariate/solvers/constrained/samin.jl")
 
 # Univariate methods

--- a/src/multivariate/solvers/constrained/lbfgsb.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb.jl
@@ -1055,7 +1055,11 @@ function optimize(
             α = min(T(1) / 10^4, αmax)
         end
 
-        @. x_candidate = x + α * B.d
+        # Project onto the box. The line search caps α at αmax (the exact step to
+        # the nearest bound), so this only matters at the ULP level when a bound
+        # is active — but it guarantees every iterate (and the returned x) is
+        # feasible rather than a rounding-width outside.
+        @. x_candidate = clamp(x + α * B.d, l, u)
         f_new, _gn = value_gradient!(d, x_candidate)
         g_new .= _gn
 

--- a/src/multivariate/solvers/constrained/lbfgsb.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb.jl
@@ -89,11 +89,11 @@ Base.summary(io::IO, ::LBFGSB) = print(io, "L-BFGS-B")
 # x_abschange/f_abschange accessors return the real change values: the
 # ZerothOrderState methods return NaN, which would mask the x/f-based
 # termination codes (SmallObjectiveChange, SmallXChange, ...).
-struct LBFGSBState{T,Tx} <: AbstractOptimizerState
+struct LBFGSBState{Tx,Tf,Tfp} <: AbstractOptimizerState
     x::Tx
-    f_x::T
+    f_x::Tf
     x_previous::Tx
-    f_x_previous::T
+    f_x_previous::Tfp
 end
 
 # Compact representation of the limited-memory Hessian approximation

--- a/src/multivariate/solvers/constrained/lbfgsb.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb.jl
@@ -1,0 +1,1164 @@
+# Native L-BFGS-B (limited-memory BFGS with box constraints).
+#
+# Partial source/paper iomplementation, partial translation of some inner
+# methods from the Fortran L-BFGS-B 3.0 algorithm of Byrd, Lu, Nocedal & Zhu (1995),
+# "A Limited Memory Algorithm for Bound Constrained Optimization",
+# SIAM J. Sci. Comput. 16(5):1190-1208.
+#
+# Unlike Fminbox (a log-barrier wrapper around an unconstrained solver), this
+# handles the bounds natively. Each iteration computes a generalized Cauchy
+# point (with lazy heap-ordered breakpoints), then minimizes the quadratic model
+# over the free variables, then does a line search along the resulting
+# direction. The Hessian approximation is kept in the compact form
+# B = θI - W M Wᵀ; the middle solves use Cholesky-factored intermediate matrices
+# (formt!/formk!/bmv!) and an incrementally maintained free/active set (freev!),
+# and the hot paths are in-place.
+#
+# The line searches live in lbfgsb/ and are self-contained (no LineSearches.jl
+# dependency); they share the find_steplength / LineSearcher interface.
+# These are essentially re-implementations and needed better support for
+# max steplengths. We can adjust this later and upstream
+
+using NLSolversBase: value_gradient!
+
+abstract type LineSearcher end
+
+include("lbfgsb/hz.jl")              # HZAW (Hager-Zhang approximate Wolfe)
+include("lbfgsb/linesearches_mt.jl") # MTLS (Moré-Thuente), pulls in mt/*
+
+struct LBFGSB{L<:LineSearcher,T} <: AbstractConstrainedOptimizer
+    m::Int               # number of correction pairs kept in memory
+    linesearch::L        # vendored line search (HZAW, MTLS, ...)
+    stepsize::T          # default trial step handed to the line search
+    clip_subspace::Bool  # true: component-wise clamp (Fortran), false: backtracking (paper)
+end
+
+"""
+# LBFGSB
+## Constructor
+```julia
+LBFGSB(; m::Integer = 10,
+         linesearch::LineSearcher = HZAW(),
+         stepsize = 1.0,
+         clip_subspace::Bool = true)
+```
+## Description
+`LBFGSB` is a native implementation of the limited-memory BFGS algorithm with
+box constraints `lb .<= x .<= ub`. It is a bound-constrained optimizer in its
+own right (a sibling of `Fminbox`/`SAMIN`), not a wrapper around an
+unconstrained method.
+
+Each iteration computes the generalized Cauchy point along the projected
+gradient, minimizes the limited-memory quadratic model over the variables that
+remain free at the Cauchy point, and performs a line search (capped at the
+distance to the nearest active bound) along the resulting search direction. The
+compact representation is maintained with Cholesky-factored intermediate
+matrices and an incrementally updated free/active set, so the per-iteration cost
+is linear in the number of variables for a fixed memory length `m`.
+
+The memory length `m` controls how many `(s, y)` correction pairs are stored.
+`linesearch` selects one of the vendored line searches (`HZAW()` or `MTLS()`).
+`clip_subspace` chooses between later style component-wise clamping of the
+subspace step (`true`) and the original paper's proportional backtracking (`false`).
+
+Gradient-based convergence uses the **projected gradient**, not the plain
+gradient: the run stops when `‖x - P(x - g)‖∞ ≤ g_abstol`, where `P` projects
+onto the box `[lb, ub]`. This is the correct first-order stationarity measure
+for a bound-constrained problem, and it equals `‖g‖∞` only when no bound is
+active. The reported `g_residual` (shown as `|g(x)|` in the results summary)
+is this projected-gradient norm.
+
+## References
+ - Byrd, R. H., Lu, P., Nocedal, J. and Zhu, C. (1995). A Limited Memory
+   Algorithm for Bound Constrained Optimization. SIAM Journal on Scientific
+   Computing, 16(5), 1190-1208.
+"""
+function LBFGSB(;
+    m::Integer = 10,
+    linesearch::LineSearcher = HZAW(),
+    stepsize::Real = 1.0,
+    clip_subspace::Bool = true,
+)
+    LBFGSB(Int(m), linesearch, float(stepsize), clip_subspace)
+end
+
+Base.summary(io::IO, ::LBFGSB) = print(io, "L-BFGS-B")
+
+# Minimal state used only to report the termination code. It subtypes
+# AbstractOptimizerState (not ZerothOrderState) so that the generic
+# x_abschange/f_abschange accessors return the real change values: the
+# ZerothOrderState methods return NaN, which would mask the x/f-based
+# termination codes (SmallObjectiveChange, SmallXChange, ...).
+struct LBFGSBState{T,Tx} <: AbstractOptimizerState
+    x::Tx
+    f_x::T
+    x_previous::Tx
+    f_x_previous::T
+end
+
+# Compact representation of the limited-memory Hessian approximation
+# B = θI - W M Wᵀ, with correction pairs in a circular buffer (S, Y) and the
+# middle matrix kept as Cholesky factors (J for formt!, wn for formk!).
+# Probably need to simplify this, but tried to really not allocate more than 
+# the fortran version.
+mutable struct CompactLBFGS{T}
+    m::Int                # max history size
+    S::Matrix{T}          # n × m, correction pairs sₖ
+    Y::Matrix{T}          # n × m, correction pairs yₖ
+    SᵀS::Matrix{T}        # m × m, SₖᵀSₖ
+    SY::Matrix{T}         # m × m, SₖᵀYₖ (lower tri = L, diag = D)
+    J::Matrix{T}          # m × m, upper Cholesky factor of T = θSᵀS + LD⁻¹Lᵀ
+    work::Vector{T}       # length 2m, scratch for bmv!
+    θ::T                  # Hessian scaling θ = yₖᵀyₖ / yₖᵀsₖ
+    k::Int                # number of pairs stored
+    head::Int             # circular buffer: physical index of oldest column
+    wn::Matrix{T}         # 2m × 2m, factored K-matrix for subspace solve
+    wn1::Matrix{T}        # 2m × 2m, inner products
+    index::Vector{Int}    # length n: free vars (1:nfree), then active vars
+    iwhere::Vector{Int}   # length n: 0=free, >0=at bound
+    indx2::Vector{Int}    # length n: entering/leaving scratch (also iorder in cauchy)
+    nfree::Int            # number of free variables
+    iupdat::Int           # total BFGS updates so far
+    cnstnd::Bool          # whether the problem has finite bounds
+    s::Vector{T}          # length n, scratch for update_compact! (x_new - x)
+    y::Vector{T}          # length n, scratch for update_compact! (g_new - g)
+    # Pre-allocated workspace (Fortran keeps these in one long work vector).
+    xc::Vector{T}         # length n, Cauchy point / trial point (Fortran: z)
+    t_bp::Vector{T}       # length n, breakpoint times (Fortran: t)
+    p_ws::Vector{T}       # length 2m, W'd accumulator in Cauchy
+    c_ws::Vector{T}       # length 2m, W'(xc - x) coefficients
+    Mv::Vector{T}         # length 2m, bmv! scratch in Cauchy
+    wb::Vector{T}         # length 2m, Wrow! scratch in Cauchy
+    r_ws::Vector{T}       # length n, reduced gradient (Fortran: r)
+    du::Vector{T}         # length n, subspace direction (Fortran: d)
+    d::Vector{T}          # length n, search direction x̂ - x
+end
+
+function CompactLBFGS{T}(n::Integer, m::Integer) where {T}
+    CompactLBFGS{T}(
+        m,
+        zeros(T, n, m),
+        zeros(T, n, m),
+        zeros(T, m, m),
+        zeros(T, m, m),
+        zeros(T, m, m),
+        zeros(T, 2m),
+        one(T),
+        0,
+        1,
+        zeros(T, 2m, 2m),
+        zeros(T, 2m, 2m),
+        collect(1:n),
+        zeros(Int, n),
+        zeros(Int, n),
+        0,
+        0,
+        false,
+        zeros(T, n),
+        zeros(T, n),
+        zeros(T, n),
+        zeros(T, n),
+        zeros(T, 2m),
+        zeros(T, 2m),
+        zeros(T, 2m),
+        zeros(T, 2m),
+        zeros(T, n),
+        zeros(T, n),
+        zeros(T, n),
+    )
+end
+
+function reset_history!(B::CompactLBFGS{T}) where {T}
+    B.k = 0
+    B.head = 1
+    B.θ = one(T)
+    B.iupdat = 0
+    B.nfree = 0
+    B.wn .= 0
+    B.wn1 .= 0
+    return B
+end
+
+# Map logical column j (1 = oldest) to physical column in the circular buffer.
+pcol(B::CompactLBFGS, j::Int) = mod(B.head + j - 2, B.m) + 1
+
+# Build T = θ·SᵀS + L·D⁻¹·Lᵀ and Cholesky-factor into B.J (upper triangle).
+# L = strict lower triangle of SY, D = Diagonal(diag(SY)). (Fortran `formt`.)
+function formt!(B::CompactLBFGS)
+    k = B.k
+    k == 0 && return
+    J, SY, SS = B.J, B.SY, B.SᵀS
+
+    for i = 1:k
+        for j = i:k
+            ddum = B.θ * SS[i, j]
+            for p = 1:(min(i, j)-1)
+                ddum += SY[i, p] * SY[j, p] / SY[p, p]
+            end
+            J[i, j] = ddum
+        end
+    end
+
+    cholesky!(Symmetric(@view(J[1:k, 1:k]), :U))
+    return
+end
+
+# Compute p = M·v with M the middle matrix of the compact form, using the
+# Cholesky factor in B.J rather than an explicit inverse. (Fortran `bmv`.)
+function bmv!(p::AbstractVector, v::AbstractVector, B::CompactLBFGS)
+    k = B.k
+    k == 0 && return
+    T = eltype(p)
+
+    SY = B.SY
+    U = LinearAlgebra.UpperTriangular(@view(B.J[1:k, 1:k]))
+
+    # p₂ = (U')⁻¹ (v₂ + L·D⁻¹·v₁)
+    for i = 1:k
+        s = v[k+i]
+        for j = 1:(i-1)
+            s += SY[i, j] * v[j] / SY[j, j]
+        end
+        p[k+i] = s
+    end
+    ldiv!(U', @view(p[(k+1):2k]))
+
+    # p₁ = D^{-½}·v₁
+    for i = 1:k
+        p[i] = v[i] / sqrt(SY[i, i])
+    end
+
+    # p₂ = U⁻¹·p₂
+    ldiv!(U, @view(p[(k+1):2k]))
+
+    # p₁ = -D^{-½}·p₁ + D⁻¹·Lᵀ·p₂
+    for i = 1:k
+        p[i] = -p[i] / sqrt(SY[i, i])
+        s = zero(T)
+        for j = (i+1):k
+            s += SY[j, i] * p[k+j] / SY[i, i]
+        end
+        p[i] += s
+    end
+    return
+end
+
+# Extract row b of the implicit W = [Y  θS] into wb (length 2k).
+function Wrow!(wb::AbstractVector, B::CompactLBFGS, b::Int)
+    k = B.k
+    for j = 1:k
+        pj = pcol(B, j)
+        wb[j] = B.Y[b, pj]
+        wb[k+j] = B.θ * B.S[b, pj]
+    end
+    return
+end
+
+# Count entering/leaving variables and rebuild the free/active index set.
+# Returns (nenter, ileave, wrk) where wrk = true if formk! needs to run.
+# (Fortran `freev`.)
+function freev!(B::CompactLBFGS, iter::Int, updatd::Bool)
+    n = length(B.iwhere)
+    nenter = 0
+    ileave = n + 1
+
+    if iter > 0 && B.cnstnd
+        for i = 1:B.nfree
+            k = B.index[i]
+            if B.iwhere[k] > 0
+                ileave -= 1
+                B.indx2[ileave] = k
+            end
+        end
+        for i = (B.nfree+1):n
+            k = B.index[i]
+            if B.iwhere[k] <= 0
+                nenter += 1
+                B.indx2[nenter] = k
+            end
+        end
+    end
+
+    wrk = (ileave < n + 1) || (nenter > 0) || updatd
+
+    B.nfree = 0
+    iact = n + 1
+    for i = 1:n
+        if B.iwhere[i] <= 0
+            B.nfree += 1
+            B.index[B.nfree] = i
+        else
+            iact -= 1
+            B.index[iact] = i
+        end
+    end
+
+    return nenter, ileave, wrk
+end
+
+# Build and Cholesky-factor the 2col×2col indefinite K-matrix for the subspace
+# solve, incrementally updating the inner-product cache wn1. (Fortran `formk`.)
+# Returns info: 0 = success, -1/-2 = Cholesky failure.
+function formk!(B::CompactLBFGS, nenter::Int, ileave::Int, updatd::Bool)
+    n = length(B.iwhere)
+    m = B.m
+    col = B.k
+    col == 0 && return 0
+    T = eltype(B.wn)
+
+    if updatd
+        if B.iupdat > m
+            for jy = 1:(m-1)
+                js = m + jy
+                for i = 1:(m-jy)
+                    B.wn1[jy+i-1, jy] = B.wn1[jy+i, jy+1]
+                end
+                for i = 1:(m-jy)
+                    B.wn1[js+i-1, js] = B.wn1[js+i, js+1]
+                end
+                for i = 1:(m-1)
+                    B.wn1[m+i, jy] = B.wn1[m+i+1, jy+1]
+                end
+            end
+        end
+
+        ipntr = pcol(B, col)
+
+        for jy = 1:col
+            jpntr = pcol(B, jy)
+            js = m + jy
+            temp1 = zero(T)
+            temp2 = zero(T)
+            temp3 = zero(T)
+            for ii = 1:B.nfree
+                k1 = B.index[ii]
+                temp1 += B.Y[k1, ipntr] * B.Y[k1, jpntr]
+            end
+            for ii = (B.nfree+1):n
+                k1 = B.index[ii]
+                temp2 += B.S[k1, ipntr] * B.S[k1, jpntr]
+                temp3 += B.S[k1, ipntr] * B.Y[k1, jpntr]
+            end
+            B.wn1[col, jy] = temp1
+            B.wn1[m+col, js] = temp2
+            B.wn1[m+col, jy] = temp3
+        end
+
+        jpntr = pcol(B, col)
+        for i = 1:col
+            ipntr2 = pcol(B, i)
+            is = m + i
+            temp3 = zero(T)
+            for ii = 1:B.nfree
+                k1 = B.index[ii]
+                temp3 += B.S[k1, ipntr2] * B.Y[k1, jpntr]
+            end
+            B.wn1[is, col] = temp3
+        end
+        upcl = col - 1
+    else
+        upcl = col
+    end
+
+    for iy = 1:upcl
+        ipntr = pcol(B, iy)
+        is = m + iy
+        for jy = 1:iy
+            jpntr = pcol(B, jy)
+            js = m + jy
+            temp1 = zero(T)
+            temp2 = zero(T)
+            temp3 = zero(T)
+            temp4 = zero(T)
+            for ii = 1:nenter
+                k1 = B.indx2[ii]
+                temp1 += B.Y[k1, ipntr] * B.Y[k1, jpntr]
+                temp2 += B.S[k1, ipntr] * B.S[k1, jpntr]
+            end
+            for ii = ileave:n
+                k1 = B.indx2[ii]
+                temp3 += B.Y[k1, ipntr] * B.Y[k1, jpntr]
+                temp4 += B.S[k1, ipntr] * B.S[k1, jpntr]
+            end
+            B.wn1[iy, jy] += temp1 - temp3
+            B.wn1[is, js] += -temp2 + temp4
+        end
+    end
+
+    for iy = 1:upcl
+        ipntr = pcol(B, iy)
+        is = m + iy
+        for jy = 1:upcl
+            jpntr = pcol(B, jy)
+            temp1 = zero(T)
+            temp3 = zero(T)
+            for ii = 1:nenter
+                k1 = B.indx2[ii]
+                temp1 += B.S[k1, ipntr] * B.Y[k1, jpntr]
+            end
+            for ii = ileave:n
+                k1 = B.indx2[ii]
+                temp3 += B.S[k1, ipntr] * B.Y[k1, jpntr]
+            end
+            if is <= jy + m
+                B.wn1[is, jy] += temp1 - temp3
+            else
+                B.wn1[is, jy] += -temp1 + temp3
+            end
+        end
+    end
+
+    θ = B.θ
+    wn = B.wn
+    wn1 = B.wn1
+
+    for iy = 1:col
+        is = col + iy
+        is1 = m + iy
+        for jy = 1:iy
+            js = col + jy
+            js1 = m + jy
+            wn[jy, iy] = wn1[iy, jy] / θ
+            wn[js, is] = wn1[is1, js1] * θ
+        end
+        for jy = 1:(iy-1)
+            wn[jy, is] = -wn1[is1, jy]
+        end
+        for jy = iy:col
+            wn[jy, is] = wn1[is1, jy]
+        end
+        wn[iy, iy] += B.SY[iy, iy]
+    end
+
+    C1 = cholesky!(Symmetric(@view(wn[1:col, 1:col]), :U); check = false)
+    issuccess(C1) || return -1
+
+    U1 = LinearAlgebra.UpperTriangular(@view(wn[1:col, 1:col]))
+    for js = (col+1):2col
+        ldiv!(U1', @view(wn[1:col, js]))
+    end
+
+    for is = (col+1):2col
+        for js = is:2col
+            wn[is, js] += dot(@view(wn[1:col, is]), @view(wn[1:col, js]))
+        end
+    end
+
+    C2 = cholesky!(Symmetric(@view(wn[(col+1):2col, (col+1):2col]), :U); check = false)
+    issuccess(C2) || return -2
+
+    return 0
+end
+
+# Project x onto the box [lb, ub].
+project(x, lb, ub) = clamp.(x, lb, ub)
+
+# Maximum step before hitting a bound along direction d.
+function max_steplength(x, d, lb, ub)
+    T = eltype(x)
+    αmax = T(Inf)
+    for i in eachindex(x)
+        if d[i] > 0
+            αmax = min(αmax, (ub[i] - x[i]) / d[i])
+        elseif d[i] < 0
+            αmax = min(αmax, (lb[i] - x[i]) / d[i])
+        end
+    end
+    return αmax
+end
+
+# Projected gradient ∞-norm, ‖x - P(x - g)‖∞, computed without allocation.
+function pg_norm(x, g, lb, ub)
+    result = zero(eltype(g))
+    for i in eachindex(x, g, lb, ub)
+        gi = g[i]
+        if gi < 0
+            isfinite(ub[i]) && (gi = max(x[i] - ub[i], gi))
+        elseif gi > 0
+            isfinite(lb[i]) && (gi = min(x[i] - lb[i], gi))
+        end
+        agi = abs(gi)
+        agi > result && (result = agi)
+    end
+    return result
+end
+
+# Min-heap operations for lazy breakpoint ordering. (Fortran `hpsolb`.)
+function hpsolb!(t, iorder, n, iheap)
+    if iheap == 0
+        for k = 2:n
+            val = t[k]
+            idx = iorder[k]
+            i = k
+            while i > 1
+                j = i >> 1
+                if val < t[j]
+                    t[i] = t[j]
+                    iorder[i] = iorder[j]
+                    i = j
+                else
+                    break
+                end
+            end
+            t[i] = val
+            iorder[i] = idx
+        end
+    end
+
+    n > 1 || return
+
+    out_val = t[1]
+    out_idx = iorder[1]
+    val = t[n]
+    idx = iorder[n]
+
+    i = 1
+    while true
+        j = 2i
+        j <= n - 1 || break
+        if t[j+1] < t[j]
+            j += 1
+        end
+        if t[j] < val
+            t[i] = t[j]
+            iorder[i] = iorder[j]
+            i = j
+        else
+            break
+        end
+    end
+    t[i] = val
+    iorder[i] = idx
+
+    t[n] = out_val
+    iorder[n] = out_idx
+    return
+end
+
+# Algorithm CP: generalized Cauchy point. Writes xᶜ into B.xc and c = Wᵀ(xᶜ - x)
+# into B.c_ws. Uses lazy heap ordering of the breakpoints. (Fortran `cauchy`.)
+function cauchy_point!(B::CompactLBFGS, x, g, lb, ub)
+    T = eltype(x)
+    n = length(x)
+    bk = B.k
+    mcols = 2bk
+    θ = B.θ
+
+    Mv = @view(B.Mv[1:mcols])
+    fill!(Mv, zero(T))
+    wb = @view(B.wb[1:mcols])
+
+    t_bp = B.t_bp
+    iorder = B.indx2   # reused: freev!/formk! run after cauchy returns
+
+    p = @view(B.p_ws[1:mcols])
+    fill!(p, zero(T))
+    c = @view(B.c_ws[1:mcols])
+    fill!(c, zero(T))
+
+    f′ = zero(T)
+    nbreak = 0
+    ibkmin = 0
+    bkmin = T(Inf)
+
+    for i = 1:n
+        gi = g[i]
+        if gi < 0
+            ti = (x[i] - ub[i]) / gi
+        elseif gi > 0
+            ti = (x[i] - lb[i]) / gi
+        else
+            continue
+        end
+
+        ti > 0 || continue
+
+        di = -gi
+        f′ -= di * di
+
+        for j = 1:bk
+            pj = pcol(B, j)
+            p[j] += B.Y[i, pj] * di
+            p[bk+j] += B.S[i, pj] * di
+        end
+
+        if isfinite(ti)
+            nbreak += 1
+            t_bp[nbreak] = ti
+            iorder[nbreak] = i
+            if nbreak == 1 || ti < bkmin
+                bkmin = ti
+                ibkmin = nbreak
+            end
+        end
+    end
+
+    for j = 1:bk
+        p[bk+j] *= θ
+    end
+
+    if f′ == zero(T)
+        copyto!(B.xc, x)
+        fill!(c, zero(T))
+        return
+    end
+
+    bmv!(Mv, p, B)
+    f″ = -θ * f′ - dot(p, Mv)
+    Δtmin = -f′ / f″
+    t_old = zero(T)
+
+    if nbreak == 0
+        Δtmin = max(Δtmin, zero(T))
+        xc = B.xc
+        copyto!(xc, x)
+        for i = 1:n
+            g[i] == 0 || (xc[i] = clamp(x[i] - Δtmin * g[i], lb[i], ub[i]))
+        end
+        c .= Δtmin .* p
+        return
+    end
+
+    nleft = nbreak
+    iter = 1
+
+    while true
+        if iter == 1
+            tj = bkmin
+            ibp = iorder[ibkmin]
+        else
+            if iter == 2
+                if ibkmin != nbreak
+                    t_bp[ibkmin] = t_bp[nbreak]
+                    iorder[ibkmin] = iorder[nbreak]
+                end
+            end
+            hpsolb!(t_bp, iorder, nleft, iter == 2 ? 0 : 1)
+            tj = t_bp[nleft]
+            ibp = iorder[nleft]
+        end
+
+        dt = tj - t_old
+
+        Δtmin < dt && break
+
+        b = ibp
+        xᶜ_b = g[b] < 0 ? ub[b] : lb[b]
+        z_b = xᶜ_b - x[b]
+
+        c .+= dt .* p
+        g_b = g[b]
+        Wrow!(wb, B, b)
+        bmv!(Mv, c, B)
+        wMc = dot(wb, Mv)
+        bmv!(Mv, p, B)
+        wMp = dot(wb, Mv)
+        bmv!(Mv, wb, B)
+        wMw = dot(wb, Mv)
+        f′ += dt * f″ + g_b^2 + θ * g_b * z_b - g_b * wMc
+        f″ += -θ * g_b^2 - 2 * g_b * wMp - g_b^2 * wMw
+        p .+= g_b .* wb
+
+        Δtmin = f″ > 0 ? -f′ / f″ : (f′ < 0 ? T(Inf) : zero(T))
+        t_old = tj
+
+        nleft -= 1
+        nleft > 0 || break
+
+        iter += 1
+    end
+
+    Δtmin = max(Δtmin, zero(T))
+    t_old += Δtmin
+    xc = B.xc
+    copyto!(xc, x)
+    for i = 1:n
+        if g[i] == 0
+            xc[i] = x[i]  # avoid Inf*0 = NaN
+        else
+            xc[i] = clamp(x[i] - t_old * g[i], lb[i], ub[i])
+        end
+    end
+    c .+= Δtmin .* p
+
+    return
+end
+
+# Direct primal subspace minimization using the K factorization from formk! and
+# the free set from freev!. Reads xc from B.xc, c from B.c_ws; writes the result
+# back into B.xc. (Fortran `cmprlb` + `subsm`.)
+function subspace_optimize!(B::CompactLBFGS, x, g, lb, ub; clip::Bool = true)
+    T = eltype(x)
+    θ = B.θ
+    nsub = B.nfree
+    col = B.k
+    xc = B.xc
+    c = @view(B.c_ws[1:2col])
+
+    (nsub == 0 || col == 0) && return  # B.xc already holds the Cauchy point
+
+    col2 = 2col
+    wv = B.work
+
+    # Reduced gradient r = -θ(xc - x) - g + W·(M·c).
+    r = @view(B.r_ws[1:nsub])
+    for i = 1:nsub
+        k = B.index[i]
+        r[i] = -θ * (xc[k] - x[k]) - g[k]
+    end
+
+    bmv!(wv, c, B)   # wv[1:2col] = M·c
+    for j = 1:col
+        pj = pcol(B, j)
+        a1 = wv[j]
+        a2 = θ * wv[col+j]
+        for i = 1:nsub
+            k = B.index[i]
+            r[i] += B.Y[k, pj] * a1 + B.S[k, pj] * a2
+        end
+    end
+
+    # wv = W'Z·r
+    for j = 1:col
+        pj = pcol(B, j)
+        temp1 = zero(T)
+        temp2 = zero(T)
+        for i = 1:nsub
+            k = B.index[i]
+            temp1 += B.Y[k, pj] * r[i]
+            temp2 += B.S[k, pj] * r[i]
+        end
+        wv[j] = temp1
+        wv[col+j] = θ * temp2
+    end
+
+    # Solve K⁻¹·wv via the U'EU factorization (E = diag(-I_col, I_col)).
+    wv_view = @view(wv[1:col2])
+    U = LinearAlgebra.UpperTriangular(@view(B.wn[1:col2, 1:col2]))
+    ldiv!(U', wv_view)
+    for i = 1:col
+        wv[i] = -wv[i]
+    end
+    ldiv!(U, wv_view)
+
+    # du = (1/θ)r + (1/θ²)Z'W·wv
+    du = @view(B.du[1:nsub])
+    copyto!(du, r)
+    for j = 1:col
+        pj = pcol(B, j)
+        for i = 1:nsub
+            k = B.index[i]
+            du[i] += B.Y[k, pj] * wv[j] / θ + B.S[k, pj] * wv[col+j]
+        end
+    end
+    du ./= θ
+
+    # Project onto bounds, writing directly into B.xc (each element read before
+    # written at the same index, matching Fortran subsm).
+    x̄ = xc
+
+    if clip
+        any_bound_hit = false
+        for i = 1:nsub
+            k = B.index[i]
+            x̄[k] = clamp(xc[k] + du[i], lb[k], ub[k])
+            if x̄[k] == lb[k] || x̄[k] == ub[k]
+                any_bound_hit = true
+            end
+        end
+
+        if any_bound_hit
+            dd_p = zero(T)
+            for i in eachindex(x)
+                dd_p += (x̄[i] - x[i]) * g[i]
+            end
+            if dd_p > 0
+                α_star = one(T)
+                for i = 1:nsub
+                    k = B.index[i]
+                    if du[i] > 0
+                        α_star = min(α_star, (ub[k] - xc[k]) / du[i])
+                    elseif du[i] < 0
+                        α_star = min(α_star, (lb[k] - xc[k]) / du[i])
+                    end
+                end
+                for i = 1:nsub
+                    k = B.index[i]
+                    x̄[k] = xc[k] + α_star * du[i]
+                end
+            end
+        end
+    else
+        α_star = one(T)
+        for i = 1:nsub
+            k = B.index[i]
+            if du[i] > 0
+                α_star = min(α_star, (ub[k] - xc[k]) / du[i])
+            elseif du[i] < 0
+                α_star = min(α_star, (lb[k] - xc[k]) / du[i])
+            end
+        end
+        for i = 1:nsub
+            k = B.index[i]
+            x̄[k] = xc[k] + α_star * du[i]
+        end
+    end
+
+    return
+end
+
+# Compute s = x_new - x, y = g_new - g into B.s/B.y, then update the compact
+# representation if curvature yᵀs > 0. Returns yᵀs (always computed).
+function update_compact!(B::CompactLBFGS, x, x_new, g, g_new)
+    s = B.s
+    y = B.y
+    @. s = x_new - x
+    @. y = g_new - g
+    yts = dot(y, s)
+
+    yts <= 0 && return yts
+
+    k = B.k
+    m = B.m
+
+    if k < m
+        # Buffer not full: append to the next column (head stays at 1).
+        k += 1
+        B.k = k
+        B.S[:, k] .= s
+        B.Y[:, k] .= y
+
+        for j = 1:(k-1)
+            B.SY[k, j] = dot(s, @view(B.Y[:, j]))
+            B.SᵀS[j, k] = dot(@view(B.S[:, j]), s)
+            B.SᵀS[k, j] = B.SᵀS[j, k]
+        end
+        B.SY[k, k] = yts
+        B.SᵀS[k, k] = dot(s, s)
+    else
+        # Buffer full: circular overwrite of the oldest column.
+        for i = 1:(m-1), j = 1:(m-1)
+            B.SY[i, j] = B.SY[i+1, j+1]
+            B.SᵀS[i, j] = B.SᵀS[i+1, j+1]
+        end
+
+        ph = B.head
+        B.S[:, ph] .= s
+        B.Y[:, ph] .= y
+        B.head = mod(ph, m) + 1
+
+        for j = 1:(m-1)
+            pj = pcol(B, j)
+            B.SY[m, j] = dot(s, @view(B.Y[:, pj]))
+            B.SᵀS[j, m] = dot(@view(B.S[:, pj]), s)
+            B.SᵀS[m, j] = B.SᵀS[j, m]
+        end
+        B.SY[m, m] = yts
+        B.SᵀS[m, m] = dot(s, s)
+    end
+
+    B.θ = dot(y, y) / yts
+    B.iupdat += 1
+
+    formt!(B)   # Cholesky-factor T into B.J
+
+    return yts
+end
+
+# Trace entry for L-BFGS-B. The reported gradient norm is the projected
+# gradient ∞-norm, the natural stationarity measure for a box-constrained run.
+function trace_lbfgsb!(tr, iteration, f_x, pgnorm, x, g_x, options, curr_time)
+    dt = Dict{String,Any}()
+    dt["time"] = curr_time
+    if options.extended_trace
+        dt["x"] = copy(x)
+        dt["g(x)"] = copy(g_x)
+    end
+    update!(
+        tr,
+        iteration,
+        f_x,
+        pgnorm,
+        dt,
+        options.store_trace,
+        options.show_trace,
+        options.show_every,
+    )
+end
+
+# Callable that evaluates (ϕ(α), ϕ'(α)) along the search direction without
+# allocating per call. `x` and `dir` alias the loop's iterate and B.d, which are
+# mutated in place, so this is constructed once and reused every iteration.
+mutable struct LBFGSBLineFn{D,Tx}
+    obj::D
+    x::Tx
+    dir::Tx
+    xα::Tx
+end
+
+function (φ::LBFGSBLineFn)(α)
+    @. φ.xα = φ.x + α * φ.dir
+    fα, gα = value_gradient!(φ.obj, φ.xα)
+    return (fα, dot(gα, φ.dir))
+end
+
+function optimize(
+    f,
+    l::AbstractArray,
+    u::AbstractArray,
+    x0::AbstractArray,
+    method::LBFGSB,
+    options::Options = Options();
+    inplace::Bool = true,
+    autodiff::ADTypes.AbstractADType = DEFAULT_AD_TYPE,
+)
+    if f isa NonDifferentiable
+        f = f.f
+    end
+    od = OnceDifferentiable(f, x0, zero(eltype(x0)); inplace, autodiff)
+    optimize(od, l, u, x0, method, options)
+end
+
+function optimize(
+    f,
+    g,
+    l::AbstractArray,
+    u::AbstractArray,
+    x0::AbstractArray,
+    method::LBFGSB,
+    options::Options = Options();
+    inplace::Bool = true,
+)
+    g! = inplace ? g : (G, x) -> copyto!(G, g(x))
+    od = OnceDifferentiable(f, g!, x0, zero(eltype(x0)))
+    optimize(od, l, u, x0, method, options)
+end
+
+function optimize(
+    d::OnceDifferentiable,
+    l::AbstractArray,
+    u::AbstractArray,
+    x0::AbstractArray,
+    method::LBFGSB,
+    options::Options = Options(),
+)
+    T = eltype(x0)
+    t0 = time()
+    (; callback) = options
+
+    n = length(x0)
+    (length(l) == n && length(u) == n) ||
+        throw(DimensionMismatch("lb, ub and x0 must have the same length."))
+    all(i -> l[i] <= u[i], eachindex(l)) ||
+        throw(ArgumentError("Each lower bound must be ≤ the corresponding upper bound."))
+    all(i -> l[i] <= x0[i] <= u[i], eachindex(x0)) ||
+        throw(ArgumentError("Initial x0 is outside the box [lb, ub]."))
+
+    x = project(copy(x0), l, u)
+    f_x, _g = value_gradient!(d, x)
+    g = copy(_g)
+
+    B = CompactLBFGS{T}(n, method.m)
+    B.cnstnd = any(i -> isfinite(l[i]) || isfinite(u[i]), eachindex(x))
+    updatd = false
+
+    x_previous = copy(x)
+    f_x_previous = oftype(f_x, NaN)
+    x_candidate = similar(x)
+    g_new = similar(g)
+
+    # x and B.d alias the fields the line search reads; both are mutated in place.
+    φ = LBFGSBLineFn(d, x, B.d, similar(x))
+
+    tr = OptimizationTrace{typeof(f_x),typeof(method)}()
+    tracing = options.store_trace || options.show_trace || options.extended_trace
+    options.show_trace && print_header(method)
+
+    pgnorm = pg_norm(x, g, l, u)
+
+    x_converged = false
+    f_converged = false
+    g_converged = pgnorm <= options.g_abstol
+    f_increased = false
+    ls_failed = false
+    stopped_by_time_limit = false
+    f_limit_reached = false
+    g_limit_reached = false
+
+    iteration = 0
+    _time = time()
+    tracing && trace_lbfgsb!(tr, iteration, f_x, pgnorm, x, g, options, _time - t0)
+    stopped_by_callback = callback !== nothing && callback((; x, f_x, g_x = g, iteration)) == true
+
+    converged = g_converged
+    stopped = stopped_by_callback || !isfinite(f_x) || any(!isfinite, g)
+
+    while !converged && !stopped && iteration < options.iterations
+        iteration += 1
+
+        # Generalized Cauchy point (writes B.xc, B.c_ws).
+        cauchy_point!(B, x, g, l, u)
+
+        # Free/active sets and the K factorization for the subspace solve.
+        for i = 1:n
+            B.iwhere[i] = (B.xc[i] <= l[i] || B.xc[i] >= u[i]) ? 1 : 0
+        end
+        nenter, ileave, wrk = freev!(B, iteration - 1, updatd)
+        if wrk && B.k > 0
+            info = formk!(B, nenter, ileave, updatd)
+            if info != 0
+                # Cholesky failure: drop the memory and restart from B = I.
+                reset_history!(B)
+                updatd = false
+                cauchy_point!(B, x, g, l, u)
+                for i = 1:n
+                    B.iwhere[i] = (B.xc[i] <= l[i] || B.xc[i] >= u[i]) ? 1 : 0
+                end
+                freev!(B, 0, false)
+            end
+        end
+
+        # Subspace minimization (writes B.xc); search direction d = xc - x.
+        subspace_optimize!(B, x, g, l, u; clip = method.clip_subspace)
+        @. B.d = B.xc - x
+
+        dφ0 = dot(g, B.d)
+        if dφ0 >= 0 && B.k > 0
+            # Not a descent direction: restart from B = I and redo the step.
+            reset_history!(B)
+            updatd = false
+            cauchy_point!(B, x, g, l, u)
+            for i = 1:n
+                B.iwhere[i] = (B.xc[i] <= l[i] || B.xc[i] >= u[i]) ? 1 : 0
+            end
+            freev!(B, 0, false)
+            subspace_optimize!(B, x, g, l, u; clip = method.clip_subspace)
+            @. B.d = B.xc - x
+            dφ0 = dot(g, B.d)
+        end
+        if dφ0 >= 0
+            ls_failed = true
+            break
+        end
+
+        αmax = max_steplength(x, B.d, l, u)
+        dnorm = norm(B.d)
+        boxed = all(i -> isfinite(l[i]) && isfinite(u[i]), eachindex(x))
+        α₀ = if B.k == 0 && !boxed && dnorm > 0
+            min(one(T) / dnorm, αmax)
+        else
+            min(T(method.stepsize), αmax)
+        end
+
+        α, _, _ = find_steplength(method.linesearch, φ, f_x, dφ0, α₀; αmax = αmax)
+        if !isfinite(α)
+            α = min(T(1) / 10^4, αmax)
+        end
+
+        @. x_candidate = x + α * B.d
+        f_new, _gn = value_gradient!(d, x_candidate)
+        g_new .= _gn
+
+        if isfinite(f_new)
+            yts = update_compact!(B, x, x_candidate, g, g_new)
+            updatd = yts > 0
+        else
+            updatd = false
+        end
+
+        copyto!(x_previous, x)
+        f_x_previous = f_x
+        copyto!(x, x_candidate)   # in place: keeps φ.x valid
+        f_x = f_new
+        copyto!(g, g_new)
+
+        pgnorm = pg_norm(x, g, l, u)
+
+        x_converged =
+            x_abschange(x, x_previous) <= options.x_abstol ||
+            x_relchange(x, x_previous) <= options.x_reltol
+        f_converged =
+            f_abschange(f_x, f_x_previous) <= options.f_abstol ||
+            f_relchange(f_x, f_x_previous) <= options.f_reltol
+        g_converged = pgnorm <= options.g_abstol
+        f_increased = f_x > f_x_previous
+        converged = x_converged || f_converged || g_converged
+
+        tracing && trace_lbfgsb!(tr, iteration, f_x, pgnorm, x, g, options, time() - t0)
+        if callback !== nothing
+            stopped_by_callback = callback((; x, f_x, g_x = g, iteration)) == true
+        end
+
+        _time = time()
+        stopped_by_time_limit = _time - t0 > options.time_limit
+        f_limit_reached =
+            options.f_calls_limit > 0 && NLSolversBase.f_calls(d) >= options.f_calls_limit
+        g_limit_reached =
+            options.g_calls_limit > 0 && NLSolversBase.g_calls(d) >= options.g_calls_limit
+
+        if stopped_by_callback ||
+           stopped_by_time_limit ||
+           f_limit_reached ||
+           g_limit_reached ||
+           (f_increased && !options.allow_f_increases) ||
+           !isfinite(f_x) ||
+           any(!isfinite, g)
+            stopped = true
+        end
+    end
+
+    _time = time()
+    Tf = typeof(f_x)
+    f_incr_pick = f_increased && !options.allow_f_increases
+
+    stopped_by = (
+        f_limit_reached = f_limit_reached,
+        g_limit_reached = g_limit_reached,
+        h_limit_reached = false,
+        time_limit = stopped_by_time_limit,
+        callback = stopped_by_callback,
+        f_increased = f_incr_pick,
+        ls_failed = ls_failed,
+        iterations = iteration == options.iterations,
+        x_converged = x_converged,
+        f_converged = f_converged,
+        g_converged = g_converged,
+        small_trustregion_radius = false,
+    )
+
+    termination_code = _termination_code(
+        d,
+        pgnorm,
+        LBFGSBState(x, f_x, x_previous, f_x_previous),
+        stopped_by,
+        options,
+    )
+
+    return MultivariateOptimizationResults(
+        method,
+        x0,
+        f_incr_pick ? x_previous : x,
+        Tf(f_incr_pick ? f_x_previous : f_x),
+        iteration,
+        Tf(options.x_abstol),
+        Tf(options.x_reltol),
+        x_abschange(x, x_previous),
+        x_relchange(x, x_previous),
+        Tf(options.f_abstol),
+        Tf(options.f_reltol),
+        f_abschange(f_x, f_x_previous),
+        f_relchange(f_x, f_x_previous),
+        Tf(options.g_abstol),
+        pgnorm,
+        tr,
+        NLSolversBase.f_calls(d),
+        NLSolversBase.g_calls(d),
+        NLSolversBase.jvp_calls(d),
+        NLSolversBase.h_calls(d),
+        NLSolversBase.hvp_calls(d),
+        options.time_limit,
+        _time - t0,
+        stopped_by,
+        termination_code,
+    )
+end

--- a/src/multivariate/solvers/constrained/lbfgsb/hz.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb/hz.jl
@@ -1,0 +1,517 @@
+# Hager-Zhang Approximate Wolfe line search
+#
+# Adapted from LineSearches.jl (JuliaNLSolvers/LineSearches.jl) hagerzhangls.jl
+# Renamed HagerZhangLS → HZAW to match local naming convention.
+#
+# TODO
+# Original paper implements:
+# V1: only Wolfe conditions
+# V2: only approximate Wolfe conditions
+# V3: initially try to satisfy Wolfe conditions. If the following condition is satisfied for some
+#     k then only check the approximate Wolfe conditions for the rest of the iterations:
+#  abs(f(x_k+1)-f(x_k)) ≤ ω*Ck
+# Qk = 1 + Q_k-1 * Δ, Q_-1 = 0
+# Ck = Ck-1 + (abs(fx_k))-Ck-1)/Qk, C_-1 = 0
+#
+# for Δ ∈ [0,1) and ω ∈ [0,1]. This is all discussed on [p. 121, CG_DESCENT_851].
+#
+# There is also inital(k) on [p.124, CG_DESCENT_851], but this is quite complicated and
+# reaches into the surrounding code and would require a greater line search state. It's
+# implemented in the other HagerZhang
+
+"""
+    HZAW
+
+An object that controls the Hager-Zhang approximate Wolfe line search
+algorithm.[^HZ2005]
+
+    HZAW(; kwargs...)
+
+The `HZAW` constructor takes the following keyword arguments. Default values
+correspond to those used in section 5 of [^HZ2005].
+
+ - `decrease`: parameter between 0 and 1, less than or equal to `curvature`,
+   specifying sufficient decrease in the objective per the Armijo rule.
+   Defaults to `0.1`.
+ - `curvature`: parameter between 0 and 1, greater than or equal to `decrease`,
+   specifying sufficient decrease in the gradient per the curvature condition.
+   Defaults to `0.9`.
+ - `theta`: parameter between 0 and 1 that controls the bracketing interval
+   update. Defaults to `0.5`, which indicates bisection. (See step U3 of the
+   interval update procedure in section 4 of [^HZ2005].)
+ - `gamma`: factor by which the length of the bracketing interval should
+   decrease at each iteration of the algorithm. Defaults to `2/3`. If such
+   a decrease is not achieved, the interval is bisected instead of using the
+   output of the secant² step.
+ - `epsilon_k`: parameter that controls the approximate Wolfe conditions.
+   Defaults to `1e-6`. See [p. 122, CG_DESCENT_851] for more details.
+ - `maxiter`: maximum number of iterations to perform in the main loop of
+   the algorithm. Defaults to `50`.
+ - `maxiter_U3`: maximum number of iterations to perform in step U3 of
+   the interval update procedure. Defaults to `50`.
+ - `maxiter_finite_check`: maximum number of backtracking iterations to find a
+   finite function value from a non-finite initial step length. Defaults to `100`.
+ - `rho`: expansion factor used in the `bracket` procedure when searching for
+   an interval satisfying the opposite slope condition. Defaults to `5.0`.
+ - `rho_finite_check`: contraction factor used to backtrack from a non-finite initial step
+   length into a feasible region. Defaults to `1/10`.
+
+We tweak the original algorithm slightly, by backtracking into a feasible
+region if the original step length results in function values that are not
+finite. This allows us to set up an interval from this point that satisfies
+the `bracket` procedure (bottom of [p. 123, CG_DESCENT_851]).
+
+[^HZ2005]: Hager, W. W., & Zhang, H. (2005). A New Conjugate Gradient Method
+           with Guaranteed Descent and an Efficient Line Search. SIAM Journal
+           on Optimization, 16(1), 170–192. doi:10.1137/030601880
+[^CG_DESCENT_851]: Hager, W. W., & Zhang, H. (2006). Algorithm 851: CG_DESCENT,
+                   a Conjugate Gradient Method with Guaranteed Descent. ACM
+                   Transactions on Mathematical Software, 32(1), 113–137.
+                   doi:10.1145/1139480.1139484
+"""
+struct HZAW{T,Tepsilon} <: LineSearcher
+    decrease::T
+    curvature::T
+    θ::T
+    γ::T
+    ϵ::Tepsilon
+    maxiter::Int
+    maxiter_U3::Int
+    maxiter_finite_check::Int
+    ρ::T
+    ρ_finite_check::T
+end
+
+Base.summary(::HZAW) = "Approximate Wolfe Line Search (Hager & Zhang)"
+HZAW{T}(hzl::HZAW) where {T} = HZAW(
+    T(hzl.decrease),
+    T(hzl.curvature),
+    T(hzl.θ),
+    T(hzl.γ),
+    T(hzl.ϵ),
+    hzl.maxiter,
+    hzl.maxiter_U3,
+    hzl.maxiter_finite_check,
+    T(hzl.ρ),
+    T(hzl.ρ_finite_check),
+)
+function HZAW(;
+    decrease = 0.1,
+    curvature = 0.9,
+    theta = 0.5,
+    gamma = 2 / 3,
+    maxiter = 50,
+    maxiter_U3 = 50,
+    maxiter_finite_check = 100,
+    epsilon_k = 1e-6,
+    rho = 5.0,
+    rho_finite_check = 1/10,
+)
+    if !(0 < decrease ≤ curvature)
+        throw(
+            ArgumentError(
+                "Decrease constant must be positive and smaller than the curvature condition. Got decrease = $decrease and curvature = $curvature",
+            ),
+        )
+    end
+    if decrease >= 1/2
+        throw(
+            ArgumentError(
+                "Decrease constant must be smaller than 1/2. Got decrease = $decrease",
+            ),
+        )
+    end
+    if curvature >= 1
+        throw(
+            ArgumentError(
+                "Curvature constant must be smaller than one. Got curvature = $curvature",
+            ),
+        )
+    end
+    HZAW(
+        decrease,
+        curvature,
+        theta,
+        gamma,
+        epsilon_k,
+        maxiter,
+        maxiter_U3,
+        maxiter_finite_check,
+        rho,
+        rho_finite_check,
+    )
+end
+
+struct TrialBundle{T}
+    p::T
+    φ::T
+    dφ::T
+end
+function TrialBundle(c, t::Tuple)
+    TrialBundle(promote(c, t[1], t[2])...)
+end
+Base.isfinite(tb::TrialBundle) = isfinite(tb.φ) && isfinite(tb.dφ)
+
+# At the core of this line search we have the (approximate) Wolfe conditions.
+struct WolfeSetup{T}
+    φ0::T
+    dφ0::T
+    δ::T
+    σ::T
+    ϵ::T # [p.182, HZ2005] uses |f(x_k)| see also [p. 122, CG_DESCENT_851] but we do not implement Ck. could rename this to epsilon_rel and have an abs as well.
+end
+function WolfeSetup(Σ0::TrialBundle, δ, σ, ϵ)
+    WolfeSetup(Σ0.φ, Σ0.dφ, δ, σ, ϵ)
+end
+
+# [eq (22), p.120, CG_DESCENT_851]
+function is_wolfe(wc::WolfeSetup, Σc::TrialBundle)
+    (; φ0, dφ0, δ, σ) = wc
+    φc, dφc, c = Σc.φ, Σc.dφ, Σc.p
+    # Satisfies T1
+    δ * dφ0 ≥ (φc - φ0) / c && dφc ≥ σ * dφ0
+end
+# [eq (23), p.120, CG_DESCENT_851]
+function is_approx_wolfe(awc::WolfeSetup, Σc::TrialBundle)
+    (; φ0, dφ0, δ, σ, ϵ) = awc
+    φc, dφc, c = Σc.φ, Σc.dφ, Σc.p
+    # Satisfies T2 and eqn (27) [p. 122, CG_DESCENT_851]
+    (2 * δ - 1) * dφ0 ≥ dφc ≥ σ * dφ0 && φc ≤ φ0 + ϵ * abs(φ0)
+end
+
+# Armijo sufficient decrease check (no curvature condition)
+function is_armijo(wc::WolfeSetup, Σc::TrialBundle)
+    (; φ0, dφ0, δ) = wc
+    φc, c = Σc.φ, Σc.p
+    φc ≤ φ0 + δ * c * dφ0
+end
+
+# Roughly equivalent to L0-L3 but we add L0' where
+# L0': Check that the right side of the interval yields finite function values and directional derivative values.
+#
+# αmax: maximum step length (e.g., distance to nearest bound along d).
+#   If bracket expansion hits αmax without forming a valid bracket,
+#   we fall back to Armijo backtracking and return wolfe=false.
+function find_steplength(hzl::HZAW, φ, φ0, dφ0, c::T; αmax::T = T(Inf)) where {T}
+    hzl = HZAW{T}(hzl)
+    # c = initial(k) but this is done outside
+    δ = hzl.decrease
+    σ = hzl.curvature
+    ρ = hzl.ρ
+    ρ_finite_check = hzl.ρ_finite_check
+    ϵ = hzl.ϵ
+    Σ0 = TrialBundle(T(0), φ0, dφ0)
+    if !isfinite(Σ0)
+        # Non-finite value/slope at α = 0: nothing to search along. The caller
+        # (the L-BFGS-B loop) detects the non-finite α and falls back.
+        return T(NaN), T(NaN), false
+    end
+
+    Σc = TrialBundle(c, φ(c))
+    # Backtrack into feasible region; not part of original algorithm
+    iter = 0
+    while !isfinite(Σc) && iter <= hzl.maxiter_finite_check
+        iter += 1
+        # don't use interpolation, this is vanilla backtracking
+        c = c*ρ_finite_check
+        Σc = TrialBundle(c, φ(c))
+    end
+    if iter > hzl.maxiter_finite_check
+        # Could not backtrack into a region with finite values; signal failure.
+        return T(NaN), T(NaN), false
+    end
+    wolfesetup = WolfeSetup(Σ0, δ, σ, ϵ)
+
+    # Wolfe conditions
+    is_wolfe(wolfesetup, Σc) && return Σc.p, Σc.φ, true
+    # Approximate Wolfe conditions
+    is_approx_wolfe(wolfesetup, Σc) && return Σc.p, Σc.φ, true
+    # Set up interval
+    Σaj, Σbj, wolfe_in_bracket, hit_αmax = bracket(hzl, Σ0, Σc, φ, ρ, wolfesetup, αmax)
+    if wolfe_in_bracket
+        return Σaj.p, Σaj.φ, true
+    end
+    if hit_αmax
+        # Bracket expansion reached αmax without forming an opposite-slope bracket.
+        # Σaj holds the best point found (sufficient decrease, descent direction).
+        # Fall back to Armijo backtracking from this point.
+        Σbest = Σaj
+        α = Σbest.p
+        # Backtrack by halving until Armijo is satisfied (it likely already is)
+        for _ = 1:50
+            is_armijo(wolfesetup, Σbest) && return Σbest.p, Σbest.φ, false
+            α = α / 2
+            Σbest = TrialBundle(α, φ(α))
+        end
+        # Last resort: return whatever we have
+        return Σbest.p, Σbest.φ, false
+    end
+
+    for j = 1:hzl.maxiter
+        # === Step L1: Secant² update ===
+        # This is the main step. It's called so because we expect two secant updates to
+        # update each end of the interval. First a secant step will move one endpoint,
+        # then the other endpoint will be updated by the second secant step. An exception
+        # can be that one secant step ends outside of the interval.
+        Σa, Σb, iswolfe = secant²(hzl, φ, φ0, Σaj, Σbj, ϵ, wolfesetup)
+        if iswolfe
+            return Σa.p, Σa.φ, true
+        end
+
+        # === Step L2: Bisection if insufficient decrease ===
+        # When the interval was not decreasing by at least a factor of γ, we bisect instead.
+        # Notice that this forces us not to be in U0 so the interval *will* change.
+        aj, bj = Σaj.p, Σbj.p
+        a, b = Σa.p, Σb.p
+        Σaj, Σbj = if b - a > hzl.γ * (bj - aj)
+            c = (a + b) / 2
+            update(hzl, Σa, Σb, c, φ, φ0, ϵ)
+        else
+            Σa, Σb
+        end
+
+        # The Wolfe conditions are sufficient but can be hard to satisfy.
+        a_wolfe = is_wolfe(wolfesetup, Σaj) || is_approx_wolfe(wolfesetup, Σaj)
+        b_wolfe = is_wolfe(wolfesetup, Σbj) || is_approx_wolfe(wolfesetup, Σbj)
+        if a_wolfe && b_wolfe
+            aj, φaj = Σaj.p, Σaj.φ
+            bj, φbj = Σbj.p, Σbj.φ
+            if φaj < φbj
+                return aj, φaj, true
+            else
+                return bj, φbj, true
+            end
+        elseif a_wolfe
+            return Σaj.p, Σaj.φ, true
+        elseif b_wolfe
+            return Σbj.p, Σbj.φ, true
+        end
+    end
+    return T(NaN), T(NaN), false
+end
+
+"""
+   update_U3_a_c
+
+Used to take step U3 of the updating procedure [p.123, CG_DESCENT_851]. The other steps
+are in update, but this step is separated out to be able to use it in
+step B2 of bracket. Initialization of ā and b̄ is done outside this call.
+"""
+function update_U3_a_c(
+    hzl::HZAW,
+    φ,
+    φ0,
+    Σā::TrialBundle{T},
+    Σb̄::TrialBundle{T},
+    ϵ,
+) where {T}
+    # verified against paper description [p. 123, CG_DESCENT_851]
+    θ = hzl.θ
+
+    for j = 1:hzl.maxiter_U3
+        # === Step U3.a === convex combination of ā and b̄; 0.5 implies bisection
+        ā, b̄ = Σā.p, Σb̄.p
+        d = (1 - θ) * ā + θ * b̄
+        Σd = TrialBundle(d, φ(d))
+
+        if Σd.dφ ≥ T(0)
+            # found point of increasing objective; return with upper bound d
+            return Σā, Σd
+        else # now Σd.dφ < T(0)
+            if Σd.φ ≤ φ0 + ϵ * abs(φ0)
+                # === Step U3.b ===
+                Σā = Σd
+            else # φ(d) ≥ φ0 + ϵ * abs(φ0)
+                # === Step U3.c ===
+                Σb̄ = Σd
+            end
+        end
+    end
+    # Reached the U3 iteration cap without a point of increasing objective;
+    # return the current endpoints and let the outer loop proceed.
+    return Σā, Σb̄
+end
+
+in_bounds(c, Σa, Σb) = Σa.p <= c <= Σb.p
+
+# Full update: bounds check + evaluate + U1-U3. Used by L2 bisection.
+function update(hzl::HZ, Σa, Σb, c::T, φ, φ0, ϵ) where {HZ<:HZAW,T}
+    # === Step U0: Check c is interior to interval ===
+    if !in_bounds(c, Σa, Σb)
+        return Σa, Σb
+    end
+    Σc = TrialBundle(c, φ(c))
+    _update(hzl, Σa, Σb, Σc, φ, φ0, ϵ)
+end
+
+# Inner update with pre-evaluated Σc: U1-U3 only. Used by secant² after Wolfe check.
+function _update(hzl::HZ, Σa, Σb, Σc::TrialBundle{T}, φ, φ0, ϵ) where {HZ<:HZAW,T}
+    # verified against paper description [p. 123, CG_DESCENT_851]
+    # === Step U1: Positive derivative (update upper bound) ===
+    if Σc.dφ ≥ T(0)
+        return Σa, Σc
+    else # Σc.dφ < T(0)
+        # === Step U2: Negative derivative with sufficient decrease ===
+        if Σc.φ ≤ φ0 + ϵ * abs(φ0)
+            return Σc, Σb
+        end
+        # === Step U3: Negative derivative without sufficient decrease ===
+        Σā, Σb̄ = Σa, Σc
+        Σa, Σb = update_U3_a_c(hzl, φ, φ0, Σā, Σb̄, ϵ)
+        return Σa, Σb
+    end
+end
+"""
+  bracket
+
+Find an interval satisfying the opposite slope condition starting from [0, c] [pp. 123-124, CG_DESCENT_851].
+
+Returns `(Σa, Σb, wolfe_found, hit_αmax)`:
+- `wolfe_found`: a point satisfying (approx) Wolfe was found during expansion
+- `hit_αmax`: bracket expansion reached αmax without forming a valid bracket;
+  Σa holds the best descent point with sufficient decrease
+"""
+function bracket(
+    hzl::HZAW,
+    Σ0::TrialBundle{T},
+    Σc::TrialBundle{T},
+    φ,
+    ρ,
+    wolfesetup,
+    αmax,
+) where {T}
+    # verified against paper description [pp. 123-124, CG_DESCENT_851]
+    φ0 = Σ0.φ
+    # === Step B0: Initialize bracket search ===
+    # Already checked for initial convergence and finite values
+    Σcj = Σc
+
+    # Note, we know that dφ(0) < 0 since we're accepted that the current step is in a
+    # direction of descent.
+    Σci = Σ0
+
+    # ci is a lower bound and cj is an upper bound (candidate)
+    # below we test for the following cases:
+    # B1: φ is increasing at cj, set [a,b] to [ci,cj]
+    # B2: φ is decreasing at cj but function value is sufficiently larger than φ0
+    #     use U3 to update. (This is the only case where we call U3 in the whole algorithm.)
+    # B3: φ is decreasing at cj and function value is sufficiently smaller than φ0
+
+    maxj = 100
+    j = 0
+    while j < maxj && Σcj.dφ < T(0)
+        j += 1
+        if Σcj.φ > Σ0.φ + Σ0.φ * hzl.ϵ # we could collect all condition checks on one type instead of the wolfe and approx wolfe
+            # === Step B2: Decreasing derivative without sufficient decrease ===
+            # φ is decreasing at cj but function value is sufficiently larger than
+            # φ0 so we must have passed a place with increasing φ, use U3 to update.
+            Σa, Σb = update_U3_a_c(hzl, φ, φ0, Σ0, Σcj, hzl.ϵ)
+            return Σa, Σb, false, false
+        end
+
+        # === Step B3: Decreasing derivative with sufficient decrease ===
+        # Move lower bound up to cj, expand by factor ρ > 1
+        Σci = Σcj
+
+        cj = ρ * Σcj.p
+        # Cap expansion at αmax (box constraint boundary)
+        if cj ≥ αmax
+            if αmax > Σci.p
+                # Evaluate at αmax — it may form a bracket or satisfy Wolfe
+                Σcj = TrialBundle(αmax, φ(αmax))
+                if is_wolfe(wolfesetup, Σcj) || is_approx_wolfe(wolfesetup, Σcj)
+                    return Σcj, Σcj, true, false
+                end
+                if Σcj.dφ ≥ T(0)
+                    # αmax gave us an opposite-slope bracket
+                    return Σci, Σcj, false, false
+                end
+                # Still descending at αmax — can't expand further.
+                # Σci is the best point: dφ < 0, φ ≤ φ0 + ε (passed B3 check).
+                # If αmax point also has sufficient decrease, prefer it (larger step).
+                if Σcj.φ ≤ Σ0.φ + Σ0.φ * hzl.ϵ
+                    return Σcj, Σcj, false, true
+                end
+            end
+            return Σci, Σci, false, true
+        end
+        Σcj = TrialBundle(cj, φ(cj))
+        # Check if the new point satisfies Wolfe before continuing expansion
+        if is_wolfe(wolfesetup, Σcj) || is_approx_wolfe(wolfesetup, Σcj)
+            return Σcj, Σcj, true, false
+        end
+    end
+    if j == maxj
+        @warn(
+            "Failed to find a bracket satisfying the opposite slope condition after $maxj iterations."
+        )
+    end
+
+    # implicitly Σcj.dφ ≥ T(0) since we exited the loop =>
+    # === Step B1: Positive derivative found (opposite slope condition) ===
+    # φ is increasing at cj, set b to cj as this is an upper bound,
+    # since φ is initially decreasing.
+    return Σci, Σcj, false, false
+end
+function secant(hzl::HZAW, Σa::TrialBundle{T}, Σb::TrialBundle{T}) where {T}
+    # verified against paper description [p. 123, CG_DESCENT_851]
+    #(a*dφb - b*dφa)/(dφb - dφa)
+    # It has been observed that dφa can be very close to dφb,
+    # so we avoid taking the difference
+    a, dφa, b, dφb = Σa.p, Σa.dφ, Σb.p, Σb.dφ
+    sec = a / (1 - dφa / dφb) + b / (1 - dφb / dφa)
+    if isnan(sec)
+        sec_naive = (a*dφb - b*dφa)/(dφb - dφa)
+        return sec_naive
+    end
+    return sec
+end
+function secant²(
+    hzl::HZAW,
+    φ,
+    φ0,
+    Σa::TrialBundle{T},
+    Σb::TrialBundle{T},
+    ϵ,
+    wolfesetup,
+) where {T}
+    # verified against paper description [p. 123, CG_DESCENT_851]
+    # === Step S1: First secant step ===
+    c = secant(hzl, Σa, Σb)
+    if !in_bounds(c, Σa, Σb)
+        return Σa, Σb, false
+    end
+    Σc = TrialBundle(c, φ(c))
+    if is_wolfe(wolfesetup, Σc) || is_approx_wolfe(wolfesetup, Σc)
+        return Σc, Σc, true
+    end
+    # First update (U1-U3 with pre-evaluated Σc)
+    ΣA, ΣB = _update(hzl, Σa, Σb, Σc, φ, φ0, ϵ)
+    updated = false
+    c̄ = c
+    if c == ΣB.p # B == c
+        # === Step S2: Second secant with new upper bound ===
+        c̄ = secant(hzl, Σb, ΣB)
+        updated = true
+    elseif c == ΣA.p # A == c
+        # === Step S3: Second secant with new lower bound ===
+        c̄ = secant(hzl, Σa, ΣA)
+        updated = true
+    end
+
+    # === Step S4 ===
+    if !updated # so !(c==A || c==B from the paper)
+        # === Step S4 (variant 2): Return without second secant ===
+        return ΣA, ΣB, false
+    end
+    if !in_bounds(c̄, ΣA, ΣB)
+        return ΣA, ΣB, false
+    end
+    Σc̄ = TrialBundle(c̄, φ(c̄))
+    if is_wolfe(wolfesetup, Σc̄) || is_approx_wolfe(wolfesetup, Σc̄)
+        return Σc̄, Σc̄, true
+    end
+    # === Step S4 (variant 1): Update with second secant point ===
+    Σā, Σb̄ = _update(hzl, ΣA, ΣB, Σc̄, φ, φ0, ϵ)
+    return Σā, Σb̄, false
+end

--- a/src/multivariate/solvers/constrained/lbfgsb/linesearches_mt.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb/linesearches_mt.jl
@@ -1,0 +1,78 @@
+# LineSearcher wrapper for the Moré-Thuente line search.
+#
+# Provides MTLS <: LineSearcher with a find_steplength method matching
+# the HZAW interface so it can be used as a drop-in replacement in the
+# L-BFGS-B optimizer.
+
+include("mt/morethuente.jl")
+
+"""
+    MTLS
+
+Moré-Thuente line search parameters, matching the `LineSearcher` interface.
+
+    MTLS(; decrease=1e-4, curvature=0.9, maxiter=100)
+
+Finds α > 0 satisfying the strong Wolfe conditions:
+
+    ϕ(α)    ≤ ϕ(0) + μ·α·ϕ'(0)     (sufficient decrease)
+    |ϕ'(α)| ≤ η·|ϕ'(0)|             (curvature)
+
+where `μ = decrease` and `η = curvature`.
+
+Based on: Moré, J. J., & Thuente, D. J. (1994). Line search algorithms
+with guaranteed sufficient decrease. ACM TOMS, 20(3), 286–307.
+"""
+struct MTLS{T} <: LineSearcher
+    μ::T          # sufficient decrease (Armijo)
+    η::T          # curvature
+    maxiter::Int
+end
+
+function MTLS(; decrease = 1e-4, curvature = 0.9, maxiter = 100)
+    MTLS(decrease, curvature, maxiter)
+end
+
+MTLS{T}(mt::MTLS) where {T} = MTLS(T(mt.μ), T(mt.η), mt.maxiter)
+
+Base.summary(::MTLS) = "Moré-Thuente Line Search"
+
+"""
+    find_steplength(mt::MTLS, φdφ, φ0, dφ0, c; αmax=Inf) -> (α, f, wolfe)
+
+Adapter matching the `find_steplength(::HZAW, ...)` interface.
+
+`φdφ(α)` returns `(f(α), f'(α))`.  `c` is the initial trial step.
+`αmax` is passed through to the core algorithm which handles step
+clamping internally (MINPACK style), ensuring that bracket state
+always reflects the true evaluated positions.
+"""
+function find_steplength(mt::MTLS, φdφ, φ0, dφ0, c::T; αmax::T = T(Inf)) where {T}
+    mt = MTLS{T}(mt)
+
+    # Cap initial step at αmax
+    c = min(c, αmax)
+
+    try
+        α, fα, dφα = more_thuente(
+            φdφ,
+            c,
+            φ0,
+            dφ0;
+            μ = mt.μ,
+            η = mt.η,
+            max_iters = mt.maxiter,
+            αmax = αmax,
+        )
+
+        # Verify strong Wolfe using derivative already computed by more_thuente
+        wolfe = fα ≤ φ0 + mt.μ * α * dφ0 && abs(dφα) ≤ mt.η * abs(dφ0)
+        return α, fα, wolfe
+    catch e
+        if e isa ErrorException && contains(e.msg, "did not converge")
+            # Convergence failure → return NaN like HZAW does
+            return T(NaN), T(NaN), false
+        end
+        rethrow()
+    end
+end

--- a/src/multivariate/solvers/constrained/lbfgsb/mt/morethuente.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb/mt/morethuente.jl
@@ -1,0 +1,151 @@
+# Main loop for the More-Thuente line search.
+#
+# Implementation of Algorithm 2.6 (Moré & Thuente, 1994) with MINPACK-2
+# engineering from the Fortran dcsrch/dcstep bundled with L-BFGS-B 3.0:
+# local step bounds (stmin/stmax), Fortran-style stage transition,
+# conditional ψ-usage, boundary termination, and fallback to best point.
+
+include("poly_min.jl")    # cubic_min, quadratic_min, secant_min
+include("update.jl")      # update_bracket   (Section 2 / Section 3 case analysis)
+include("trial_value.jl") # trial_value      (dcstep four-case analysis)
+
+"""
+    more_thuente(ϕdϕ, α0, ϕ0, dϕ0; μ=1e-4, η=0.9, max_iters=100,
+                 αmax=Inf, xtol=0.1) -> (α, ϕ(α), ϕ'(α))
+
+Find α > 0 satisfying the strong Wolfe conditions
+
+    ϕ(α)    ≤ ϕ(0) + μ·α·ϕ'(0)     (sufficient decrease)
+    |ϕ'(α)| ≤ η·|ϕ'(0)|             (curvature)
+
+`ϕdϕ(α)` must return `(ϕ(α), ϕ'(α))`. `ϕ0 = ϕ(0)` and `dϕ0 = ϕ'(0)` are
+passed in so the search doesn't need to evaluate at α = 0. `α0 > 0` is
+the initial trial step.
+
+When `αmax` is finite the search is constrained to `(0, αmax]`. Trial
+values are clamped internally and the algorithm tracks local step bounds
+`(stmin, stmax)` matching Fortran `dcsrch`. If the trial reaches `αmax`
+with sufficient decrease and the function still descending, the boundary
+point is accepted.
+
+`xtol` (default 0.1, matching L-BFGS-B 3.0) controls the relative
+bracket-width tolerance for the stall fallback.
+"""
+function more_thuente(ϕdϕ, α0, ϕ0, dϕ0; μ=1e-4, η=0.9, max_iters=100,
+                      αmax=oftype(α0, Inf), xtol=oftype(α0, 1//10))
+    @assert dϕ0 < 0 "Search direction is not a descent direction"
+
+    μdϕ0 = μ * dϕ0
+
+    # State: best endpoint αₗ, other endpoint αᵤ, current trial αₜ.
+    # Values stored as ϕ; we convert to ψ at call sites when needed.
+    αₗ, fₗ, gₗ = zero(α0), ϕ0, dϕ0
+    αᵤ, fᵤ, gᵤ = zero(α0), ϕ0, dϕ0
+    αₜ = α0
+
+    bracketed = false
+    stage1    = true
+
+    # Bracket-shrink monitor (paper p. 293): if the bracket width
+    # doesn't shrink by factor 0.66 over the past two trials, force
+    # bisection.
+    width      = oftype(α0, Inf)
+    width_prev = oftype(α0, Inf)
+
+    # Local step bounds (Fortran dcsrch lines 3537-3538).
+    # Initial: stmin=0, stmax = α₀ + 4·α₀.
+    stmin = zero(α0)
+    stmax = α0 + oftype(α0, 4) * α0
+
+    for _ in 1:max_iters
+        fₜ, gₜ = ϕdϕ(αₜ)
+        ftest = ϕ0 + αₜ * μdϕ0
+
+        # ── Termination checks ──────────────────────────────────────
+
+        # Strong Wolfe — convergence.
+        if fₜ ≤ ftest && abs(gₜ) ≤ η * abs(dϕ0)
+            return αₜ, fₜ, gₜ
+        end
+
+        # Boundary termination (MINPACK "STP = STPMAX"):
+        # at αmax with sufficient decrease and still descending.
+        if αₜ == αmax && fₜ ≤ ftest && gₜ ≤ μdϕ0
+            return αₜ, fₜ, gₜ
+        end
+
+        # ── Stage transition (Fortran dcsrch line 3573) ─────────────
+        # Fortran uses g ≥ 0 (the actual derivative is non-negative),
+        # stricter than the paper's ψ'(αₜ) ≥ 0 condition.
+        if stage1 && fₜ ≤ ftest && gₜ ≥ zero(gₜ)
+            stage1 = false
+        end
+
+        # ── Trial value + bracket update ────────────────────────────
+        # Fortran dcsrch only feeds ψ-values to dcstep when all three
+        # hold: stage 1, function decreased from best (fₜ ≤ fₗ), and
+        # sufficient decrease not yet met (fₜ > ftest). Otherwise φ
+        # is used even in stage 1 (dcsrch line 3600).
+        use_modified = stage1 && fₜ ≤ fₗ && fₜ > ftest
+
+        αₜ_next = if use_modified
+            fₗψ, gₗψ = fₗ - ϕ0 - αₗ*μdϕ0, gₗ - μdϕ0
+            fᵤψ, gᵤψ = fᵤ - ϕ0 - αᵤ*μdϕ0, gᵤ - μdϕ0
+            fₜψ, gₜψ = fₜ - ϕ0 - αₜ*μdϕ0, gₜ - μdϕ0
+
+            αt⁺ = trial_value(αₗ, fₗψ, gₗψ, αᵤ, fᵤψ, gᵤψ,
+                              αₜ, fₜψ, gₜψ, bracketed, stmin, stmax)
+            (αₗ, fₗψ, gₗψ, αᵤ, fᵤψ, gᵤψ, bracketed) =
+                update_bracket(αₗ, fₗψ, gₗψ, αᵤ, fᵤψ, gᵤψ,
+                               αₜ, fₜψ, gₜψ, bracketed)
+
+            # Convert returned ψ-values back to ϕ for storage.
+            fₗ, gₗ = fₗψ + ϕ0 + αₗ*μdϕ0, gₗψ + μdϕ0
+            fᵤ, gᵤ = fᵤψ + ϕ0 + αᵤ*μdϕ0, gᵤψ + μdϕ0
+            αt⁺
+        else
+            αt⁺ = trial_value(αₗ, fₗ, gₗ, αᵤ, fᵤ, gᵤ,
+                              αₜ, fₜ, gₜ, bracketed, stmin, stmax)
+            (αₗ, fₗ, gₗ, αᵤ, fᵤ, gᵤ, bracketed) =
+                update_bracket(αₗ, fₗ, gₗ, αᵤ, fᵤ, gᵤ,
+                               αₜ, fₜ, gₜ, bracketed)
+            αt⁺
+        end
+
+        # ── Bracket-shrink safeguard (paper p. 293) ────────────────
+        if bracketed
+            if abs(αᵤ - αₗ) ≥ BRACKET_SAFEGUARD * width_prev
+                αₜ_next = (αₗ + αᵤ) / 2
+            end
+            width_prev = width
+            width      = abs(αᵤ - αₗ)
+        end
+
+        # ── Update local step bounds for next iteration ─────────────
+        # (Fortran dcsrch lines 3642-3648).
+        if bracketed
+            stmin = min(αₗ, αᵤ)
+            stmax = max(αₗ, αᵤ)
+        else
+            stmin = αₜ_next + oftype(αₜ_next, 1.1) * (αₜ_next - αₗ)
+            stmax = αₜ_next + oftype(αₜ_next, 4.0) * (αₜ_next - αₗ)
+        end
+
+        # ── Global step bounds (Fortran lines 3652-3653) ───────────
+        αₜ_next = max(αₜ_next, zero(αₜ_next))
+        αₜ_next = min(αₜ_next, αmax)
+
+        # ── Fallback to best point when progress stalls ─────────────
+        # (Fortran dcsrch lines 3578-3585, 3658-3659). Return the
+        # best point found rather than looping — equivalent to the
+        # Fortran's WARNING termination on the next call.
+        if bracketed && (αₜ_next ≤ stmin || αₜ_next ≥ stmax ||
+                         stmax - stmin ≤ xtol * stmax)
+            return αₗ, fₗ, gₗ
+        end
+
+        αₜ = αₜ_next
+    end
+
+    error("more_thuente did not converge in $max_iters iterations")
+end

--- a/src/multivariate/solvers/constrained/lbfgsb/mt/poly_min.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb/mt/poly_min.jl
@@ -1,0 +1,97 @@
+# Polynomial minimizers used by the More-Thuente line search (§4 of
+# Moré & Thuente, 1994, ACM TOMS 20(3):286-307).
+#
+# Three closed-form interpolating-polynomial minimizers, matching the
+# paper's notation:
+#
+#   α_c: cubic Hermite minimizer   (4 data: fₗ, gₗ, fₜ, gₜ)
+#   α_q: quadratic minimizer       (3 data: fₗ, gₗ, fₜ)
+#   α_s: secant on the derivative  (3 data: fₗ, gₗ, gₜ)
+#
+# Each function returns the α at which the corresponding interpolant has
+# a stationary point (a minimum in the cases the paper actually uses
+# them). They are agnostic to whether the input values come from φ or
+# from the auxiliary function ψ.
+
+"""
+    cubic_min(αₗ, fₗ, gₗ, αₜ, fₜ, gₜ) -> α_c
+
+Minimizer of the unique cubic Hermite polynomial p(α) satisfying
+    p(αₗ) = fₗ,  p'(αₗ) = gₗ,
+    p(αₜ) = fₜ,  p'(αₜ) = gₜ.
+
+Returns `NaN` of the appropriate type when the cubic has no real
+stationary point. This happens when the discriminant θ² - gₗ·gₜ is
+negative — possible only when gₗ and gₜ have the same sign (paper's
+Case 3); in that situation the data is consistent with the cubic being
+monotone over the relevant region.
+
+The function is symmetric in its two interpolation points: swapping
+(αₗ, fₗ, gₗ) with (αₜ, fₜ, gₜ) yields the same α_c. The sign convention
+on γ below picks the minimizer (where p'' ≥ 0), not the maximizer.
+"""
+function cubic_min(αₗ, fₗ, gₗ, αₜ, fₜ, gₜ)
+    # θ is the standard "modified second difference" of cubic Hermite
+    # interpolation (Nocedal & Wright eq. 3.59, d₁):
+    #     θ = gₗ + gₜ + 3·(fₗ - fₜ)/(αₜ - αₗ)
+    θ = 3*(fₗ - fₜ)/(αₜ - αₗ) + gₗ + gₜ
+
+    # The minimizer formula involves √(θ² - gₗ·gₜ). Rescale by
+    # s = max(|θ|, |gₗ|, |gₜ|) before squaring so that the squared
+    # quantities do not over/underflow when slopes are very large or
+    # very small (this is MINPACK's `s` trick).
+    s = max(abs(θ), abs(gₗ), abs(gₜ))
+    s == zero(s) && return (αₗ + αₜ)/2          # degenerate, fall back to midpoint
+    disc = (θ/s)^2 - (gₗ/s)*(gₜ/s)
+
+    # No real stationary point.
+    disc < zero(disc) && return oftype(αₗ, NaN)
+
+    # γ ≡ sign(αₜ - αₗ) · √(θ² - gₗ·gₜ). The sign selects the
+    # minimum-side root of p'(α) = 0 rather than the maximum-side root.
+    γ = s * sqrt(disc) * sign(αₜ - αₗ)
+
+    # Closed form (Nocedal & Wright 3.59):
+    #     α_c = αₜ - (αₜ - αₗ)·(gₜ + γ - θ)/(gₜ - gₗ + 2γ)
+    return αₜ - (αₜ - αₗ) * (gₜ + γ - θ) / (gₜ - gₗ + 2γ)
+end
+
+
+"""
+    quadratic_min(αₗ, fₗ, gₗ, αₜ, fₜ) -> α_q
+
+Minimizer of the unique quadratic q(α) interpolating
+    q(αₗ) = fₗ,  q'(αₗ) = gₗ,  q(αₜ) = fₜ.
+
+This is the paper's α_q (Case 1 of §4), used when fₜ > fₗ and we want
+a candidate biased toward the lower-valued endpoint αₗ.
+
+Note the asymmetry: the slope at αₗ is used; the slope at αₜ is not.
+"""
+function quadratic_min(αₗ, fₗ, gₗ, αₜ, fₜ)
+    # q(α) = fₗ + gₗ(α - αₗ) + a(α - αₗ)²
+    # q(αₜ) = fₜ pins  a = (fₜ - fₗ - gₗ·h)/h²,  with h = αₜ - αₗ.
+    # q'(α_q) = 0      ⇒  α_q = αₗ - gₗ/(2a)
+    #                  ⇒  α_q = αₗ + h · gₗ / (2·(gₗ - (fₜ - fₗ)/h)).
+    secant_slope = (fₜ - fₗ) / (αₜ - αₗ)
+    return αₗ + (αₜ - αₗ) * gₗ / (2 * (gₗ - secant_slope))
+end
+
+
+"""
+    secant_min(αₗ, gₗ, αₜ, gₜ) -> α_s
+
+Zero of the linear interpolant of gₗ at αₗ and gₜ at αₜ — equivalently,
+the minimizer of any quadratic whose derivative is that linear
+interpolant.
+
+This is the paper's α_s (Cases 2 and 3 of §4). The result depends only
+on the slopes; function values do not enter the formula.
+
+Symmetric in its two interpolation points.
+"""
+function secant_min(αₗ, gₗ, αₜ, gₜ)
+    # Linear interpolant of g over [αₗ, αₜ] is zero at
+    #     α_s = αₜ + (αₗ - αₜ)·gₜ/(gₜ - gₗ).
+    return αₜ + (αₗ - αₜ) * gₜ / (gₜ - gₗ)
+end

--- a/src/multivariate/solvers/constrained/lbfgsb/mt/trial_value.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb/mt/trial_value.jl
@@ -1,0 +1,94 @@
+# Trial value selection for the More-Thuente line search.
+#
+# Implements the four-case analysis of Fortran dcstep (MINPACK-2), which
+# runs regardless of bracket status. Local step bounds (stpmin, stpmax)
+# computed by the caller guide the extrapolation when not yet bracketed.
+
+"""
+    trial_value(αₗ, fₗ, gₗ, αᵤ, fᵤ, gᵤ, αₜ, fₜ, gₜ, bracketed,
+                stpmin, stpmax) -> αₜ⁺
+
+Compute the next trial value for the line search.
+
+Implements the four-case analysis of Fortran `dcstep` (MINPACK-2).
+Unlike the paper-faithful version that only extrapolates when not
+bracketed, this runs the full case analysis in both states.
+
+`stpmin` and `stpmax` are local step bounds from the caller:
+- **Bracketed**: `min(αₗ,αᵤ)` / `max(αₗ,αᵤ)` — bracket interval.
+- **Not bracketed**: `αₜ + 1.1·(αₜ - αₗ)` / `αₜ + 4·(αₜ - αₗ)` —
+  extrapolation window (Fortran `xtrapl`/`xtrapu`).
+
+# Cases (Fortran dcstep / paper §4)
+
+- **Case 1** (`fₜ > fₗ`): trial rose. Cubic+quadratic between αₗ, αₜ.
+  Bracket-independent.
+- **Case 2** (opposite slopes): cubic+secant, farther from αₜ.
+  Bracket-independent.
+- **Case 3** (same slopes, `|gₜ| ≤ |gₗ|`):
+  - *Bracketed*: closer of cubic/secant + 0.66 safeguard.
+  - *Not bracketed*: farther of cubic/secant, clamped to [stpmin,stpmax].
+- **Case 4** (same slopes, `|gₜ| > |gₗ|`):
+  - *Bracketed*: cubic between αₜ and αᵤ.
+  - *Not bracketed*: jump to stpmax (or stpmin).
+"""
+function trial_value(αₗ, fₗ, gₗ, αᵤ, fᵤ, gᵤ, αₜ, fₜ, gₜ, bracketed, stpmin, stpmax)
+    # TODO maybe expose?
+    BRACKET_SAFEGUARD = 66 // 100
+    if fₜ > fₗ
+        # Case 1: trial rose — minimum bracketed in (αₗ, αₜ).
+        # Cubic α_c and quadratic α_q. Take α_c if closer to αₗ,
+        # else average — avoids pathological α_q near αₗ when fₜ ≫ fₗ.
+        α_c = cubic_min(αₗ, fₗ, gₗ, αₜ, fₜ, gₜ)
+        α_q = quadratic_min(αₗ, fₗ, gₗ, αₜ, fₜ)
+        return abs(α_c - αₗ) < abs(α_q - αₗ) ? α_c : (α_c + α_q) / 2
+
+    elseif gₜ * gₗ < zero(gₜ)
+        # Case 2: lower value, opposite slope signs — minimum bracketed
+        # by slope sign change. Take whichever of cubic/secant is farther
+        # from αₜ.
+        α_c = cubic_min(αₗ, fₗ, gₗ, αₜ, fₜ, gₜ)
+        α_s = secant_min(αₗ, gₗ, αₜ, gₜ)
+        return abs(α_c - αₜ) ≥ abs(α_s - αₜ) ? α_c : α_s
+
+    elseif abs(gₜ) ≤ abs(gₗ)
+        # Case 3: lower value, same slope signs, magnitude decreasing.
+        α_c = cubic_min(αₗ, fₗ, gₗ, αₜ, fₜ, gₜ)
+        α_s = secant_min(αₗ, gₗ, αₜ, gₜ)
+
+        # Cubic is usable only if it exists (finite) and its minimiser
+        # lies past αₜ away from αₗ. Matches Fortran: r < 0 && γ ≠ 0.
+        cubic_ok = isfinite(α_c) && sign(αₜ - αₗ) * (α_c - αₜ) > zero(α_c)
+
+        if bracketed
+            # Closer of cubic/secant, with 0.66 safeguard toward αᵤ.
+            αₜ⁺ = if cubic_ok
+                abs(α_c - αₜ) < abs(α_s - αₜ) ? α_c : α_s
+            else
+                α_s
+            end
+            if αₜ > αₗ
+                return min(αₜ + BRACKET_SAFEGUARD * (αᵤ - αₜ), αₜ⁺)
+            else
+                return max(αₜ + BRACKET_SAFEGUARD * (αᵤ - αₜ), αₜ⁺)
+            end
+        else
+            # Not bracketed: farther of cubic/secant, clamped to local
+            # bounds. When cubic unusable, fall back to stpmax/stpmin
+            # (Fortran dcstep lines 3865-3869).
+            α_c_eff = cubic_ok ? α_c : (αₜ > αₗ ? stpmax : stpmin)
+            αₜ⁺ = abs(α_c_eff - αₜ) > abs(α_s - αₜ) ? α_c_eff : α_s
+            return clamp(αₜ⁺, stpmin, stpmax)
+        end
+
+    else
+        # Case 4: lower value, same slope signs, magnitude increasing.
+        if bracketed
+            # Cubic between αₜ and αᵤ.
+            return cubic_min(αₜ, fₜ, gₜ, αᵤ, fᵤ, gᵤ)
+        else
+            # Jump to boundary (Fortran dcstep lines 3919-3923).
+            return αₜ > αₗ ? stpmax : stpmin
+        end
+    end
+end

--- a/src/multivariate/solvers/constrained/lbfgsb/mt/trial_value.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb/mt/trial_value.jl
@@ -3,7 +3,8 @@
 # Implements the four-case analysis of Fortran dcstep (MINPACK-2), which
 # runs regardless of bracket status. Local step bounds (stpmin, stpmax)
 # computed by the caller guide the extrapolation when not yet bracketed.
-
+# TODO maybe expose?
+const BRACKET_SAFEGUARD = 66 // 100
 """
     trial_value(αₗ, fₗ, gₗ, αᵤ, fᵤ, gᵤ, αₜ, fₜ, gₜ, bracketed,
                 stpmin, stpmax) -> αₜ⁺
@@ -33,8 +34,6 @@ bracketed, this runs the full case analysis in both states.
   - *Not bracketed*: jump to stpmax (or stpmin).
 """
 function trial_value(αₗ, fₗ, gₗ, αᵤ, fᵤ, gᵤ, αₜ, fₜ, gₜ, bracketed, stpmin, stpmax)
-    # TODO maybe expose?
-    BRACKET_SAFEGUARD = 66 // 100
     if fₜ > fₗ
         # Case 1: trial rose — minimum bracketed in (αₗ, αₜ).
         # Cubic α_c and quadratic α_q. Take α_c if closer to αₗ,

--- a/src/multivariate/solvers/constrained/lbfgsb/mt/update.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb/mt/update.jl
@@ -1,0 +1,79 @@
+# Bracket update rule for the More-Thuente line search (Section 2/Section 3 of
+# Moré & Thuente, 1994).
+#
+# The paper presents the same three-case update twice: as Cases U1-U3
+# acting on ψ-values in Section 2 (p. 291), and equivalently as Cases a-c
+# acting on φ-values in Section 3 (p. 297). The case structure is identical —
+# only the function feeding the tests changes. We implement it once,
+# agnostic to whether the inputs are φ-values or ψ-shifted values.
+# Below we refer to the cases by their Section 2 names (U1-U3); a-c is the
+# same algorithm applied to φ rather than ψ.
+#
+# Notation in this file matches the paper:
+#   αₗ — current best step  (lowest value seen, "anchor")
+#   αᵤ — other endpoint of the interval of uncertainty
+#   αₜ — current trial step  (the one whose data we just computed)
+#
+# Note that the paper does not assume αₗ < αᵤ; the interval of
+# uncertainty is [min(αₗ, αᵤ), max(αₗ, αᵤ)].
+
+"""
+    update_bracket(αₗ, fₗ, gₗ, αᵤ, fᵤ, gᵤ, αₜ, fₜ, gₜ, bracketed)
+        -> (αₗ⁺, fₗ⁺, gₗ⁺, αᵤ⁺, fᵤ⁺, gᵤ⁺, bracketed⁺)
+
+Update the interval of uncertainty after evaluating the trial value αₜ.
+Implements the three-case algorithm of Moré-Thuente (1994), Section 2
+(Cases U1-U3) — equivalently Section 3 (Cases a-c), which is the same case
+analysis applied to φ rather than ψ.
+
+# Cases
+
+- **U1 — trial value rose** (`fₜ > fₗ`): a minimizer is bracketed in
+  the interval (αₗ, αₜ). Update: `αₗ⁺ = αₗ`, `αᵤ⁺ = αₜ`.
+
+- **U2 — trial fell, slope away from αₗ** (`fₜ ≤ fₗ` and
+  `gₜ·(αₗ - αₜ) > 0`): the function continues to descend past αₜ in the
+  direction away from αₗ. The minimum lies beyond αₜ; move αₗ forward.
+  Update: `αₗ⁺ = αₜ`, `αᵤ⁺ = αᵤ`.
+
+- **U3 — trial fell, slope toward αₗ** (`fₜ ≤ fₗ` and
+  `gₜ·(αₗ - αₜ) < 0`): the slope at αₜ points back at αₗ, so a minimizer
+  is bracketed in (αₗ, αₜ). αₜ becomes the new best; the old αₗ becomes
+  the other endpoint. Update: `αₗ⁺ = αₜ`, `αᵤ⁺ = αₗ`.
+
+# Bracketing
+
+The `bracketed` flag tracks whether αᵤ is meaningful (the interval has
+a finite right endpoint). Cases U1 and U3 establish the bracket; Case
+U2 extends a still-open interval. Once `bracketed == true`, it stays
+true.
+
+# Termination corner case
+
+The paper notes (p. 291) that if `gₜ = 0` and `fₜ ≤ fₗ`, then αₜ already
+satisfies `T(μ)` and no update is needed — the caller should detect this
+and terminate. This function does not test for it; the `gₜ·(αₗ - αₜ) = 0`
+boundary falls into the U3 branch here, which is harmless if the caller
+didn't already exit.
+
+# Precondition
+
+The caller must maintain the Section 2 endpoint invariants (paper eq. 2.1):
+`fₗ ≤ fᵤ`, `fₗ ≤ 0` (for ψ-values), and `gₗ·(αᵤ - αₗ) < 0`. The paper
+proves these are preserved across calls (modulo the `gₜ = 0`
+termination case).
+"""
+function update_bracket(αₗ, fₗ, gₗ, αᵤ, fᵤ, gᵤ, αₜ, fₜ, gₜ, bracketed)
+    if fₜ > fₗ
+        # Case U1: trial rose. Old αₗ stays; new αᵤ is αₜ.
+        return αₗ, fₗ, gₗ, αₜ, fₜ, gₜ, true
+    elseif gₜ * (αₗ - αₜ) > zero(gₜ)
+        # Case U2: trial fell, slope still pointing away from αₗ.
+        # Bracket is not yet (re)established; αᵤ inherits the prior value.
+        return αₜ, fₜ, gₜ, αᵤ, fᵤ, gᵤ, bracketed
+    else
+        # Case U3: trial fell, slope points back toward αₗ.
+        # The old αₗ becomes the upper endpoint.
+        return αₜ, fₜ, gₜ, αₗ, fₗ, gₗ, true
+    end
+end

--- a/src/multivariate/solvers/constrained/simple_lbfgsb.jl
+++ b/src/multivariate/solvers/constrained/simple_lbfgsb.jl
@@ -1,0 +1,571 @@
+# Simple reference L-BFGS-B, kept internal (NOT exported) purely so the
+# efficient `LBFGSB` solver in lbfgsb.jl can be compared against it. This
+# Was my first implementation without all the optimizations
+#
+# Same algorithm as `LBFGSB` (generalized Cauchy point + subspace minimization
+# on B = θI - W M Wᵀ), but written for clarity rather than speed: dense Gram
+# rebuilds and an explicit `inv` instead of Cholesky factors, and fresh
+# allocations instead of in-place workspace. Run it with `Optim.SimpleLBFGSB()`.
+
+module SimpleLBFGSBReference
+
+import ..Optim
+import NLSolversBase
+using NLSolversBase: OnceDifferentiable, NonDifferentiable, value_gradient!
+using LinearAlgebra: dot, norm, I, Diagonal, tril, diag
+import ADTypes
+
+abstract type LineSearcher end
+include("lbfgsb/hz.jl")
+include("lbfgsb/linesearches_mt.jl")
+
+struct SimpleLBFGSB{L<:LineSearcher,T} <: Optim.AbstractConstrainedOptimizer
+    m::Int
+    linesearch::L
+    stepsize::T
+    clip_subspace::Bool
+end
+
+#=
+    Optim.SimpleLBFGSB(; m=10, linesearch=HZAW(), stepsize=1.0, clip_subspace=true)
+
+Reference implementation of L-BFGS-B, kept internal and **not exported**. It
+solves the same bound-constrained problem as `Optim.LBFGSB` with the same
+options and keywords, but uses dense matrix rebuilds and an explicit inverse
+instead of the Cholesky-factored, incremental, in-place machinery of `LBFGSB`.
+It is a fully independent implementation, kept only for cross-checking the
+efficient solver, and is not intended for production use. Run it with
+`Optim.SimpleLBFGSB()`. Its line search keyword accepts
+`Optim.SimpleLBFGSBReference.HZAW()` / `...MTLS()`.
+=#
+function SimpleLBFGSB(;
+    m::Integer = 10,
+    linesearch::LineSearcher = HZAW(),
+    stepsize::Real = 1.0,
+    clip_subspace::Bool = true,
+)
+    SimpleLBFGSB(Int(m), linesearch, float(stepsize), clip_subspace)
+end
+
+Base.summary(io::IO, ::SimpleLBFGSB) = print(io, "L-BFGS-B (simple reference)")
+
+# Own optimizer state for the termination code. Subtypes AbstractOptimizerState
+# (not ZerothOrderState) so the generic change accessors return real values.
+struct SimpleState{T,Tx} <: Optim.AbstractOptimizerState
+    x::Tx
+    f_x::T
+    x_previous::Tx
+    f_x_previous::T
+end
+
+# Dense compact representation: all Gram matrices are rebuilt each update.
+mutable struct CompactLBFGS{T}
+    m::Int
+    S::Matrix{T}
+    Y::Matrix{T}
+    SᵀS::Matrix{T}
+    L::Matrix{T}
+    W::Matrix{T}
+    M::Matrix{T}
+    θ::T
+    k::Int
+end
+
+function CompactLBFGS{T}(n::Integer, m::Integer) where {T}
+    CompactLBFGS{T}(
+        m,
+        zeros(T, n, m),
+        zeros(T, n, m),
+        zeros(T, m, m),
+        zeros(T, m, m),
+        zeros(T, n, 2m),
+        zeros(T, 2m, 2m),
+        one(T),
+        0,
+    )
+end
+
+function reset_history!(B::CompactLBFGS{T}) where {T}
+    B.k = 0
+    B.θ = one(T)
+    return B
+end
+
+project(x, lb, ub) = clamp.(x, lb, ub)
+
+function max_steplength(x, d, lb, ub)
+    T = eltype(x)
+    αmax = T(Inf)
+    for i in eachindex(x)
+        if d[i] > 0
+            αmax = min(αmax, (ub[i] - x[i]) / d[i])
+        elseif d[i] < 0
+            αmax = min(αmax, (lb[i] - x[i]) / d[i])
+        end
+    end
+    return αmax
+end
+
+function pg_norm(x, g, lb, ub)
+    result = zero(eltype(g))
+    for i in eachindex(x, g, lb, ub)
+        gi = g[i]
+        if gi < 0
+            isfinite(ub[i]) && (gi = max(x[i] - ub[i], gi))
+        elseif gi > 0
+            isfinite(lb[i]) && (gi = min(x[i] - lb[i], gi))
+        end
+        agi = abs(gi)
+        agi > result && (result = agi)
+    end
+    return result
+end
+
+# Generalized Cauchy point; returns (xᶜ, c) with c = Wᵀ(xᶜ - x).
+function cauchy_point(x, g, lb, ub, B::CompactLBFGS)
+    T = eltype(x)
+    n = length(x)
+    mcols = 2B.k
+    θ = B.θ
+
+    W = @view B.W[:, 1:mcols]
+    M = @view B.M[1:mcols, 1:mcols]
+
+    t = fill(T(Inf), n)
+    d = zeros(T, n)
+    for i = 1:n
+        if g[i] < 0
+            t[i] = (x[i] - ub[i]) / g[i]
+        elseif g[i] > 0
+            t[i] = (x[i] - lb[i]) / g[i]
+        end
+        if t[i] > 0
+            d[i] = -g[i]
+        end
+    end
+
+    order = sortperm(t)
+    p = W' * d
+    c = zeros(T, mcols)
+    f′ = -dot(d, d)
+    f″ = -θ * f′ - dot(p, M * p)
+    Δtmin = -f′ / f″
+    t_old = zero(T)
+
+    idx = 1
+    while idx <= n && t[order[idx]] <= 0
+        idx += 1
+    end
+    if idx > n
+        return copy(x), zeros(T, mcols)
+    end
+    t_cur = t[order[idx]]
+    Δt = t_cur - t_old
+
+    while Δtmin >= Δt && idx <= n && isfinite(Δt)
+        b = order[idx]
+
+        xᶜ_b = b <= 0 ? zero(T) : (d[b] > 0 ? ub[b] : lb[b])
+        z_b = xᶜ_b - x[b]
+
+        c .+= Δt .* p
+        g_b = g[b]
+        wb = @view W[b, :]
+        f′ += Δt * f″ + g_b^2 + θ * g_b * z_b - g_b * dot(wb, M * c)
+        f″ += -θ * g_b^2 - 2 * g_b * dot(wb, M * p) - g_b^2 * dot(wb, M * wb)
+        p .+= g_b .* wb
+        d[b] = zero(T)
+
+        Δtmin = f″ > 0 ? -f′ / f″ : (f′ < 0 ? T(Inf) : zero(T))
+        t_old = t_cur
+
+        idx += 1
+        while idx <= n && t[order[idx]] <= t_old
+            idx += 1
+        end
+        if idx <= n
+            t_cur = t[order[idx]]
+            Δt = t_cur - t_old
+        else
+            break
+        end
+    end
+
+    Δtmin = max(Δtmin, zero(T))
+    t_old += Δtmin
+    xc = copy(x)
+    for i = 1:n
+        if g[i] == 0
+            xc[i] = x[i]
+        else
+            xc[i] = clamp(x[i] - t_old * g[i], lb[i], ub[i])
+        end
+    end
+    c .+= Δtmin .* p
+
+    return xc, c
+end
+
+# Subspace minimization over the free variables at the Cauchy point.
+function subspace_optimize(x, xc, c, g, lb, ub, B::CompactLBFGS; clip::Bool = true)
+    T = eltype(x)
+    θ = B.θ
+    W = @view B.W[:, 1:2B.k]
+    M = @view B.M[1:2B.k, 1:2B.k]
+
+    free = findall(i -> lb[i] < xc[i] < ub[i], eachindex(xc))
+
+    if isempty(free) || B.k == 0
+        return copy(xc)
+    end
+
+    Wf = W[free, :]
+    x̂c = xc[free] .- x[free]
+    rc = g[free] .+ θ .* x̂c .- Wf * (M * c)
+    v = M * (Wf' * rc)
+    N = Matrix(I - (one(T) / θ) .* (M * (Wf' * Wf)))
+    v = N \ v
+    du = -(one(T) / θ) .* rc .- (one(T) / θ^2) .* (Wf * v)
+
+    x̄ = copy(xc)
+
+    if clip
+        any_bound_hit = false
+        for (j, i) in enumerate(free)
+            x̄[i] = clamp(xc[i] + du[j], lb[i], ub[i])
+            if x̄[i] == lb[i] || x̄[i] == ub[i]
+                any_bound_hit = true
+            end
+        end
+
+        if any_bound_hit
+            dd_p = dot(x̄ .- x, g)
+            if dd_p > 0
+                α_star = one(T)
+                for (j, i) in enumerate(free)
+                    if du[j] > 0
+                        α_star = min(α_star, (ub[i] - xc[i]) / du[j])
+                    elseif du[j] < 0
+                        α_star = min(α_star, (lb[i] - xc[i]) / du[j])
+                    end
+                end
+                for (j, i) in enumerate(free)
+                    x̄[i] = xc[i] + α_star * du[j]
+                end
+            end
+        end
+    else
+        α_star = one(T)
+        for (j, i) in enumerate(free)
+            if du[j] > 0
+                α_star = min(α_star, (ub[i] - xc[i]) / du[j])
+            elseif du[j] < 0
+                α_star = min(α_star, (lb[i] - xc[i]) / du[j])
+            end
+        end
+        for (j, i) in enumerate(free)
+            x̄[i] = xc[i] + α_star * du[j]
+        end
+    end
+
+    return x̄
+end
+
+function update_compact!(B::CompactLBFGS, x, x_new, g, g_new)
+    T = eltype(x)
+    s = x_new .- x
+    y = g_new .- g
+    yts = dot(y, s)
+
+    yts <= 0 && return B
+
+    k = B.k
+    m = B.m
+
+    if k < m
+        k += 1
+        B.k = k
+        B.S[:, k] .= s
+        B.Y[:, k] .= y
+    else
+        for j = 1:(m-1)
+            B.S[:, j] .= B.S[:, j+1]
+            B.Y[:, j] .= B.Y[:, j+1]
+        end
+        B.S[:, m] .= s
+        B.Y[:, m] .= y
+    end
+
+    B.θ = dot(y, y) / yts
+
+    Sk = @view B.S[:, 1:k]
+    Yk = @view B.Y[:, 1:k]
+    SᵀY = Sk' * Yk
+
+    B.SᵀS[1:k, 1:k] .= Sk' * Sk
+    B.L[1:k, 1:k] .= tril(SᵀY, -1)
+
+    B.W[:, 1:k] .= Yk
+    B.W[:, (k+1):2k] .= B.θ .* Sk
+
+    D = Diagonal(diag(SᵀY))
+    Minv = zeros(T, 2k, 2k)
+    Minv[1:k, 1:k] .= -D
+    Minv[1:k, (k+1):2k] .= B.L[1:k, 1:k]'
+    Minv[(k+1):2k, 1:k] .= B.L[1:k, 1:k]
+    Minv[(k+1):2k, (k+1):2k] .= B.θ .* B.SᵀS[1:k, 1:k]
+    B.M[1:2k, 1:2k] .= inv(Minv)
+
+    return B
+end
+
+function trace!(tr, iteration, f_x, pgnorm, x, g, options, curr_time)
+    dt = Dict{String,Any}()
+    dt["time"] = curr_time
+    if options.extended_trace
+        dt["x"] = copy(x)
+        dt["g(x)"] = copy(g)
+    end
+    Optim.update!(
+        tr,
+        iteration,
+        f_x,
+        pgnorm,
+        dt,
+        options.store_trace,
+        options.show_trace,
+        options.show_every,
+    )
+end
+
+function Optim.optimize(
+    f,
+    l::AbstractArray,
+    u::AbstractArray,
+    x0::AbstractArray,
+    method::SimpleLBFGSB,
+    options::Optim.Options = Optim.Options();
+    inplace::Bool = true,
+    autodiff::ADTypes.AbstractADType = Optim.DEFAULT_AD_TYPE,
+)
+    if f isa NonDifferentiable
+        f = f.f
+    end
+    od = OnceDifferentiable(f, x0, zero(eltype(x0)); inplace, autodiff)
+    Optim.optimize(od, l, u, x0, method, options)
+end
+
+function Optim.optimize(
+    f,
+    g,
+    l::AbstractArray,
+    u::AbstractArray,
+    x0::AbstractArray,
+    method::SimpleLBFGSB,
+    options::Optim.Options = Optim.Options();
+    inplace::Bool = true,
+)
+    g! = inplace ? g : (G, x) -> copyto!(G, g(x))
+    od = OnceDifferentiable(f, g!, x0, zero(eltype(x0)))
+    Optim.optimize(od, l, u, x0, method, options)
+end
+
+function Optim.optimize(
+    d::OnceDifferentiable,
+    l::AbstractArray,
+    u::AbstractArray,
+    x0::AbstractArray,
+    method::SimpleLBFGSB,
+    options::Optim.Options = Optim.Options(),
+)
+    T = eltype(x0)
+    t0 = time()
+    (; callback) = options
+
+    n = length(x0)
+    (length(l) == n && length(u) == n) ||
+        throw(DimensionMismatch("lb, ub and x0 must have the same length."))
+    all(i -> l[i] <= u[i], eachindex(l)) ||
+        throw(ArgumentError("Each lower bound must be ≤ the corresponding upper bound."))
+    all(i -> l[i] <= x0[i] <= u[i], eachindex(x0)) ||
+        throw(ArgumentError("Initial x0 is outside the box [lb, ub]."))
+
+    x = project(copy(x0), l, u)
+    f_x, _g = value_gradient!(d, x)
+    g = copy(_g)
+
+    B = CompactLBFGS{T}(n, method.m)
+
+    tr = Optim.OptimizationTrace{typeof(f_x),typeof(method)}()
+    tracing = options.store_trace || options.show_trace || options.extended_trace
+    options.show_trace && Optim.print_header(method)
+
+    x_previous = copy(x)
+    f_x_previous = oftype(f_x, NaN)
+
+    pgnorm = pg_norm(x, g, l, u)
+
+    x_converged = false
+    f_converged = false
+    g_converged = pgnorm <= options.g_abstol
+    f_increased = false
+    ls_failed = false
+    stopped_by_time_limit = false
+    f_limit_reached = false
+    g_limit_reached = false
+
+    iteration = 0
+    _time = time()
+    tracing && trace!(tr, iteration, f_x, pgnorm, x, g, options, _time - t0)
+    stopped_by_callback = callback !== nothing && callback((; x, f_x, g_x = g, iteration)) == true
+
+    converged = g_converged
+    stopped = stopped_by_callback || !isfinite(f_x) || any(!isfinite, g)
+
+    while !converged && !stopped && iteration < options.iterations
+        iteration += 1
+
+        xc, c = cauchy_point(x, g, l, u, B)
+        x̂ = subspace_optimize(x, xc, c, g, l, u, B; clip = method.clip_subspace)
+        dvec = x̂ .- x
+
+        dφ0 = dot(g, dvec)
+        if dφ0 >= 0 && B.k > 0
+            reset_history!(B)
+            xc, c = cauchy_point(x, g, l, u, B)
+            x̂ = subspace_optimize(x, xc, c, g, l, u, B; clip = method.clip_subspace)
+            dvec = x̂ .- x
+            dφ0 = dot(g, dvec)
+        end
+        if dφ0 >= 0
+            ls_failed = true
+            break
+        end
+
+        αmax = max_steplength(x, dvec, l, u)
+        φdφ = α -> begin
+            xα = x .+ α .* dvec
+            fα, gα = value_gradient!(d, xα)
+            (fα, dot(gα, dvec))
+        end
+
+        dnorm = norm(dvec)
+        boxed = all(i -> isfinite(l[i]) && isfinite(u[i]), eachindex(x))
+        α₀ = if B.k == 0 && !boxed && dnorm > 0
+            min(one(T) / dnorm, αmax)
+        else
+            min(T(method.stepsize), αmax)
+        end
+
+        α, _, _ = find_steplength(method.linesearch, φdφ, f_x, dφ0, α₀; αmax = αmax)
+        if !isfinite(α)
+            α = min(T(1) / 10^4, αmax)
+        end
+
+        x_new = x .+ α .* dvec
+        f_new, _gn = value_gradient!(d, x_new)
+        g_new = copy(_gn)
+
+        yts = dot(g_new .- g, x_new .- x)
+        if isfinite(f_new) && yts > 0
+            update_compact!(B, x, x_new, g, g_new)
+        end
+
+        copyto!(x_previous, x)
+        f_x_previous = f_x
+        copyto!(x, x_new)
+        f_x = f_new
+        copyto!(g, g_new)
+
+        pgnorm = pg_norm(x, g, l, u)
+
+        x_converged =
+            Optim.x_abschange(x, x_previous) <= options.x_abstol ||
+            Optim.x_relchange(x, x_previous) <= options.x_reltol
+        f_converged =
+            Optim.f_abschange(f_x, f_x_previous) <= options.f_abstol ||
+            Optim.f_relchange(f_x, f_x_previous) <= options.f_reltol
+        g_converged = pgnorm <= options.g_abstol
+        f_increased = f_x > f_x_previous
+        converged = x_converged || f_converged || g_converged
+
+        tracing && trace!(tr, iteration, f_x, pgnorm, x, g, options, time() - t0)
+        if callback !== nothing
+            stopped_by_callback = callback((; x, f_x, g_x = g, iteration)) == true
+        end
+
+        _time = time()
+        stopped_by_time_limit = _time - t0 > options.time_limit
+        f_limit_reached =
+            options.f_calls_limit > 0 && NLSolversBase.f_calls(d) >= options.f_calls_limit
+        g_limit_reached =
+            options.g_calls_limit > 0 && NLSolversBase.g_calls(d) >= options.g_calls_limit
+
+        if stopped_by_callback ||
+           stopped_by_time_limit ||
+           f_limit_reached ||
+           g_limit_reached ||
+           (f_increased && !options.allow_f_increases) ||
+           !isfinite(f_x) ||
+           any(!isfinite, g)
+            stopped = true
+        end
+    end
+
+    _time = time()
+    Tf = typeof(f_x)
+    f_incr_pick = f_increased && !options.allow_f_increases
+
+    stopped_by = (
+        f_limit_reached = f_limit_reached,
+        g_limit_reached = g_limit_reached,
+        h_limit_reached = false,
+        time_limit = stopped_by_time_limit,
+        callback = stopped_by_callback,
+        f_increased = f_incr_pick,
+        ls_failed = ls_failed,
+        iterations = iteration == options.iterations,
+        x_converged = x_converged,
+        f_converged = f_converged,
+        g_converged = g_converged,
+        small_trustregion_radius = false,
+    )
+
+    termination_code = Optim._termination_code(
+        d,
+        pgnorm,
+        SimpleState(x, f_x, x_previous, f_x_previous),
+        stopped_by,
+        options,
+    )
+
+    return Optim.MultivariateOptimizationResults(
+        method,
+        x0,
+        f_incr_pick ? x_previous : x,
+        Tf(f_incr_pick ? f_x_previous : f_x),
+        iteration,
+        Tf(options.x_abstol),
+        Tf(options.x_reltol),
+        Optim.x_abschange(x, x_previous),
+        Optim.x_relchange(x, x_previous),
+        Tf(options.f_abstol),
+        Tf(options.f_reltol),
+        Optim.f_abschange(f_x, f_x_previous),
+        Optim.f_relchange(f_x, f_x_previous),
+        Tf(options.g_abstol),
+        pgnorm,
+        tr,
+        NLSolversBase.f_calls(d),
+        NLSolversBase.g_calls(d),
+        NLSolversBase.jvp_calls(d),
+        NLSolversBase.h_calls(d),
+        NLSolversBase.hvp_calls(d),
+        options.time_limit,
+        _time - t0,
+        stopped_by,
+        termination_code,
+    )
+end
+
+end # module SimpleLBFGSBReference

--- a/src/multivariate/solvers/constrained/simple_lbfgsb.jl
+++ b/src/multivariate/solvers/constrained/simple_lbfgsb.jl
@@ -51,15 +51,15 @@ Base.summary(io::IO, ::SimpleLBFGSB) = print(io, "L-BFGS-B (simple reference)")
 
 # Own optimizer state for the termination code. Subtypes AbstractOptimizerState
 # (not ZerothOrderState) so the generic change accessors return real values.
-struct SimpleState{T,Tx} <: Optim.AbstractOptimizerState
+struct SimpleState{Tx,Tf,Tfp} <: Optim.AbstractOptimizerState
     x::Tx
-    f_x::T
+    f_x::Tf
     x_previous::Tx
-    f_x_previous::T
+    f_x_previous::Tfp
 end
 
 # Dense compact representation: all Gram matrices are rebuilt each update.
-mutable struct CompactLBFGS{T}
+mutable struct CompactLBFGS{T<:Real}
     m::Int
     S::Matrix{T}
     Y::Matrix{T}
@@ -271,8 +271,7 @@ function subspace_optimize(x, xc, c, g, lb, ub, B::CompactLBFGS; clip::Bool = tr
     return x̄
 end
 
-function update_compact!(B::CompactLBFGS, x, x_new, g, g_new)
-    T = eltype(x)
+function update_compact!(B::CompactLBFGS{T}, x, x_new, g, g_new) where {T}
     s = x_new .- x
     y = g_new .- g
     yts = dot(y, s)
@@ -309,7 +308,9 @@ function update_compact!(B::CompactLBFGS, x, x_new, g, g_new)
     B.W[:, (k+1):2k] .= B.θ .* Sk
 
     D = Diagonal(diag(SᵀY))
-    Minv = zeros(T, 2k, 2k)
+    # `Matrix{T}(undef, …)` (not `zeros(T, …)`) so the element type and ndims=2 are
+    # fixed in the type; the four block assignments below overwrite every entry.
+    Minv = Matrix{T}(undef, 2k, 2k)::Matrix{T}
     Minv[1:k, 1:k] .= -D
     Minv[1:k, (k+1):2k] .= B.L[1:k, 1:k]'
     Minv[(k+1):2k, 1:k] .= B.L[1:k, 1:k]

--- a/src/multivariate/solvers/constrained/simple_lbfgsb.jl
+++ b/src/multivariate/solvers/constrained/simple_lbfgsb.jl
@@ -463,7 +463,9 @@ function Optim.optimize(
             α = min(T(1) / 10^4, αmax)
         end
 
-        x_new = x .+ α .* dvec
+        # Project onto the box (only a ULP-level correction at an active bound,
+        # since αmax already caps the step there) so every iterate stays feasible.
+        x_new = clamp.(x .+ α .* dvec, l, u)
         f_new, _gn = value_gradient!(d, x_new)
         g_new = copy(_gn)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -52,6 +52,11 @@ Options(inherit_options; opts...)
 Default values for unspecified `opts` will then be "inherited" from `inherit_options`. This
 can be used to modify a subset of options in a previously defined `Options` variable.
 
+Note: for the bound-constrained solvers (`Fminbox` and `LBFGSB`), `g_abstol` is compared
+against the infinity norm of the *projected* gradient `‖x - P(x - g)‖∞` (with `P` the
+projection onto the box), which is the first-order stationarity measure under bounds, rather
+than against `‖g‖∞`. The two coincide only when no bound is active.
+
 For more information on individual options, see the documentation at
 <http://julianlsolvers.github.io/Optim.jl/stable/user/config>.
 """

--- a/test/multivariate/solvers/constrained/lbfgsb.jl
+++ b/test/multivariate/solvers/constrained/lbfgsb.jl
@@ -1,0 +1,281 @@
+# Reference Fortran L-BFGS-B 3.0 wrapper. Aliased so it does not collide with
+# Optim's exported `LBFGSB` (the native solver under test).
+import LBFGSB as RefLBFGSB
+
+@testset "L-BFGS-B" begin
+    feasible(x, l, u) = all(l .<= x .<= u)
+
+    # Run the whole suite against both the efficient `LBFGSB` and the internal
+    # reference `Optim.SimpleLBFGSBReference.SimpleLBFGSB`. Each variant carries
+    # its own line-search constructors, since the simple port defines its own in
+    # a submodule.
+    variants = (
+        (
+            name = "LBFGSB (efficient)",
+            make = (; kw...) -> LBFGSB(; kw...),
+            hzaw = Optim.HZAW,
+            mtls = Optim.MTLS,
+        ),
+        (
+            name = "SimpleLBFGSB (reference)",
+            make = (; kw...) -> Optim.SimpleLBFGSBReference.SimpleLBFGSB(; kw...),
+            hzaw = Optim.SimpleLBFGSBReference.HZAW,
+            mtls = Optim.SimpleLBFGSBReference.MTLS,
+        ),
+    )
+
+    @testset "$(V.name)" for V in variants
+        @testset "unconstrained problems with slack bounds" begin
+            for (name, prob) in MVP.UnconstrainedProblems.examples
+                xtrue = prob.solutions
+                length(xtrue) > 10 && continue
+                ("Large Polynomial" == name || "Trigonometric" == name) && continue
+                f = MVP.objective(prob)
+                l = min.(xtrue, prob.initial_x) .- 1
+                u = max.(xtrue, prob.initial_x) .+ 1
+                res = optimize(f, l, u, prob.initial_x, V.make(), Optim.Options(g_abstol = 1e-8))
+                @test feasible(Optim.minimizer(res), l, u)
+                @test abs(prob.minimum - Optim.minimum(res)) < 1e-6
+            end
+        end
+
+        @testset "active bound at the solution" begin
+            g(x) = (x[1] - 3.0)^2 + (x[2] + 4.0)^2
+            l = [-2.0, -2.0]
+            u = [2.0, 2.0]
+            res = optimize(g, l, u, [0.0, 0.0], V.make())
+            @test feasible(Optim.minimizer(res), l, u)
+            @test Optim.minimizer(res) ≈ [2.0, -2.0] atol = 1e-6
+        end
+
+        @testset "agreement with Fminbox(LBFGS())" begin
+            rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+            l = [-2.0, -2.0]
+            u = [2.0, 2.0]
+            x0 = [-1.2, 1.0]
+            rb = optimize(rosen, l, u, x0, V.make())
+            rf = optimize(rosen, l, u, x0, Fminbox(LBFGS()))
+            @test Optim.minimizer(rb) ≈ [1.0, 1.0] atol = 1e-4
+            @test Optim.minimizer(rb) ≈ Optim.minimizer(rf) atol = 1e-3
+        end
+
+        @testset "line searches" begin
+            rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+            l = [-2.0, -2.0]
+            u = [2.0, 2.0]
+            x0 = [-1.2, 1.0]
+            for ls in (V.hzaw(), V.mtls())
+                res = optimize(rosen, l, u, x0, V.make(linesearch = ls))
+                @test feasible(Optim.minimizer(res), l, u)
+                @test Optim.minimizer(res) ≈ [1.0, 1.0] atol = 1e-4
+            end
+        end
+
+        @testset "scalar bounds" begin
+            f(x) = sum(abs2, x)
+            x0 = [1.0, -2.0, 3.0]
+            res = optimize(f, -5.0, 5.0, x0, V.make())
+            @test Optim.converged(res)
+            @test Optim.minimizer(res) ≈ zeros(3) atol = 1e-6
+        end
+
+        @testset "one-sided bounds and fixed variables" begin
+            g(x) = (x[1] - 3.0)^2 + (x[2] + 4.0)^2
+            res = optimize(g, [1.0, -Inf], [Inf, Inf], [3.0, 0.0], V.make())
+            @test Optim.minimizer(res) ≈ [3.0, -4.0] atol = 1e-6
+
+            res2 = optimize(g, [1.0, -10.0], [1.0, 10.0], [1.0, 0.0], V.make())
+            @test Optim.minimizer(res2)[1] ≈ 1.0 atol = 1e-8
+            @test Optim.minimizer(res2)[2] ≈ -4.0 atol = 1e-6
+        end
+
+        @testset "type genericity" begin
+            f(x) = sum(abs2, x)
+            for ls in (V.hzaw(), V.mtls())
+                res32 = optimize(f, fill(-5.0f0, 3), fill(5.0f0, 3), Float32[1, -2, 3], V.make(linesearch = ls))
+                @test eltype(Optim.minimizer(res32)) == Float32
+                @test typeof(Optim.minimum(res32)) == Float32
+                @test Optim.minimum(res32) < 1.0f-8
+            end
+        end
+
+        @testset "options: iteration cap and callback" begin
+            rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+            l = [-2.0, -2.0]
+            u = [2.0, 2.0]
+            capped = optimize(rosen, l, u, [-1.2, 1.0], V.make(), Optim.Options(iterations = 2))
+            @test Optim.iterations(capped) <= 2
+            @test !Optim.converged(capped)
+
+            calls = Ref(0)
+            cb = state -> (calls[] += 1; state.iteration >= 3)
+            optimize(rosen, l, u, [-1.2, 1.0], V.make(), Optim.Options(callback = cb))
+            @test calls[] >= 1
+        end
+
+        @testset "errors on infeasible start / bad bounds" begin
+            f(x) = sum(abs2, x)
+            @test_throws ArgumentError optimize(f, [0.0, 0.0], [1.0, 1.0], [2.0, 0.5], V.make())
+            @test_throws ArgumentError optimize(f, [1.0, 0.0], [0.0, 1.0], [0.5, 0.5], V.make())
+        end
+
+        @testset "high-dimensional active set, clip=$clip" for clip in (true, false)
+            n = 30
+            c = collect(range(-3.0, 3.0; length = n))
+            f(x) = sum((x .- c) .^ 2)
+            l = fill(-1.0, n)
+            u = fill(1.0, n)
+            xstar = clamp.(c, l, u)
+            res = optimize(f, l, u, zeros(n), V.make(clip_subspace = clip), Optim.Options(g_abstol = 1e-8))
+            @test feasible(Optim.minimizer(res), l, u)
+            @test Optim.minimizer(res) ≈ xstar atol = 1e-6
+            @test any(Optim.minimizer(res) .≈ -1.0)
+            @test any(Optim.minimizer(res) .≈ 1.0)
+        end
+
+        @testset "feasible start on the boundary" begin
+            n = 10
+            c = collect(range(-3.0, 3.0; length = n))
+            f(x) = sum((x .- c) .^ 2)
+            l = fill(-1.0, n)
+            u = fill(1.0, n)
+            res = optimize(f, l, u, fill(-1.0, n), V.make())
+            @test feasible(Optim.minimizer(res), l, u)
+            @test Optim.minimizer(res) ≈ clamp.(c, l, u) atol = 1e-6
+        end
+
+        @testset "memory length m=$m" for m in (2, 3, 20)
+            rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+            res = optimize(rosen, [-2.0, -2.0], [2.0, 2.0], [-1.2, 1.0], V.make(m = m))
+            @test Optim.converged(res)
+            @test Optim.minimizer(res) ≈ [1.0, 1.0] atol = 1e-4
+        end
+
+        @testset "memory length m=1 reaches the minimizer" begin
+            # A single correction pair gives too poor a model to drive the projected
+            # gradient below g_abstol on Rosenbrock for the efficient solver (the
+            # Fortran reference behaves the same); the minimizer is still reached.
+            rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+            res = optimize(rosen, [-2.0, -2.0], [2.0, 2.0], [-1.2, 1.0], V.make(m = 1))
+            @test Optim.minimizer(res) ≈ [1.0, 1.0] atol = 1e-4
+        end
+
+        @testset "tracing" begin
+            rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+            l = [-2.0, -2.0]
+            u = [2.0, 2.0]
+
+            ext = optimize(rosen, l, u, [-1.2, 1.0], V.make(),
+                Optim.Options(store_trace = true, extended_trace = true))
+            tr = Optim.trace(ext)
+            @test length(tr) >= 1
+            @test isfinite(tr[end].g_norm)
+            @test haskey(tr[end].metadata, "x")
+            @test haskey(tr[end].metadata, "g(x)")
+
+            plain = optimize(rosen, l, u, [-1.2, 1.0], V.make(), Optim.Options(store_trace = true))
+            @test !haskey(Optim.trace(plain)[end].metadata, "x")
+        end
+
+        @testset "termination by limits" begin
+            rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+            l = [-2.0, -2.0]
+            u = [2.0, 2.0]
+            x0 = [-1.2, 1.0]
+
+            r_f = optimize(rosen, l, u, x0, V.make(), Optim.Options(f_calls_limit = 5))
+            @test !Optim.converged(r_f)
+            @test r_f.termination_code == Optim.TerminationCode.ObjectiveCalls
+
+            r_g = optimize(rosen, l, u, x0, V.make(), Optim.Options(g_calls_limit = 5))
+            @test !Optim.converged(r_g)
+            @test r_g.termination_code == Optim.TerminationCode.GradientCalls
+
+            r_i = optimize(rosen, l, u, x0, V.make(), Optim.Options(iterations = 3))
+            @test Optim.iterations(r_i) == 3
+            @test r_i.termination_code == Optim.TerminationCode.Iterations
+        end
+
+        @testset "termination codes for x/f tolerances" begin
+            # With g_abstol disabled, convergence is on the x- or f-change criterion,
+            # and the reported termination_code must reflect that (regression: the
+            # state passed to _termination_code must not subtype ZerothOrderState).
+            rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+            g!(G, x) = (G[1] = -2.0 * (1 - x[1]) - 400.0 * x[1] * (x[2] - x[1]^2);
+                G[2] = 200.0 * (x[2] - x[1]^2); G)
+            l = [-2.0, -2.0]
+            u = [2.0, 2.0]
+            x0 = [-1.2, 1.0]
+
+            r_f = optimize(rosen, g!, l, u, x0, V.make(), Optim.Options(g_abstol = 0.0, f_abstol = 1e-6))
+            @test Optim.converged(r_f)
+            @test r_f.termination_code == Optim.TerminationCode.SmallObjectiveChange
+
+            r_x = optimize(rosen, g!, l, u, x0, V.make(), Optim.Options(g_abstol = 0.0, x_abstol = 1e-4))
+            @test Optim.converged(r_x)
+            @test r_x.termination_code == Optim.TerminationCode.SmallXChange
+        end
+
+        @testset "BigFloat precision" begin
+            f(x) = sum(abs2, x)
+            res = optimize(f, fill(big(-5.0), 3), fill(big(5.0), 3), big.([1.0, -2.0, 3.0]),
+                V.make(), Optim.Options(g_abstol = big(1e-20)))
+            @test eltype(Optim.minimizer(res)) == BigFloat
+            @test Optim.minimum(res) < big(1e-18)
+        end
+
+        @testset "cross-check vs reference LBFGSB.jl (Fortran)" begin
+            refkw = (m = 10, factr = 1e1, pgtol = 1e-9, maxiter = 10_000, maxfun = 10_000)
+
+            csep = collect(range(-3.0, 3.0; length = 25))
+            problems = [
+                (
+                    name = "rosenbrock (interior minimum)",
+                    fval = x -> (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2,
+                    grad = x -> [
+                        -2.0 * (1.0 - x[1]) - 400.0 * x[1] * (x[2] - x[1]^2),
+                        200.0 * (x[2] - x[1]^2),
+                    ],
+                    l = [-2.0, -2.0],
+                    u = [2.0, 2.0],
+                    x0 = [-1.2, 1.0],
+                ),
+                (
+                    name = "shifted quadratic (active corner)",
+                    fval = x -> (x[1] - 3.0)^2 + (x[2] + 4.0)^2,
+                    grad = x -> [2.0 * (x[1] - 3.0), 2.0 * (x[2] + 4.0)],
+                    l = [-2.0, -2.0],
+                    u = [2.0, 2.0],
+                    x0 = [0.0, 0.0],
+                ),
+                (
+                    name = "separable quadratic (many active)",
+                    fval = x -> sum((x .- csep) .^ 2),
+                    grad = x -> 2.0 .* (x .- csep),
+                    l = fill(-1.0, length(csep)),
+                    u = fill(1.0, length(csep)),
+                    x0 = zeros(length(csep)),
+                ),
+            ]
+
+            for p in problems
+                @testset "$(p.name)" begin
+                    fref, xref = RefLBFGSB.lbfgsb(
+                        x -> (p.fval(x), p.grad(x)),
+                        p.x0;
+                        lb = p.l,
+                        ub = p.u,
+                        refkw...,
+                    )
+
+                    g! = (G, x) -> copyto!(G, p.grad(x))
+                    res = optimize(p.fval, g!, p.l, p.u, p.x0, V.make(), Optim.Options(g_abstol = 1e-9))
+
+                    @test feasible(Optim.minimizer(res), p.l, p.u)
+                    @test Optim.minimizer(res) ≈ xref atol = 1e-4
+                    @test Optim.minimum(res) ≈ fref atol = 1e-8 rtol = 1e-6
+                end
+            end
+        end
+    end
+end

--- a/test/multivariate/solvers/constrained/lbfgsb.jl
+++ b/test/multivariate/solvers/constrained/lbfgsb.jl
@@ -6,25 +6,12 @@ import LBFGSB as RefLBFGSB
     feasible(x, l, u) = all(l .<= x .<= u)
 
     # Run the whole suite against both the efficient `LBFGSB` and the internal
-    # reference `Optim.SimpleLBFGSBReference.SimpleLBFGSB`. Each variant carries
-    # its own line-search constructors, since the simple port defines its own in
-    # a submodule.
-    variants = (
-        (
-            name = "LBFGSB (efficient)",
-            make = (; kw...) -> LBFGSB(; kw...),
-            hzaw = Optim.HZAW,
-            mtls = Optim.MTLS,
-        ),
-        (
-            name = "SimpleLBFGSB (reference)",
-            make = (; kw...) -> Optim.SimpleLBFGSBReference.SimpleLBFGSB(; kw...),
-            hzaw = Optim.SimpleLBFGSBReference.HZAW,
-            mtls = Optim.SimpleLBFGSBReference.MTLS,
-        ),
-    )
+    # reference `Optim.SimpleLBFGSBReference.SimpleLBFGSB`. Each variant is the
+    # solver type itself, so `V(m = m)` constructs it; its line searches live in
+    # the type's own module (`parentmodule(V).HZAW()` / `.MTLS()`).
+    variants = (LBFGSB, Optim.SimpleLBFGSBReference.SimpleLBFGSB)
 
-    @testset "$(V.name)" for V in variants
+    @testset "$(nameof(V))" for V in variants
         @testset "unconstrained problems with slack bounds" begin
             for (name, prob) in MVP.UnconstrainedProblems.examples
                 xtrue = prob.solutions
@@ -33,7 +20,7 @@ import LBFGSB as RefLBFGSB
                 f = MVP.objective(prob)
                 l = min.(xtrue, prob.initial_x) .- 1
                 u = max.(xtrue, prob.initial_x) .+ 1
-                res = optimize(f, l, u, prob.initial_x, V.make(), Optim.Options(g_abstol = 1e-8))
+                res = optimize(f, l, u, prob.initial_x, V(), Optim.Options(g_abstol = 1e-8))
                 @test feasible(Optim.minimizer(res), l, u)
                 @test abs(prob.minimum - Optim.minimum(res)) < 1e-6
             end
@@ -43,7 +30,7 @@ import LBFGSB as RefLBFGSB
             g(x) = (x[1] - 3.0)^2 + (x[2] + 4.0)^2
             l = [-2.0, -2.0]
             u = [2.0, 2.0]
-            res = optimize(g, l, u, [0.0, 0.0], V.make())
+            res = optimize(g, l, u, [0.0, 0.0], V())
             @test feasible(Optim.minimizer(res), l, u)
             @test Optim.minimizer(res) ≈ [2.0, -2.0] atol = 1e-6
         end
@@ -53,7 +40,7 @@ import LBFGSB as RefLBFGSB
             l = [-2.0, -2.0]
             u = [2.0, 2.0]
             x0 = [-1.2, 1.0]
-            rb = optimize(rosen, l, u, x0, V.make())
+            rb = optimize(rosen, l, u, x0, V())
             rf = optimize(rosen, l, u, x0, Fminbox(LBFGS()))
             @test Optim.minimizer(rb) ≈ [1.0, 1.0] atol = 1e-4
             @test Optim.minimizer(rb) ≈ Optim.minimizer(rf) atol = 1e-3
@@ -64,8 +51,8 @@ import LBFGSB as RefLBFGSB
             l = [-2.0, -2.0]
             u = [2.0, 2.0]
             x0 = [-1.2, 1.0]
-            for ls in (V.hzaw(), V.mtls())
-                res = optimize(rosen, l, u, x0, V.make(linesearch = ls))
+            for ls in (parentmodule(V).HZAW(), parentmodule(V).MTLS())
+                res = optimize(rosen, l, u, x0, V(linesearch = ls))
                 @test feasible(Optim.minimizer(res), l, u)
                 @test Optim.minimizer(res) ≈ [1.0, 1.0] atol = 1e-4
             end
@@ -74,25 +61,25 @@ import LBFGSB as RefLBFGSB
         @testset "scalar bounds" begin
             f(x) = sum(abs2, x)
             x0 = [1.0, -2.0, 3.0]
-            res = optimize(f, -5.0, 5.0, x0, V.make())
+            res = optimize(f, -5.0, 5.0, x0, V())
             @test Optim.converged(res)
             @test Optim.minimizer(res) ≈ zeros(3) atol = 1e-6
         end
 
         @testset "one-sided bounds and fixed variables" begin
             g(x) = (x[1] - 3.0)^2 + (x[2] + 4.0)^2
-            res = optimize(g, [1.0, -Inf], [Inf, Inf], [3.0, 0.0], V.make())
+            res = optimize(g, [1.0, -Inf], [Inf, Inf], [3.0, 0.0], V())
             @test Optim.minimizer(res) ≈ [3.0, -4.0] atol = 1e-6
 
-            res2 = optimize(g, [1.0, -10.0], [1.0, 10.0], [1.0, 0.0], V.make())
+            res2 = optimize(g, [1.0, -10.0], [1.0, 10.0], [1.0, 0.0], V())
             @test Optim.minimizer(res2)[1] ≈ 1.0 atol = 1e-8
             @test Optim.minimizer(res2)[2] ≈ -4.0 atol = 1e-6
         end
 
         @testset "type genericity" begin
             f(x) = sum(abs2, x)
-            for ls in (V.hzaw(), V.mtls())
-                res32 = optimize(f, fill(-5.0f0, 3), fill(5.0f0, 3), Float32[1, -2, 3], V.make(linesearch = ls))
+            for ls in (parentmodule(V).HZAW(), parentmodule(V).MTLS())
+                res32 = optimize(f, fill(-5.0f0, 3), fill(5.0f0, 3), Float32[1, -2, 3], V(linesearch = ls))
                 @test eltype(Optim.minimizer(res32)) == Float32
                 @test typeof(Optim.minimum(res32)) == Float32
                 @test Optim.minimum(res32) < 1.0f-8
@@ -103,20 +90,20 @@ import LBFGSB as RefLBFGSB
             rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
             l = [-2.0, -2.0]
             u = [2.0, 2.0]
-            capped = optimize(rosen, l, u, [-1.2, 1.0], V.make(), Optim.Options(iterations = 2))
+            capped = optimize(rosen, l, u, [-1.2, 1.0], V(), Optim.Options(iterations = 2))
             @test Optim.iterations(capped) <= 2
             @test !Optim.converged(capped)
 
             calls = Ref(0)
             cb = state -> (calls[] += 1; state.iteration >= 3)
-            optimize(rosen, l, u, [-1.2, 1.0], V.make(), Optim.Options(callback = cb))
+            optimize(rosen, l, u, [-1.2, 1.0], V(), Optim.Options(callback = cb))
             @test calls[] >= 1
         end
 
         @testset "errors on infeasible start / bad bounds" begin
             f(x) = sum(abs2, x)
-            @test_throws ArgumentError optimize(f, [0.0, 0.0], [1.0, 1.0], [2.0, 0.5], V.make())
-            @test_throws ArgumentError optimize(f, [1.0, 0.0], [0.0, 1.0], [0.5, 0.5], V.make())
+            @test_throws ArgumentError optimize(f, [0.0, 0.0], [1.0, 1.0], [2.0, 0.5], V())
+            @test_throws ArgumentError optimize(f, [1.0, 0.0], [0.0, 1.0], [0.5, 0.5], V())
         end
 
         @testset "high-dimensional active set, clip=$clip" for clip in (true, false)
@@ -126,7 +113,7 @@ import LBFGSB as RefLBFGSB
             l = fill(-1.0, n)
             u = fill(1.0, n)
             xstar = clamp.(c, l, u)
-            res = optimize(f, l, u, zeros(n), V.make(clip_subspace = clip), Optim.Options(g_abstol = 1e-8))
+            res = optimize(f, l, u, zeros(n), V(clip_subspace = clip), Optim.Options(g_abstol = 1e-8))
             @test feasible(Optim.minimizer(res), l, u)
             @test Optim.minimizer(res) ≈ xstar atol = 1e-6
             @test any(Optim.minimizer(res) .≈ -1.0)
@@ -139,14 +126,14 @@ import LBFGSB as RefLBFGSB
             f(x) = sum((x .- c) .^ 2)
             l = fill(-1.0, n)
             u = fill(1.0, n)
-            res = optimize(f, l, u, fill(-1.0, n), V.make())
+            res = optimize(f, l, u, fill(-1.0, n), V())
             @test feasible(Optim.minimizer(res), l, u)
             @test Optim.minimizer(res) ≈ clamp.(c, l, u) atol = 1e-6
         end
 
         @testset "memory length m=$m" for m in (2, 3, 20)
             rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
-            res = optimize(rosen, [-2.0, -2.0], [2.0, 2.0], [-1.2, 1.0], V.make(m = m))
+            res = optimize(rosen, [-2.0, -2.0], [2.0, 2.0], [-1.2, 1.0], V(m = m), Optim.Options(iterations = 2000, g_abstol = 1e-8))
             println(res)
             @test Optim.converged(res)
             @test Optim.minimizer(res) ≈ [1.0, 1.0] atol = 1e-4
@@ -157,7 +144,7 @@ import LBFGSB as RefLBFGSB
             # gradient below g_abstol on Rosenbrock for the efficient solver (the
             # Fortran reference behaves the same); the minimizer is still reached.
             rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
-            res = optimize(rosen, [-2.0, -2.0], [2.0, 2.0], [-1.2, 1.0], V.make(m = 1))
+            res = optimize(rosen, [-2.0, -2.0], [2.0, 2.0], [-1.2, 1.0], V(m = 1))
             @test Optim.minimizer(res) ≈ [1.0, 1.0] atol = 1e-4
         end
 
@@ -166,7 +153,7 @@ import LBFGSB as RefLBFGSB
             l = [-2.0, -2.0]
             u = [2.0, 2.0]
 
-            ext = optimize(rosen, l, u, [-1.2, 1.0], V.make(),
+            ext = optimize(rosen, l, u, [-1.2, 1.0], V(),
                 Optim.Options(store_trace = true, extended_trace = true))
             tr = Optim.trace(ext)
             @test length(tr) >= 1
@@ -174,7 +161,7 @@ import LBFGSB as RefLBFGSB
             @test haskey(tr[end].metadata, "x")
             @test haskey(tr[end].metadata, "g(x)")
 
-            plain = optimize(rosen, l, u, [-1.2, 1.0], V.make(), Optim.Options(store_trace = true))
+            plain = optimize(rosen, l, u, [-1.2, 1.0], V(), Optim.Options(store_trace = true))
             @test !haskey(Optim.trace(plain)[end].metadata, "x")
         end
 
@@ -184,15 +171,15 @@ import LBFGSB as RefLBFGSB
             u = [2.0, 2.0]
             x0 = [-1.2, 1.0]
 
-            r_f = optimize(rosen, l, u, x0, V.make(), Optim.Options(f_calls_limit = 5))
+            r_f = optimize(rosen, l, u, x0, V(), Optim.Options(f_calls_limit = 5))
             @test !Optim.converged(r_f)
             @test r_f.termination_code == Optim.TerminationCode.ObjectiveCalls
 
-            r_g = optimize(rosen, l, u, x0, V.make(), Optim.Options(g_calls_limit = 5))
+            r_g = optimize(rosen, l, u, x0, V(), Optim.Options(g_calls_limit = 5))
             @test !Optim.converged(r_g)
             @test r_g.termination_code == Optim.TerminationCode.GradientCalls
 
-            r_i = optimize(rosen, l, u, x0, V.make(), Optim.Options(iterations = 3))
+            r_i = optimize(rosen, l, u, x0, V(), Optim.Options(iterations = 3))
             @test Optim.iterations(r_i) == 3
             @test r_i.termination_code == Optim.TerminationCode.Iterations
         end
@@ -208,11 +195,11 @@ import LBFGSB as RefLBFGSB
             u = [2.0, 2.0]
             x0 = [-1.2, 1.0]
 
-            r_f = optimize(rosen, g!, l, u, x0, V.make(), Optim.Options(g_abstol = 0.0, f_abstol = 1e-6))
+            r_f = optimize(rosen, g!, l, u, x0, V(), Optim.Options(g_abstol = 0.0, f_abstol = 1e-6))
             @test Optim.converged(r_f)
             @test r_f.termination_code == Optim.TerminationCode.SmallObjectiveChange
 
-            r_x = optimize(rosen, g!, l, u, x0, V.make(), Optim.Options(g_abstol = 0.0, x_abstol = 1e-4))
+            r_x = optimize(rosen, g!, l, u, x0, V(), Optim.Options(g_abstol = 0.0, x_abstol = 1e-4))
             @test Optim.converged(r_x)
             @test r_x.termination_code == Optim.TerminationCode.SmallXChange
         end
@@ -220,7 +207,7 @@ import LBFGSB as RefLBFGSB
         @testset "BigFloat precision" begin
             f(x) = sum(abs2, x)
             res = optimize(f, fill(big(-5.0), 3), fill(big(5.0), 3), big.([1.0, -2.0, 3.0]),
-                V.make(), Optim.Options(g_abstol = big(1e-20)))
+                V(), Optim.Options(g_abstol = big(1e-20)))
             @test eltype(Optim.minimizer(res)) == BigFloat
             @test Optim.minimum(res) < big(1e-18)
         end
@@ -270,7 +257,7 @@ import LBFGSB as RefLBFGSB
                     )
 
                     g! = (G, x) -> copyto!(G, p.grad(x))
-                    res = optimize(p.fval, g!, p.l, p.u, p.x0, V.make(), Optim.Options(g_abstol = 1e-9))
+                    res = optimize(p.fval, g!, p.l, p.u, p.x0, V(), Optim.Options(g_abstol = 1e-9))
 
                     @test feasible(Optim.minimizer(res), p.l, p.u)
                     @test Optim.minimizer(res) ≈ xref atol = 1e-4

--- a/test/multivariate/solvers/constrained/lbfgsb.jl
+++ b/test/multivariate/solvers/constrained/lbfgsb.jl
@@ -134,7 +134,6 @@ import LBFGSB as RefLBFGSB
         @testset "memory length m=$m" for m in (2, 4, 20)
             rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
             res = optimize(rosen, [-2.0, -2.0], [2.0, 2.0], [-1.2, 1.0], V(m = m), Optim.Options(iterations = 2000, g_abstol = 1e-8))
-            println(res)
             @test Optim.converged(res)
             @test Optim.minimizer(res) ≈ [1.0, 1.0] atol = 1e-4
         end

--- a/test/multivariate/solvers/constrained/lbfgsb.jl
+++ b/test/multivariate/solvers/constrained/lbfgsb.jl
@@ -212,6 +212,27 @@ import LBFGSB as RefLBFGSB
             @test Optim.minimum(res) < big(1e-18)
         end
 
+        @testset "active set under $T" for T in (Float32, BigFloat)
+            # Heavily active box (~2/3 of the bounds active at the solution) under a
+            # non-Float64 eltype, exercising the Cauchy point + subspace solve
+            # (Cholesky formk!/bmv! for the efficient port, dense inv for the
+            # reference) end-to-end in T. min Σ(xᵢ - cᵢ)² over [-1, 1]ⁿ has the
+            # analytic minimizer clamp.(c, l, u).
+            n = 12
+            c = collect(range(T(-3), T(3); length = n))
+            f(x) = sum((x .- c) .^ 2)
+            l = fill(T(-1), n)
+            u = fill(T(1), n)
+            xstar = clamp.(c, l, u)
+            gtol, atol = T === BigFloat ? (T(1e-20), T(1e-12)) : (1.0f-5, 1.0f-4)
+            res = optimize(f, l, u, zeros(T, n), V(), Optim.Options(g_abstol = gtol))
+            @test eltype(Optim.minimizer(res)) == T
+            @test feasible(Optim.minimizer(res), l, u)
+            @test Optim.minimizer(res) ≈ xstar atol = atol
+            @test any(Optim.minimizer(res) .≈ T(-1))   # lower bounds active
+            @test any(Optim.minimizer(res) .≈ T(1))    # upper bounds active
+        end
+
         @testset "cross-check vs reference LBFGSB.jl (Fortran)" begin
             refkw = (m = 10, factr = 1e1, pgtol = 1e-9, maxiter = 10_000, maxfun = 10_000)
 

--- a/test/multivariate/solvers/constrained/lbfgsb.jl
+++ b/test/multivariate/solvers/constrained/lbfgsb.jl
@@ -131,7 +131,7 @@ import LBFGSB as RefLBFGSB
             @test Optim.minimizer(res) ≈ clamp.(c, l, u) atol = 1e-6
         end
 
-        @testset "memory length m=$m" for m in (2, 3, 20)
+        @testset "memory length m=$m" for m in (2, 4, 20)
             rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
             res = optimize(rosen, [-2.0, -2.0], [2.0, 2.0], [-1.2, 1.0], V(m = m), Optim.Options(iterations = 2000, g_abstol = 1e-8))
             println(res)

--- a/test/multivariate/solvers/constrained/lbfgsb.jl
+++ b/test/multivariate/solvers/constrained/lbfgsb.jl
@@ -147,6 +147,7 @@ import LBFGSB as RefLBFGSB
         @testset "memory length m=$m" for m in (2, 3, 20)
             rosen(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
             res = optimize(rosen, [-2.0, -2.0], [2.0, 2.0], [-1.2, 1.0], V.make(m = m))
+            println(res)
             @test Optim.converged(res)
             @test Optim.minimizer(res) ≈ [1.0, 1.0] atol = 1e-4
         end

--- a/test/multivariate/solvers/constrained/lbfgsb.jl
+++ b/test/multivariate/solvers/constrained/lbfgsb.jl
@@ -120,6 +120,26 @@ import LBFGSB as RefLBFGSB
             @test any(Optim.minimizer(res) .≈ 1.0)
         end
 
+        @testset "iterate stays strictly in the box at active bounds" begin
+            # The committed step is projected onto [l, u], so the returned
+            # minimizer must satisfy l .<= x .<= u with NO tolerance, and the
+            # active coordinates must land exactly on a bound (not a ULP outside).
+            g(x) = (x[1] - 3.0)^2 + (x[2] + 4.0)^2   # unconstrained min [3, -4]
+            l2, u2 = [-2.0, -2.0], [2.0, 2.0]
+            r1 = optimize(g, l2, u2, [0.0, 0.0], V())
+            @test all(l2 .<= Optim.minimizer(r1) .<= u2)   # strict, no tolerance
+
+            n = 20
+            c = collect(range(-3.0, 3.0; length = n))     # ~2/3 of bounds active
+            f(x) = sum((x .- c) .^ 2)
+            lo, hi = fill(-1.0, n), fill(1.0, n)
+            r2 = optimize(f, lo, hi, zeros(n), V(), Optim.Options(g_abstol = 1e-8))
+            x2 = Optim.minimizer(r2)
+            @test all(lo .<= x2 .<= hi)                    # strict, no tolerance
+            # every coordinate is exactly on a bound or strictly interior
+            @test all(@. (x2 == -1.0) | (x2 == 1.0) | (-1.0 < x2 < 1.0))
+        end
+
         @testset "feasible start on the boundary" begin
             n = 10
             c = collect(range(-3.0, 3.0; length = n))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,6 +62,7 @@ multivariate_tests = [
     ## solvers
     ## constrained
     "solvers/constrained/fminbox",
+    "solvers/constrained/lbfgsb",
     "solvers/constrained/ipnewton/interface",
     "solvers/constrained/ipnewton/constraints",
     "solvers/constrained/ipnewton/counter",


### PR DESCRIPTION
This was a long way coming. I've gone back and forth to an early implementation and tried to implement it. I did some work on HZ over at LineSearches and that made me think of MT again and I wanted better bounds handling than Fminbox that was always such a hack.

I will post some benchmarks against L-BFGS-B v3 through LBFGSB.jl but they look good. I ended up having to look up the code for some of the optimized procedures that allows this to also scale to quite large problems. May not be perfect yet.

Speaking of optimizations, the structs are "big" because I really had to avoid allocations to compete with LBFGSB at high dimensions. In my experiments, this was not exactly as good as the official v3 version of the software. Not sure why.

Let's see. Tests pass locally, CI can be finicky.