### PR TITLE
Guard the trust region radius against rejected runaway steps

### DIFF
--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -98,6 +98,9 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
     # symmetric.  (Julia issue #17093)
     Hsym = Symmetric(H)
     if any(!isfinite, Hsym)
+        # Leave a well-defined (zero) step behind: callers read s after this
+        # returns, and a stale or NaN-filled s poisons the radius update.
+        fill!(s, zero(T))
         return T(Inf), false, zero(T), false, false
     end
     H_eig = eigen(Hsym)
@@ -105,6 +108,7 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
     if !isempty(H_eig.values)
         min_H_ev, max_H_ev = H_eig.values[1], H_eig.values[n]
     else
+        fill!(s, zero(T))
         return T(Inf), false, zero(T), false, false
     end
     H_scale = max(abs(min_H_ev), abs(max_H_ev)) # spectral norm
@@ -412,7 +416,12 @@ function update_state!(d::TwiceDifferentiable, state::NewtonTrustRegionState, me
         # steps reducing delta by constant factors while each solution
         # will be the same. If this keeps on happening it could be a sign
         # errors in the gradient or a non-differentiability at the optimum.
-        state.delta = norm(state.s) / 4
+        # A rejection must never enlarge the radius: an unconverged subproblem
+        # can return ‖s‖ far above delta (and a non-finite H can make it NaN),
+        # and norm(s)/4 alone would then blow the radius up instead of
+        # shrinking it, so cap by the current delta.
+        s_norm = norm(state.s)
+        state.delta = (isfinite(s_norm) ? min(state.delta, s_norm) : state.delta) / 4
     elseif state.rho < method.rho_lower
         state.delta /= 4
     elseif (state.rho > method.rho_upper) && !state.interior

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -301,4 +301,13 @@ Random.seed!(3288)
         @test (H + λ*I)*s ≈ -g atol=1e-6  # solves trust region problem
         @test all(≥(0), eigvals(H + λ*I)) # positive-definite
     end
+    @testset "non-finite Hessian leaves a well-defined zero step" begin
+        H = [1.0 0.0; 0.0 NaN]
+        g = [1.0, 1.0]
+        s = fill(NaN, 2)
+        m, interior, λ, hard_case, reached = Optim.solve_tr_subproblem!(g, H, 1.0, s)
+        @test m == Inf
+        @test !reached
+        @test all(iszero, s)
+    end
 end


### PR DESCRIPTION
Two related gaps around `solve_tr_subproblem!`.

**Unassigned step on early returns.** The non-finite-Hessian and empty-eigenvalue returns left `s` untouched, so the caller read the NaN fill from `initial_state` on iteration 1, or a stale step later. Those paths now zero `s`: a zero step is rejected downstream and shrinks the radius instead of poisoning it.

**Rejection can enlarge the radius.** `state.delta = norm(state.s) / 4` on a rejected step is only a shrink when `norm(s) ≤ delta`. An unconverged root-finding solve can hand back a step orders of magnitude longer than the radius: on Extended Powell with a finite-difference Hessian, a solve at `delta = 0.25` returned a step of norm 1542, the "shrink" reset the radius to 385, and the solver locked into a reject-explode cycle until the iteration cap. The update is now `min(delta, norm(s)) / 4`, falling back to `delta / 4` when `norm(s)` is not finite, so a rejection always shrinks.

Adds a subproblem-level test that a non-finite Hessian leaves a well-defined zero step. The reject-explode cycle itself is exercised end to end by the standard `run_optim_tests` suite once the interior-classification follow-up lands on top of this (that change makes Extended Powell with an approximated Hessian reach the cycle deterministically without this guard).

Verified: `Subproblems I/II` and the PSD/interior sweep at 0 fails, the NewtonTrustRegion test file green, full suite green.

This PR was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)