### PR TITLE
Fix LBFGSB subspace backtracking to measure from the Cauchy point

### DIFF
--- a/src/multivariate/solvers/constrained/lbfgsb.jl
+++ b/src/multivariate/solvers/constrained/lbfgsb.jl
@@ -753,14 +753,19 @@ function subspace_optimize!(B::CompactLBFGS, x, g, lb, ub; clip::Bool = true)
     end
     du ./= θ
 
-    # Project onto bounds, writing directly into B.xc (each element read before
-    # written at the same index, matching Fortran subsm).
+    # Project onto bounds, writing directly into B.xc. The clamp loop reads each
+    # element before writing the same index, but the dd_p > 0 backtracking below
+    # must measure from the unclamped Cauchy point, so its free components are
+    # stashed first (Fortran subsm keeps them in xp). r is dead once du has been
+    # formed, so its storage is reused.
     x̄ = xc
 
     if clip
+        xp = r
         any_bound_hit = false
         for i = 1:nsub
             k = B.index[i]
+            xp[i] = xc[k]
             x̄[k] = clamp(xc[k] + du[i], lb[k], ub[k])
             if x̄[k] == lb[k] || x̄[k] == ub[k]
                 any_bound_hit = true
@@ -775,16 +780,15 @@ function subspace_optimize!(B::CompactLBFGS, x, g, lb, ub; clip::Bool = true)
             if dd_p > 0
                 α_star = one(T)
                 for i = 1:nsub
-                    k = B.index[i]
                     if du[i] > 0
-                        α_star = min(α_star, (ub[k] - xc[k]) / du[i])
+                        α_star = min(α_star, (ub[B.index[i]] - xp[i]) / du[i])
                     elseif du[i] < 0
-                        α_star = min(α_star, (lb[k] - xc[k]) / du[i])
+                        α_star = min(α_star, (lb[B.index[i]] - xp[i]) / du[i])
                     end
                 end
                 for i = 1:nsub
                     k = B.index[i]
-                    x̄[k] = xc[k] + α_star * du[i]
+                    x̄[k] = xp[i] + α_star * du[i]
                 end
             end
         end

--- a/test/multivariate/solvers/constrained/lbfgsb.jl
+++ b/test/multivariate/solvers/constrained/lbfgsb.jl
@@ -306,4 +306,28 @@ import LBFGSB as RefLBFGSB
             end
         end
     end
+
+    @testset "subspace backtracking measures from the Cauchy point" begin
+        # Box-constrained Rosenbrock instance where the clipped subspace step
+        # hits a bound and the direction to the clamped point is uphill
+        # (dd_p > 0 in subspace_optimize!). The backtracking safeguard must
+        # measure the step to the bounds from the unclamped Cauchy point;
+        # measuring from the already-clamped values collapses the step onto the
+        # flagged point, and the solver then recovers only by discarding its
+        # full history (65 objective evaluations on this instance instead of 44).
+        rosen2(x) = (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
+        function rosen2_g!(G, x)
+            G[1] = -2.0 * (1.0 - x[1]) - 400.0 * (x[2] - x[1]^2) * x[1]
+            G[2] = 200.0 * (x[2] - x[1]^2)
+            G
+        end
+        l = [-0.6246061824346689, -1.3848789693740542]
+        u = [1.2952187059881008, 0.42144488961717363]
+        x0 = [-0.6246061824346689, 0.42144488961717363]
+        res = optimize(rosen2, rosen2_g!, l, u, x0, LBFGSB(m = 5))
+        @test Optim.converged(res)
+        @test feasible(Optim.minimizer(res), l, u)
+        @test Optim.minimum(res) ≈ 0.12234569775490675 atol = 1e-8
+        @test Optim.f_calls(res) <= 55
+    end
 end


### PR DESCRIPTION
## The bug

In `subspace_optimize!`'s `clip` branch, `x̄` aliases `B.xc`, so the clamp loop overwrites the Cauchy point before the `dd_p > 0` backtracking safeguard reads it. Any component clamped at a bound with `du` pointing into it then yields a zero step-to-bound ratio, `α_star` collapses to 0, and the safeguard returns exactly the clamped point it was meant to repair. Fortran `subsm` keeps the unclamped values in `xp` for this purpose, and `simple_lbfgsb.jl` copies before clamping.

The caller detects the resulting ascent direction (`dφ0 ≥ 0`) and recovers by discarding the full L-BFGS-B history and redoing the step, so the safeguard being a no-op mostly costs work rather than correctness. Instrumented on a 1,000-problem battery of box-constrained problems (random quadratics, Rosenbrock, exponential objectives): the branch fired 206 times, the collapsed `α_star = 0` outcome occurred on every firing, and the correctly backtracked step had a strictly negative directional derivative every time. On the 40 triggering Rosenbrock instances, the history-reset recovery cost ~15% more iterations and ~18% more objective evaluations. An A/B rerun of the full battery with the fix showed it is never worse: identical final minima on 993 problems, strictly better on 7 (largest objective gap 1.8), and one additional problem converging, so the recovery does not always reach the same final answer.

## The fix

Stash the free components of the Cauchy point in the clamp loop, reusing the reduced-gradient buffer `r` (dead once `du` has been formed, so no new allocation), and compute both the backtracking ratios and the backtracked point from the stashed values, matching `xp` in Fortran `subsm`.

## Tests

Adds a deterministic regression test: a 2-variable box-constrained Rosenbrock instance that reliably enters the `dd_p > 0` branch. It asserts convergence, the known minimum, and an objective-evaluation bound (the fixed build uses 44 evaluations, master uses 65). The bound fails on master and passes with the fix. The full L-BFGS-B test file passes (200 tests, including the cross-check against the Fortran reference wrapper).

This PR was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)