### PR TITLE
Remove the write-only g_x_previous from NewtonTrustRegionState

### DIFF
--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -3,7 +3,7 @@
 #
 # Args:
 #  H_eigv: The eigenvalues of H, low to high
-#  qg: The inner product of the eigenvalues and the gradient in the same order
+#  qg: The inner products of the eigenvectors and the gradient, in the same order
 #
 # Returns:
 #  hard_case: Whether it is a candidate for the hard case
@@ -318,7 +318,6 @@ mutable struct NewtonTrustRegionState{Tx,T,Tg,TH} <: AbstractOptimizerState
     H_x::TH
     f_x::T
     x_previous::Tx
-    g_x_previous::Tg
     f_x_previous::T
     s::Tx
     x_cache::Tx
@@ -351,7 +350,6 @@ function initial_state(method::NewtonTrustRegion, options, d, x0)
         copy(H_x), # Maintain current Hessian in state.H_x
         f_x, # Maintain current f in state.f_x
         fill!(similar(x0), NaN), # Maintain previous state in state.x_previous
-        fill!(similar(g_x), NaN), # Store previous gradient in state.g_x_previous
         oftype(f_x, NaN), # Store previous f in state.f_x_previous
         fill!(similar(x0), NaN), # Maintain current search direction in state.s
         fill!(similar(x0), NaN), # Cache to be able to reset state.x
@@ -440,7 +438,6 @@ function update_state!(d::TwiceDifferentiable, state::NewtonTrustRegionState, me
 
         # Update history
         copyto!(state.x_previous, state.x_cache)
-        copyto!(state.g_x_previous, state.g_cache)
         state.f_x_previous = f_cache
     else
         # Reset state


### PR DESCRIPTION
Two zero-behavior cleanups in `newton_trust_region.jl`:

- `NewtonTrustRegionState.g_x_previous` was NaN-initialized, written once from `g_cache` on accepted steps, and never read anywhere: NewtonTrustRegion does not go through `perform_linesearch!` (whose write is `hasproperty`-guarded anyway), and every other `g_x_previous` consumer (BFGS, L-BFGS, CG, N-GMRES) has its own state type. Field, initializer, and the copy are removed.
- The header comment described `qg` as the inner product of the eigen**values** and the gradient; it is the eigen**vectors** (`qg = H_eig.vectors' * gr`).

Note `state.eta` looks similarly redundant but is load-bearing: `assess_convergence(state, d, options)` has no `method` argument, so the copy in state is how the acceptance threshold reaches it. Left alone.

Verified: NewtonTrustRegion test file green.

This PR was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)