### PR TITLE
update CG with theta parameter from HZ2013 and betamax to bound the beta value

### DIFF
--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -44,6 +44,8 @@
 
 struct ConjugateGradient{Tf,T,Tprep,IL,L} <: FirstOrderOptimizer
     eta::Tf
+    theta::Tf
+    betamax::Tf
     P::T
     precondprep!::Tprep
     alphaguess!::IL
@@ -60,6 +62,8 @@ Base.summary(io::IO, ::ConjugateGradient) = print(io, "Conjugate Gradient")
 ConjugateGradient(; alphaguess = LineSearches.InitialHagerZhang(),
 linesearch = LineSearches.HagerZhang(),
 eta = 0.4,
+theta = 1.0,
+betamax = Inf,
 P = nothing,
 precondprep = Returns(nothing),
 manifold = Flat())
@@ -68,6 +72,9 @@ The strictly positive constant ``eta`` is used in determining
 the next step direction, and the default here deviates from the one used in the
 original paper (where it was ``0.01``). See more details in the original papers
 referenced below.
+The non negative constant ``theta`` is also used in determining the next step direction (see HZ2013, Eq 2.2).
+When ``theta = 0``, the step direction switches to Hestenes-Stiefel method.
+The strictly positive constant ``betamax`` is used to ensure that the beta factor is not too large in absolute value.
 
 ## Description
 The `ConjugateGradient` method implements Hager and Zhang (2006) and elements
@@ -83,12 +90,14 @@ function ConjugateGradient(;
     alphaguess = LineSearches.InitialHagerZhang(),
     linesearch = LineSearches.HagerZhang(),
     eta::Real = 0.4,
+    theta::Real = 1.0,
+    betamax::Real = Inf,
     P::Any = nothing,
     precondprep = Returns(nothing),
     manifold::Manifold = Flat(),
 )
 
-    ConjugateGradient(eta, P, precondprep, _alphaguess(alphaguess), linesearch, manifold)
+    ConjugateGradient(eta, theta, betamax, P, precondprep, _alphaguess(alphaguess), linesearch, manifold)
 end
 
 mutable struct ConjugateGradientState{Tx,T,G} <: AbstractOptimizerState
@@ -235,10 +244,11 @@ function accept_step!(d, state::ConjugateGradientState, method::ConjugateGradien
     betak =
         (
             real(dot(state.y, state.pg)) -
-            real(dot(state.y, state.py)) * real(dot(state.g_x, state.s)) / ydots
+            real(dot(state.y, state.py)) * real(dot(state.g_x, state.s)) / ydots * method.theta
         ) / ydots
     # betak may be undefined if ydots is zero (may due to f not strongly convex or non-Wolfe linesearch)
     beta = NaNMath.max(betak, etak) # TODO: Set to zero if betak is NaN?
+    beta = sign(beta) * Base.min(abs(beta), method.betamax) # Ensure beta is not too large in absolute value
     state.beta = beta
     state.s .= beta .* state.s .- state.pg
     project_tangent!(method.manifold, state.s, state.x)

--- a/src/multivariate/solvers/first_order/cg.jl
+++ b/src/multivariate/solvers/first_order/cg.jl
@@ -248,7 +248,7 @@ function accept_step!(d, state::ConjugateGradientState, method::ConjugateGradien
         ) / ydots
     # betak may be undefined if ydots is zero (may due to f not strongly convex or non-Wolfe linesearch)
     beta = NaNMath.max(betak, etak) # TODO: Set to zero if betak is NaN?
-    beta = sign(beta) * Base.min(abs(beta), method.betamax) # Ensure beta is not too large in absolute value
+    beta = clamp(beta, -method.betamax, method.betamax) # Ensure beta is not too large in absolute value
     state.beta = beta
     state.s .= beta .* state.s .- state.pg
     project_tangent!(method.manifold, state.s, state.x)

--- a/test/multivariate/solvers/first_order/cg.jl
+++ b/test/multivariate/solvers/first_order/cg.jl
@@ -14,7 +14,7 @@
         show_name = debug_printing,
     )
 
-    @testset "matrix input" begin
+    @testset "matrix input" for theta in (1.0, 0.0)
         cg_objective(X, B) = sum(abs2, X .- B) / 2
 
         function cg_objective_gradient!(G, X, B)
@@ -29,7 +29,7 @@
             X -> cg_objective(X, B),
             (G, X) -> cg_objective_gradient!(G, X, B),
             rand(2, 2),
-            ConjugateGradient(),
+            ConjugateGradient(theta = theta),
         )
         @test Optim.converged(results)
         @test Optim.minimum(results) < 1e-8
@@ -57,6 +57,7 @@
 
     @testset "Access beta from callback" begin
         # Access beta from callback and check we can apply the same update rule as CG
+        # check also that beta is bounded by betamax
 
         f(x) = 100 - x[1] + exp(x[1] - 100)
         g!(grad, x) = grad[1] = -1 + exp(x[1] - 100)
@@ -67,6 +68,8 @@
         s_k = zeros(1)
         g!(g_k, x0)
         beta_k = 0.0
+        betamax = 0.5
+        check_beta = true
 
         function my_callback(state)
             if iter_global == 0
@@ -80,6 +83,7 @@
                 g_k[1] = state.g_x[1]
                 beta_k = state.beta
                 s_k[1] = -g_k[1] + beta_k * s_k[1]
+                check_beta *= (abs(state.beta) <= betamax)
             end
             iter_global += 1
             return false
@@ -92,9 +96,11 @@
             ConjugateGradient(
                 alphaguess = LineSearches.InitialStatic(alpha = 1.0),
                 linesearch = LineSearches.BackTracking(),
+                betamax = betamax,
             ),
             Optim.Options(iterations = 3, callback = my_callback),
         )
         @test Optim.minimizer(res)[1] ≈ x_global[1]
+        @test check_beta
     end
 end


### PR DESCRIPTION
Add two new parameters to the ConjugateGradient solver
1) The missing `theta` as it appears in the Hager-Zhang 2013 paper, Equation 2.2. The default value is `theta=1` which ensures back compatibility
2) `betamax` to bound the `beta` value (in the absolute sense) which is used in determining the step direction. This is to allow the user to control the magnitude of `beta` and prevent it from overwhelming the gradient at any given iteration. The default value is `betamax=Inf` which has no effect and ensures back compatibility.