### PR TITLE
Classify interior solutions of the trust region subproblem at lambda_lb

### DIFF
--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -98,6 +98,9 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
     # symmetric.  (Julia issue #17093)
     Hsym = Symmetric(H)
     if any(!isfinite, Hsym)
+        # Leave a well-defined (zero) step behind: callers read s after this
+        # returns, and a stale or NaN-filled s poisons the radius update.
+        fill!(s, zero(T))
         return T(Inf), false, zero(T), false, false
     end
     H_eig = eigen(Hsym)
@@ -105,6 +108,7 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
     if !isempty(H_eig.values)
         min_H_ev, max_H_ev = H_eig.values[1], H_eig.values[n]
     else
+        fill!(s, zero(T))
         return T(Inf), false, zero(T), false, false
     end
     H_scale = max(abs(min_H_ev), abs(max_H_ev)) # spectral norm
@@ -412,7 +416,12 @@ function update_state!(d::TwiceDifferentiable, state::NewtonTrustRegionState, me
         # steps reducing delta by constant factors while each solution
         # will be the same. If this keeps on happening it could be a sign
         # errors in the gradient or a non-differentiability at the optimum.
-        state.delta = norm(state.s) / 4
+        # A rejection must never enlarge the radius: an unconverged subproblem
+        # can return ‖s‖ far above delta (and a non-finite H can make it NaN),
+        # and norm(s)/4 alone would then blow the radius up instead of
+        # shrinking it, so cap by the current delta.
+        s_norm = norm(state.s)
+        state.delta = (isfinite(s_norm) ? min(state.delta, s_norm) : state.delta) / 4
     elseif state.rho < method.rho_lower
         state.delta /= 4
     elseif (state.rho > method.rho_upper) && !state.interior

--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -169,7 +169,39 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
             end
         end
 
-        if !hard_case
+        # ‖s(lambda)‖ decreases in lambda, so over the feasible range it is
+        # largest at lambda_lb. If even that step lies inside the region there is
+        # no boundary solution to find, and the minimizer is the interior step at
+        # lambda_lb. A direction with H_eig.values[i] + lambda_lb ≈ 0 sends
+        # ‖s‖ to infinity unless its gradient component vanishes, in which case
+        # it drops out of the sum and out of the step. "Vanishes" is judged on
+        # the gradient's own scale: comparing qg against an H-scaled tolerance
+        # drops components whose qg/d ratio is large, which truncates the step.
+        null_tol = sqrt(eps(T)) * max(one(T), H_scale)
+        gr_tol = sqrt(eps(T)) * norm(gr)
+        norm2_lb = zero(T)
+        first_nz = 1
+        boundary_solution_exists = false
+        for i = 1:n
+            d = H_eig.values[i] + lambda_lb
+            if d <= null_tol
+                first_nz = i + 1
+                if abs(qg[i]) > gr_tol
+                    boundary_solution_exists = true
+                    break
+                end
+            else
+                norm2_lb += (qg[i] / d)^2
+            end
+        end
+        interior_at_lb = !boundary_solution_exists && norm2_lb <= delta_sq
+
+        if !hard_case && interior_at_lb
+            calc_p!(lambda_lb, first_nz, n, qg, H_eig, s)
+            interior = true
+            reached_solution = true
+            lambda = lambda_lb
+        elseif !hard_case
             lambda = initial_safeguards(H, gr, delta, lambda)
             # Algorithm 4.3 of N&W (2006), with s instead of p_l for consistency
             # with Optim.jl

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -290,16 +290,23 @@ Random.seed!(3288)
     end
 
     @testset "Singular Hessian in TR subproblem solve" begin
-        using Optim
         H = [1.0 1.0; 1.0 1.0]   # positive-semidefinite, singular: eigenvalues 0 and 2
         g = [1.0, 1.0]           # gradient in image space of H
         s = fill(NaN, 2)
-        _, _, λ, hard_case, _ = Optim.solve_tr_subproblem!(g, H, 1.0, s)
+        m, interior, λ, hard_case, reached = Optim.solve_tr_subproblem!(g, H, 1.0, s)
 
         @test !hard_case
         @test all(isfinite, s)            # correctly update `s` to a finite value
         @test (H + λ*I)*s ≈ -g atol=1e-6  # solves trust region problem
-        @test all(≥(0), eigvals(H + λ*I)) # positive-definite
+        # Positive-semidefinite up to eigensolver noise: λ sits one ulp above
+        # -min_H_ev, so the smallest eigenvalue of H + λI is zero to rounding.
+        @test all(≥(-sqrt(eps())), eigvals(H + λ*I))
+        # The minimizer is the interior pseudo-inverse step s = -[0.5, 0.5]
+        # with ‖s‖ = 0.707 < delta = 1 and model value -0.5.
+        @test reached
+        @test interior
+        @test m ≈ -0.5 atol = 1e-8
+        @test s ≈ [-0.5, -0.5] atol = 1e-6
     end
     @testset "non-finite Hessian leaves a well-defined zero step" begin
         H = [1.0 0.0; 0.0 NaN]

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -301,4 +301,13 @@ Random.seed!(3288)
         @test (H + λ*I)*s ≈ -g atol=1e-6  # solves trust region problem
         @test all(≥(0), eigvals(H + λ*I)) # positive-definite
     end
+    @testset "non-finite Hessian leaves a well-defined zero step" begin
+        H = [1.0 0.0; 0.0 NaN]
+        g = [1.0, 1.0]
+        s = fill(NaN, 2)
+        m, interior, λ, hard_case, reached = Optim.solve_tr_subproblem!(g, H, 1.0, s)
+        @test m == Inf
+        @test !reached
+        @test all(iszero, s)
+    end
 end


### PR DESCRIPTION
Stacked on #1275 (base is that branch; retarget to master after it merges).

## The gap

For a PSD-singular Hessian whose gradient lies in the range space, e.g. `H = [1 1; 1 1]`, `g = [1, 1]`, `delta = 1`, the subproblem minimizer is the interior pseudo-inverse step (`‖s‖ = 0.707 < delta`, model value `-0.5`). The root-finding loop cannot classify it: `interior = false` is assigned once and never revisited, no boundary root exists (`‖s(λ)‖` never reaches delta above `lambda_lb`), and λ halves toward `lambda_lb` until `max_iters`, so `reached_solution = false` too. #1266 made the step finite for these Hessians; the flags stayed wrong and the answer came from an unconverged solve.

## The fix

`‖s(λ)‖` is decreasing in λ, so over the feasible range it is largest at `lambda_lb`. Test that norm via the eigendecomposition already in hand, before the root-finding loop: if even the `lambda_lb` step lies inside the region, no boundary solution exists and the interior step at `lambda_lb` is exact (KKT residual ~3e-16 on the reproducer, 0 root-finding iterations, scaled 1e±6 variants included).

One subtlety that a first version of this change got wrong: near-null directions (`H_eig.values[i] + lambda_lb ≈ 0`) may be dropped as null only when their gradient component vanishes **on the gradient's own scale** (`sqrt(eps)·‖g‖`). Judging them against an H-scaled tolerance drops components whose `qg/d` ratio is still large, which truncates the step: Extended Powell with an approximated Hessian then stalls at `f = 0.082` (the dropped component there had `(qg/d)² ≈ 7e23`). With the gradient-scaled test, that problem converges in 24 iterations, and the standard `run_optim_tests` sweep passes.

## Tests

The singular-Hessian testset now asserts the flags and the exact interior answer (`reached`, `interior`, `m ≈ -0.5`, `s ≈ [-0.5, -0.5]`) instead of discarding them, drops a redundant `using Optim`, and the semidefinite eigenvalue check carries a rounding margin: λ now sits one ulp above `-min_H_ev`, so the smallest eigenvalue of `H + λI` is zero to rounding.

Verified: `Subproblems I/II` and the PSD/interior sweep at 0 fails; the NewtonTrustRegion file green including `run_optim_tests` (which fails without the gradient-scaled null test, and locks up without #1275's radius guard: an unconverged solve after these interior iterates otherwise re-inflates the radius).

This PR was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)