### PR TITLE
Fix `solve_tr_subproblem!` leaving the step as `NaN` for (near-)singular Hessians

### DIFF
--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -107,6 +107,7 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
     else
         return T(Inf), false, zero(T), false, false
     end
+    H_scale = max(abs(min_H_ev), abs(max_H_ev)) # spectral norm
     H_ridged = copy(H)
 
     # Cache the inner products between the eigenvectors and the gradient.
@@ -179,10 +180,16 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
                 end
 
                 F = cholesky(Hermitian(H_ridged), check = false)
-                # Sometimes, lambda is not sufficiently large for the Cholesky factorization
-                # to succeed. In that case, we set double lambda and continue to next iteration
+                # Sometimes, λ is not sufficiently large for the Cholesky factorization
+                # to succeed. In that case, we set increase λ and continue to next
+                # iteration. Merely doubling λ is not generally sufficient to make H + λI
+                # numerically positive-definite: e.g., if λ ~ 1e-15, we never reach a stable
+                # regime within  `max_iters`, which would leave `s` unchanged. Instead, jump
+                # to a ridge on the order of H's spectral scale so the next factorization
+                # succeeds; the root-finder can still descend toward a smaller optimal λ
+                # afterwards, since `lambda_lb` is left at its initial value
                 if !issuccess(F)
-                    lambda *= 2
+                    lambda = max(2 * lambda, sqrt(eps(T)) * H_scale)
                     continue
                 end
 

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -181,9 +181,9 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
 
                 F = cholesky(Hermitian(H_ridged), check = false)
                 # Sometimes, λ is not sufficiently large for the Cholesky factorization
-                # to succeed. In that case, we set increase λ and continue to next
-                # iteration. Merely doubling λ is not generally sufficient to make H + λI
-                # numerically positive-definite: e.g., if λ ~ 1e-15, we never reach a stable
+                # to succeed. In that case, we increase λ and continue to next iteration.
+                # Merely doubling λ is not generally sufficient to make H + λI numerically
+                # positive-definite: e.g., if λ ~ 1e-15, we would never reach a stable
                 # regime within  `max_iters`, which would leave `s` unchanged. Instead, jump
                 # to a ridge on the order of H's spectral scale so the next factorization
                 # succeeds; the root-finder can still descend toward a smaller optimal λ

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -268,4 +268,17 @@ Random.seed!(3288)
         )
         @test Optim.termination_code(res) == Optim.TerminationCode.SmallTrustRegionRadius
     end
+
+    @testset "Singular Hessian in TR subproblem solve" begin
+        using Optim
+        H = [1.0 1.0; 1.0 1.0]   # positive-semidefinite, singular: eigenvalues 0 and 2
+        g = [1.0, 1.0]           # gradient in image space of H
+        s = fill(NaN, 2)
+        _, _, λ, hard_case, _ = Optim.solve_tr_subproblem!(g, H, 1.0, s)
+
+        @test !hard_case
+        @test all(isfinite, s)            # correctly update `s` to a finite value
+        @test (H + λ*I)*s ≈ -g atol=1e-6  # solves trust region problem
+        @test all(≥(0), eigvals(H + λ*I)) # positive-definite
+    end
 end


### PR DESCRIPTION
I traced a NaN-coefficients issue in the Newton trust-region method to `solve_tr_subproblem!`. For singular or near-singular Hessians, the solve would not update `state.s` at all - and since it's initialized to `NaN`, it eventually would poison the update of the coefficients vector `state.x` resulting in `NaN` input to `value_gradient!`.

I pointed Claude & Gemini to the `solve_tr_subproblem!` code, and they suggested the following fix which seems reasonable to me.

Unfortunately, I don't have a reduced example of this throwing via `optimize` so the added test just directly works with `solve_tr_subproblem!`.

<details><summary>Robot diagnosis and explanation below</summary>

**Problem.** `solve_tr_subproblem!` (`NewtonTrustRegion`) can return without ever writing the step `s`, leaving it at the `NaN` that `initial_state` allocates into `state.s`. The iterate then becomes `NaN` and the solve breaks (downstream error or silent non-convergence).

**Cause.** When `H` is positive-semidefinite but (numerically) singular, `min_H_ev ≈ 0`, so `lambda_lb = nextfloat(-min_H_ev) ~ 1e-15` — a negligible ridge relative to `‖H‖`. In the non-hard-case branch, `s` is only assigned inside `if issuccess(F)` of the Cholesky loop; with such a tiny ridge `H + λI` is not numerically positive-definite, `cholesky(...; check=false)` fails, and the `lambda *= 2` fallback doubles a `~1e-15` value that stays negligible for all `max_iters` iterations, so `s` is never written. Whether the factorization squeaks through is BLAS/LAPACK-dependent, making the failure platform-specific.

**Fix.** In the Cholesky-failure branch, boost `λ` directly to the scale of `H` (`max(2λ, √eps·‖H‖)`) so the next factorization is guaranteed to succeed. `lambda_lb` is left unchanged, so the root-finder can still converge to a small, high-precision `λ` when one is numerically stable — the well-conditioned path is unaffected.

**Test.** With `H = [1 1; 1 1]`, `g = [1, 1]`, `solve_tr_subproblem!` now returns a finite `s` (previously `[NaN, NaN]`). On a case with a genuinely small optimal `λ ≈ 7.5e-9`, the returned step is unchanged from before this patch (confirming the fix does not perturb well-conditioned solves).

</details>