### PR TITLE
Honor f_abstol and x_reltol in NewtonTrustRegion convergence checks

### DIFF
--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -447,7 +447,10 @@ end
 
 function assess_convergence(state::NewtonTrustRegionState, d, options::Options)
     if state.rho > state.eta
-        # Accept the point and check convergence
+        # Accept the point and check convergence against all five tolerances,
+        # like the default path used by the first-order solvers. The 8-argument
+        # method only honors x_abstol and f_reltol, silently ignoring x_reltol
+        # and f_abstol.
         return assess_convergence(
             state.x,
             state.x_previous,
@@ -455,6 +458,8 @@ function assess_convergence(state::NewtonTrustRegionState, d, options::Options)
             state.f_x_previous,
             state.g_x,
             options.x_abstol,
+            options.x_reltol,
+            options.f_abstol,
             options.f_reltol,
             options.g_abstol,
         )

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -301,4 +301,24 @@ Random.seed!(3288)
         @test (H + λ*I)*s ≈ -g atol=1e-6  # solves trust region problem
         @test all(≥(0), eigvals(H + λ*I)) # positive-definite
     end
+    @testset "f_abstol and x_reltol terminate the solver" begin
+        # A shifted flat quartic: near the start the objective barely changes,
+        # so a loose f_abstol should stop the run long before g_abstol does.
+        f(x) = (x[1] - 5.0)^4 + 1.0
+        g!(G, x) = (G[1] = 4.0 * (x[1] - 5.0)^3; G)
+        h!(H, x) = (H[1, 1] = 12.0 * (x[1] - 5.0)^2; H)
+        d2 = TwiceDifferentiable(f, g!, h!, [0.0])
+        res = Optim.optimize(d2, [0.0], NewtonTrustRegion(),
+            Optim.Options(f_abstol = 1e-3, g_abstol = 0.0, iterations = 10_000))
+        @test Optim.f_converged(res)
+        # With f_abstol honored this stops at 11 iterations; ignoring it, the
+        # run only ends at 30 when the f change rounds to exactly zero.
+        @test Optim.iterations(res) <= 15
+
+        d3 = TwiceDifferentiable(f, g!, h!, [0.0])
+        res = Optim.optimize(d3, [0.0], NewtonTrustRegion(),
+            Optim.Options(x_reltol = 1e-3, g_abstol = 0.0, iterations = 10_000))
+        @test Optim.x_converged(res)
+        @test Optim.iterations(res) < 10_000
+    end
 end


### PR DESCRIPTION
NewtonTrustRegion routed its convergence assessment through the 8-argument `assess_convergence`, which tests only `x_abstol`, relative `f_reltol`, and `g_abstol`. Setting `options.f_abstol` or `options.x_reltol` was a silent no-op for this solver only; every solver on the default 10-argument path honors all five tolerances. This routes NewtonTrustRegion through the 10-argument method.

Defaults are unaffected: the added tolerances default to 0.0, and the rejected-step branch already returns all-false for repeated iterates.

Tests: on a flat shifted quartic where `g_abstol` alone would not stop the run, `f_abstol = 1e-3` now terminates at 11 iterations (previously 30, ending only when the objective change rounded to exactly zero), and `x_reltol = 1e-3` terminates with `x_converged` (previously it misreported `f_converged` from that same exact-zero rounding). Both assertions fail on master.

Verified: NewtonTrustRegion test file green; sweeps unaffected (no subproblem changes).

This PR was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)