### PR TITLE
Fix the sign of the hard-case trust region step

### DIFF
--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -157,16 +157,15 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
 
                 tau = sqrt(delta_sq - p_lambda2)
 
-                # I don't think it matters which eigenvector we pick so take
-                # the first.
-                calc_p!(lambda, min_i, n, qg, H_eig, s)
-                LinearAlgebra.axpby!(tau, view(H_eig.vectors, :, 1), -1, s)
+                # Formula 4.45 is s = p + tau*z where z is any unit eigenvector
+                # for the smallest eigenvalue; s already holds p, so add tau
+                # times the first eigenvector.
+                LinearAlgebra.axpy!(tau, view(H_eig.vectors, :, 1), s)
             end
         end
 
-        lambda = initial_safeguards(H, gr, delta, lambda)
-
         if !hard_case
+            lambda = initial_safeguards(H, gr, delta, lambda)
             # Algorithm 4.3 of N&W (2006), with s instead of p_l for consistency
             # with Optim.jl
 

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -132,6 +132,26 @@ Random.seed!(3288)
         @test reached_solution
         @test abs(lambda + L[1]) < 1e-4
         @test abs(norm(s) - delta) < 1e-12
+        # The hard-case step must satisfy the boundary KKT system
+        # (H + lambda*I)s = -gr; the reversed sign +gr also has norm delta
+        # but is not the subproblem minimizer.
+        @test norm((H + lambda * I) * s + gr) < 1e-10
+
+        # An analytically solvable hard case: lambda = 2, p = [0, -1/3],
+        # tau = sqrt(1 - 1/9), s = [±tau, -1/3], m = -7/6.
+        H2 = Matrix(Diagonal([-2.0, 1.0]))
+        gr2 = [0.0, 1.0]
+        s2 = zeros(2)
+        m2, interior2, lambda2, hard_case2, reached_solution2 =
+            Optim.solve_tr_subproblem!(gr2, H2, 1.0, s2)
+        @test hard_case2
+        @test !interior2
+        @test reached_solution2
+        @test abs(lambda2 - 2.0) < 1e-12
+        @test abs(norm(s2) - 1.0) < 1e-12
+        @test abs(s2[2] + 1 / 3) < 1e-12
+        @test abs(abs(s2[1]) - sqrt(8.0) / 3) < 1e-12
+        @test abs(m2 - (-7 / 6)) < 1e-12
 
 
         #######################################


### PR DESCRIPTION
## The bug

In the hard case, `solve_tr_subproblem!` builds the step from formula 4.45 in Nocedal & Wright: `s = p + τz`, where `p` solves `(H + λI)p = -g` on the nondegenerate eigenspace and `z` is a unit eigenvector for the smallest eigenvalue. `calc_p!` already returns `p` with the minus sign applied, but the step was assembled with `axpby!(tau, z, -1, s)`, which computes `τz - p`.

The reversed step has the same norm as the correct one (`p ⊥ z`), so the trust region constraint still holds and `hard_case`/`lambda`/norm checks all pass, but the linear term of the model flips sign: the returned step is not the subproblem minimizer, and the model value used in the ρ acceptance test is inflated by `2·Σ qgᵢ²/(λᵢ+λ)`. On the analytic instance `H = diag(-2, 1)`, `g = [0, 1]`, `Δ = 1`, the returned model value was `-1/2` where the minimizer gives `-7/6`, and the step satisfied `(H + λI)s = +g` instead of `-g`.

## The fix

- Assemble the step with `axpy!(tau, z, s)` so `s = p + τz`.
- Drop the second `calc_p!` call, which recomputed the `p` already held in `s`.
- Move the `initial_safeguards` call into the non-hard-case branch, so the returned `lambda` is the value the hard-case step was actually built with.

## Tests

The existing hard-case test checked `hard_case`, `lambda`, and the step norm, all of which the reversed step also satisfies, which is how this survived. It now also checks the KKT residual `(H + λI)s = -g`, and there is a new analytically solvable 2×2 hard case with a known step and model value (`m = -7/6`). Both new checks fail on master and pass with this change. The full newton_trust_region test file passes.

This PR was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)