### PR TITLE
Stop four tests depending on which machine CI lands on

### DIFF
--- a/test/multivariate/fdtime.jl
+++ b/test/multivariate/fdtime.jl
@@ -32,7 +32,7 @@
 
                 show_time && @time Optim.optimize(input..., prob.initial_x, method, options)
 
-                @test Optim.converged(results)
+                @test converged_or_fd_floor(results, method, i)
                 @test Optim.minimum(results) <
                       prob.minimum + sqrt(eps(typeof(prob.minimum)))
                 @test norm(Optim.minimizer(results) - prob.solutions) < 1e-2

--- a/test/multivariate/solvers/first_order/ngmres.jl
+++ b/test/multivariate/solvers/first_order/ngmres.jl
@@ -134,11 +134,12 @@ end
         Optim.Options(extended_trace = true, store_trace = true; defopts...),
     )
     @test Optim.converged(res)
-    # The bounds are due to different systems behaving differently
-    # TODO: is it a bad idea to hardcode these?
+    # The bounds are due to different systems behaving differently. Two regimes
+    # have been observed for the call counts, 234 and 249, so the bounds carry
+    # enough slack to cover both and leave room for a third.
     @test 72 < Optim.iterations(res) < 100
-    @test 245 < Optim.f_calls(res) < 310
-    @test 245 < Optim.g_calls(res) < 310
+    @test 200 < Optim.f_calls(res) < 350
+    @test 200 < Optim.g_calls(res) < 350
 
     @test Optim.minimum(res) < 1e-10
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,21 @@ input_tuple(method::Optim.SecondOrderOptimizer, prob) = (
     (MVP.objective(prob), MVP.gradient(prob), MVP.hessian(prob)),
 )
 
+# The first input passes the objective alone, so the gradient is finite
+# differenced. Central differences bottom out around eps^(1/3) relative, well
+# above the default g_tol of 1e-8, so whether these runs report convergence
+# comes down to the rounding of the machine they land on. Accept a gradient
+# that is at the finite-difference floor; the minimum and minimizer assertions
+# still pin down the answer.
+const FD_GRADIENT_TOL = 1e-6
+
+fd_gradient_input(method, i) =
+    i == 1 && method isa Union{Optim.FirstOrderOptimizer,Optim.SecondOrderOptimizer}
+
+converged_or_fd_floor(results, method, i) =
+    Optim.converged(results) ||
+    (fd_gradient_input(method, i) && Optim.g_residual(results) < FD_GRADIENT_TOL)
+
 function test_summary(x, ref::String)
     @test summary(x) == ref
     io = IOBuffer()
@@ -189,9 +204,9 @@ function run_optim_tests(
                 show_itcalls &&
                     printstyled("hvp-calls: ", Optim.hvp_calls(results), "\n"; color = :red)
                 if !((name, i) in convergence_exceptions)
-                    @test Optim.converged(results)
+                    @test converged_or_fd_floor(results, method, i)
                     # Print on error, easier to debug CI
-                    if !(Optim.converged(results))
+                    if !converged_or_fd_floor(results, method, i)
                         printstyled(
                             name,
                             " did not converge with i = ",


### PR DESCRIPTION
Four assertions pass or fail depending on which runner the job gets, for the same commit. They have appeared on three unrelated branches this week:

| Branch | Diff | Failing job |
|---|---|---|
| #1270 `pkm/ntr-hard-case` | `newton_trust_region.jl` + test | Julia min - ubuntu |
| #1271 `codex/public-converged-api` | `src/Optim.jl`, `test/runtests.jl` | Julia lts - windows |
| `pkm/lbfgsb-subsm-backtrack` | `lbfgsb.jl` + test | Julia min - windows |

An export-only change reproduces it, so the trigger is not in any of those diffs. In run [31968977225](https://github.com/JuliaNLSolvers/Optim.jl/actions/runs/31968977225), `Julia lts - ubuntu-latest` passed and `Julia min - ubuntu-latest` failed while resolving identical versions on identical runner image `20260810.271.1`; `julia = "1.10"` makes min and lts collide on 1.10.12. Same stack, opposite results.

Dependency versions are not involved. Running the four cases on one machine under both the last-green-master version set and today's gives bit-identical output, to the last digit:

```
old: OACCEL iters=89 f_calls=249 g_calls=249
     LBFGS ExtRosenbrock(FD) converged=true iters=59 |g|=2.430936202504215e-9
new: OACCEL iters=89 f_calls=249 g_calls=249
     LBFGS ExtRosenbrock(FD) converged=true iters=59 |g|=2.430936202504215e-9
```

## O-ACCEL call counts

`245 < calls < 310` in `ngmres.jl`. Every failing job reports exactly `234`; an arm64 machine reports `249`, four counts above the lower bound. Two floating-point regimes, and the band only covered one of them. Widened to `200 < calls < 350`. The comment now records both observed values in place of the old `TODO: is it a bad idea to hardcode these?`.

The iterations bound `72 < iterations < 100` is untouched, since both regimes land inside it.

## Finite-differenced gradients against g_tol

`run_optim_tests` and `fdtime.jl` both assert `Optim.converged(results)` on the objective-only input. That input finite differences the gradient, and Optim's default is `AutoFiniteDiff(fdtype = Val(:central))`. Central differences bottom out well above the default `g_tol` of 1e-8, so the failing runs report `|g| = 2.91e-08` at `f = 1.13e-15`: a converged answer missing a tolerance it cannot reach.

New shared helper in `test/runtests.jl`:

```julia
const FD_GRADIENT_TOL = 1e-6

fd_gradient_input(method, i) =
    i == 1 && method isa Union{Optim.FirstOrderOptimizer,Optim.SecondOrderOptimizer}

converged_or_fd_floor(results, method, i) =
    Optim.converged(results) ||
    (fd_gradient_input(method, i) && Optim.g_residual(results) < FD_GRADIENT_TOL)
```

I picked this over loosening `g_tol` in `Optim.Options`, which would have changed stopping behaviour for every method and problem in the harness and risked new `minimizer` failures. This version only ever turns a failure into a pass, so it cannot introduce failures elsewhere in the matrix. `g_residual` is short-circuited away for zeroth-order methods, where it is `NaN`. The `minimum` and `minimizer` assertions are unchanged and still pin down the answer.

Deliberately left alone: the `@test_broken` count bounds in the N-GMRES set and the `elseif test_broken` convergence branch. Relaxing those would flip them to an unexpected pass, which is itself a failure.

Full suite passes locally on Julia 1.10.11, with no failures and no unexpected passes.

This PR was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
