### PR TITLE
Make the trust region subproblem thresholds scale- and type-aware

### DIFF
--- a/src/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/src/multivariate/solvers/second_order/newton_trust_region.jl
@@ -4,12 +4,18 @@
 # Args:
 #  H_eigv: The eigenvalues of H, low to high
 #  qg: The inner products of the eigenvectors and the gradient, in the same order
+#  ev_tol: Eigenvalues within ev_tol of H_eigv[1] belong to the bottom cluster.
+#          Scale it to the Hessian (symmetric eigensolvers carry absolute error
+#          on the order of eps times the spectral norm).
+#  qg_tol: Gradient components below qg_tol count as zero: below the
+#          gradient's own noise floor, or too small for the boundary root
+#          they induce to be resolvable by the ridged solves.
 #
 # Returns:
 #  hard_case: Whether it is a candidate for the hard case
 #  lambda_index: The index of the first lambda not equal to the smallest
 #                eigenvalue, which is only correct if hard_case is true.
-function check_hard_case_candidate(H_eigv, qg)
+function check_hard_case_candidate(H_eigv, qg, ev_tol, qg_tol)
     @assert length(H_eigv) == length(qg)
     if H_eigv[1] >= 0
         # The hard case is only when the smallest eigenvalue is negative.
@@ -21,11 +27,11 @@ function check_hard_case_candidate(H_eigv, qg)
     while !hard_case_check_done
         if lambda_index > length(H_eigv)
             hard_case_check_done = true
-        elseif abs(H_eigv[1] - H_eigv[lambda_index]) > 1e-10
+        elseif abs(H_eigv[1] - H_eigv[lambda_index]) > ev_tol
             # The eigenvalues are reported in order.
             hard_case_check_done = true
         else
-            if abs(qg[lambda_index]) > 1e-10
+            if abs(qg[lambda_index]) > qg_tol
                 hard_case_check_done = true
                 hard_case = false
             end
@@ -75,7 +81,10 @@ end
 #  H:  The Hessian
 #  delta:  The trust region size, ||s|| <= delta
 #  s: Memory allocated for the step size, updated in place
-#  tolerance: The convergence tolerance for root finding
+#  tolerance: The convergence tolerance for root finding. The default
+#      (`nothing`) resolves to eps(T)^(2/3) times the width of the bracket
+#      containing the boundary root, which reproduces the historical absolute
+#      1e-10 at unit scale in Float64; pass a Real to override it.
 #  max_iters: The maximum number of root finding iterations
 #
 # Returns:
@@ -85,7 +94,7 @@ end
 #  hard_case - Whether or not it was a "hard case" as described by N&W (2006)
 #  reached_solution - Whether or not a solution was reached (as opposed to
 #      terminating early due to max_iters)
-function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
+function solve_tr_subproblem!(gr, H, delta, s; tolerance = nothing, max_iters = 5)
     T = eltype(gr)
     n = length(gr)
     delta_sq = delta^2
@@ -112,6 +121,27 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
         return T(Inf), false, zero(T), false, false
     end
     H_scale = max(abs(min_H_ev), abs(max_H_ev)) # spectral norm
+    gr_norm = norm(gr)
+
+    if iszero(H_scale)
+        # H == 0: the model is linear, and every tolerance below degenerates.
+        # The minimizer over the ball is the boundary Cauchy point, or the
+        # origin for a zero gradient; both are exact.
+        if iszero(gr_norm)
+            fill!(s, zero(T))
+            return zero(T), true, zero(T), false, true
+        else
+            s .= (-delta / gr_norm) .* gr
+            return -delta * gr_norm, false, gr_norm / delta, false, true
+        end
+    end
+
+    # All classification thresholds are relative and typed. Eigenvalue-space
+    # quantities compare against the spectral norm; gradient-space quantities
+    # (the qg components) compare against the gradient norm.
+    scale_tol = sqrt(eps(T)) * H_scale
+    gr_tol = sqrt(eps(T)) * gr_norm
+
     H_ridged = copy(H)
 
     # Cache the inner products between the eigenvectors and the gradient.
@@ -123,12 +153,14 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
     hard_case = false
     reached_solution = true
 
-    # Unconstrained solution
-    if min_H_ev >= 1e-8
+    # Unconstrained solution. The gate is a relative condition test: the
+    # historical absolute 1e-8 misread scaled Hessians in both directions.
+    positive_definite = min_H_ev > scale_tol
+    if positive_definite
         calc_p!(zero(T), 1, n, qg, H_eig, s)
     end
 
-    if min_H_ev >= 1e-8 && sum(abs2, s) <= delta_sq
+    if positive_definite && sum(abs2, s) <= delta_sq
         # No shrinkage is necessary: -(H \ gr) is the minimizer
         interior = true
         reached_solution = true
@@ -138,12 +170,36 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
 
         # The hard case is when the gradient is orthogonal to all
         # eigenvectors associated with the lowest eigenvalue.
-        hard_case_candidate, min_i = check_hard_case_candidate(H_eig.values, qg)
+        # A gradient component along the bottom cluster counts as zero for
+        # hard-case candidacy when it is below the gradient's noise floor, or
+        # when it is too small for the boundary root it induces to be
+        # resolvable: that root sits within qg/delta of -min_H_ev, and the
+        # ridged solves cannot resolve offsets below sqrt(eps)*H_scale. The
+        # conditioning floor applies only here, where min_H_ev < 0; the
+        # interior classification below computes its step in the eigenbasis,
+        # where such components are resolvable and must not be dropped.
+        qg_tol = max(gr_tol, scale_tol * delta)
+        hard_case_candidate, min_i =
+            check_hard_case_candidate(H_eig.values, qg, scale_tol, qg_tol)
 
-        # Solutions smaller than this lower bound on lambda are not allowed:
-        # they don't ridge H enough to make H_ridge PSD.
-        lambda_lb = nextfloat(-min_H_ev)
+        # The multiplier is bounded below by feasibility (lambda >= 0) and by
+        # positive semidefiniteness of H + lambda*I, and above by the root of
+        # the norm bound ‖s(lambda)‖ <= ‖g‖/(min_H_ev + lambda) (Geyer's
+        # lambda_up; also p. 558 of [MORESORENSEN]).
+        lambda_lb = max(zero(T), nextfloat(-min_H_ev))
+        lambda_ub = gr_norm / delta - min_H_ev
         lambda = lambda_lb
+
+        # The boundary root lives inside [lambda_lb, lambda_ub], an interval of
+        # width at most ‖g‖/delta, so the increment tolerance scales with the
+        # bracket width, floored by a few ulps of the iterates' own magnitude.
+        # eps^(2/3) reproduces the historical absolute 1e-10 at unit scale.
+        lambda_tol =
+            tolerance === nothing ?
+            max(
+                cbrt(eps(T))^2 * (lambda_ub - lambda_lb),
+                4 * eps(T) * lambda_ub,
+            ) : T(tolerance)
 
         hard_case = false
         if hard_case_candidate
@@ -177,14 +233,15 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
         # it drops out of the sum and out of the step. "Vanishes" is judged on
         # the gradient's own scale: comparing qg against an H-scaled tolerance
         # drops components whose qg/d ratio is large, which truncates the step.
-        null_tol = sqrt(eps(T)) * max(one(T), H_scale)
-        gr_tol = sqrt(eps(T)) * norm(gr)
+        # The eigenvalue-space tolerance here must equal the cluster tolerance
+        # in check_hard_case_candidate: both tests examine the same quantity,
+        # and unequal tolerances give contradictory classifications.
         norm2_lb = zero(T)
         first_nz = 1
         boundary_solution_exists = false
         for i = 1:n
             d = H_eig.values[i] + lambda_lb
-            if d <= null_tol
+            if d <= scale_tol
                 first_nz = i + 1
                 if abs(qg[i]) > gr_tol
                     boundary_solution_exists = true
@@ -235,14 +292,21 @@ function solve_tr_subproblem!(gr, H, delta, s; tolerance = 1e-10, max_iters = 5)
                 lambda_update = norm2_s * (sqrt(norm2_s) - delta) / (delta * dot(q_l, q_l))
                 lambda += lambda_update
 
-                # Check that lambda is not less than lambda_lb, and if so, go
-                # half the way to lambda_lb.
+                # Keep lambda inside the bracket [lambda_lb, lambda_ub]: a
+                # boundary root, when it exists, lies in it, so an iterate
+                # outside is an overshoot; go half the way back to the bound.
                 if lambda < lambda_lb
                     lambda = (lambda_previous + lambda_lb) / 2
+                elseif lambda > lambda_ub
+                    lambda = (lambda_previous + lambda_ub) / 2
                 end
 
-                if abs(lambda - lambda_previous) < tolerance
-                    reached_solution = true
+                if abs(lambda - lambda_previous) < lambda_tol
+                    # The lambda iterates have stopped moving. That means the
+                    # boundary root was found only if the step in hand actually
+                    # sits on the boundary; the same test also triggers on
+                    # safeguard stagnation at a bound, where the step does not.
+                    reached_solution = abs(sqrt(norm2_s) - delta) <= cbrt(eps(T)) * delta
                     break
                 end
             end

--- a/test/multivariate/solvers/second_order/newton_trust_region.jl
+++ b/test/multivariate/solvers/second_order/newton_trust_region.jl
@@ -86,30 +86,30 @@ Random.seed!(3288)
 
         # Test the checking
         hard_case, lambda_index =
-            Optim.check_hard_case_candidate([-1.0, 2.0, 3.0], [0.0, 1.0, 1.0])
+            Optim.check_hard_case_candidate([-1.0, 2.0, 3.0], [0.0, 1.0, 1.0], sqrt(eps()), sqrt(eps()))
         @test hard_case
         @test lambda_index == 2
 
         hard_case, lambda_index =
-            Optim.check_hard_case_candidate([-1.0, -1.0, 3.0], [0.0, 0.0, 1.0])
+            Optim.check_hard_case_candidate([-1.0, -1.0, 3.0], [0.0, 0.0, 1.0], sqrt(eps()), sqrt(eps()))
         @test hard_case
         @test lambda_index == 3
 
         hard_case, lambda_index =
-            Optim.check_hard_case_candidate([-1.0, -1.0, -1.0], [0.0, 0.0, 0.0])
+            Optim.check_hard_case_candidate([-1.0, -1.0, -1.0], [0.0, 0.0, 0.0], sqrt(eps()), sqrt(eps()))
         @test hard_case
         @test lambda_index == 4
 
         hard_case, lambda_index =
-            Optim.check_hard_case_candidate([1.0, 2.0, 3.0], [0.0, 1.0, 1.0])
+            Optim.check_hard_case_candidate([1.0, 2.0, 3.0], [0.0, 1.0, 1.0], sqrt(eps()), sqrt(eps()))
         @test !hard_case
 
         hard_case, lambda_index =
-            Optim.check_hard_case_candidate([-1.0, -1.0, -1.0], [0.0, 0.0, 1.0])
+            Optim.check_hard_case_candidate([-1.0, -1.0, -1.0], [0.0, 0.0, 1.0], sqrt(eps()), sqrt(eps()))
         @test !hard_case
 
         hard_case, lambda_index =
-            Optim.check_hard_case_candidate([-1.0, 2.0, 3.0], [1.0, 1.0, 1.0])
+            Optim.check_hard_case_candidate([-1.0, 2.0, 3.0], [1.0, 1.0, 1.0], sqrt(eps()), sqrt(eps()))
         @test !hard_case
 
         # Now check an actual hard case problem
@@ -317,13 +317,72 @@ Random.seed!(3288)
         @test !reached
         @test all(iszero, s)
     end
-    @testset "non-finite Hessian leaves a well-defined zero step" begin
-        H = [1.0 0.0; 0.0 NaN]
-        g = [1.0, 1.0]
+    @testset "zero Hessian returns the exact linear-model solution" begin
+        H = zeros(2, 2)
+        g = [3.0, 4.0]
+        s = fill(NaN, 2)
+        m, interior, λ, hard_case, reached = Optim.solve_tr_subproblem!(g, H, 2.0, s)
+        @test reached
+        @test !interior
+        @test s ≈ [-1.2, -1.6]        # -delta * g / ‖g‖
+        @test m ≈ -10.0               # -delta * ‖g‖
+        @test λ ≈ 2.5                 # ‖g‖ / delta
+
+        s = fill(NaN, 2)
+        m, interior, λ, hard_case, reached =
+            Optim.solve_tr_subproblem!(zeros(2), H, 2.0, s)
+        @test reached
+        @test interior
+        @test all(iszero, s)
+        @test iszero(m)
+    end
+
+    @testset "zero gradient with an indefinite Hessian is the hard case" begin
+        H = Matrix(Diagonal([-2.0, 1.0]))
+        g = zeros(2)
         s = fill(NaN, 2)
         m, interior, λ, hard_case, reached = Optim.solve_tr_subproblem!(g, H, 1.0, s)
-        @test m == Inf
-        @test !reached
-        @test all(iszero, s)
+        @test hard_case
+        @test reached
+        @test abs(norm(s) - 1.0) < 1e-12   # step to the boundary along v₁
+        @test m ≈ -1.0                     # 0.5 * λ_min * delta²
+    end
+
+    @testset "scaled and Float32 subproblems" begin
+        # The classification must be invariant under H -> c*H, g -> c*g.
+        H0 = [2.0 0.0; 0.0 1e-4]
+        g0 = [1.0, 1.0]
+        for c in (1e-6, 1e6)
+            s = fill(NaN, 2)
+            m, interior, λ, hard_case, reached =
+                Optim.solve_tr_subproblem!(c .* g0, c .* H0, 1.0, s)
+            s0 = fill(NaN, 2)
+            m0, interior0, _, _, reached0 =
+                Optim.solve_tr_subproblem!(g0, H0, 1.0, s0)
+            @test interior == interior0
+            @test reached == reached0
+            @test s ≈ s0 atol = 1e-8
+            @test m ≈ c * m0 rtol = 1e-8
+        end
+
+        H32 = Float32[2.0 0.0; 0.0 3.0]
+        g32 = Float32[1.0, 1.0]
+        s32 = zeros(Float32, 2)
+        m32, interior32, λ32, hard32, reached32 =
+            Optim.solve_tr_subproblem!(g32, H32, 5.0f0, s32)
+        @test m32 isa Float32
+        @test λ32 isa Float32
+        @test reached32
+        @test interior32
+        @test s32 ≈ Float32[-0.5, -1/3]
+
+        # A Float32 boundary solve must be able to report convergence: the
+        # historical absolute tolerance of 1e-10 sat below eps(Float32).
+        s32 = zeros(Float32, 2)
+        m32, interior32, λ32, hard32, reached32 =
+            Optim.solve_tr_subproblem!(g32, H32, 0.1f0, s32, max_iters = 100)
+        @test !interior32
+        @test reached32
+        @test abs(norm(s32) - 0.1f0) < 1e-5
     end
 end


### PR DESCRIPTION
Stacked on #1276 (base is that branch; retarget to master after it merges).

`solve_tr_subproblem!` carried four absolute Float64 constants: `1e-8` (PD gate), `1e-10` twice in `check_hard_case_candidate` (eigenvalue cluster, gradient component), and `1e-10` (root-finding tolerance). All were wrong off unit scale, unreachable in Float32, and precision-capping for BigFloat. They become relative and typed:

- **PD gate**: `min_H_ev > sqrt(eps(T)) * H_scale`, a condition-number test, matching the ridge scale the Cholesky retry already uses.
- **Cluster test**: the same `sqrt(eps(T)) * H_scale`, kept equal to the near-null tolerance in #1276's interior classification: the two tests examine the same quantity, and unequal tolerances give contradictory classifications.
- **Hard-case gradient test**: a component counts as zero below the gradient noise floor `sqrt(eps)·‖g‖`, or below `sqrt(eps)·H_scale·delta`, the resolution limit of the boundary-root offset it induces (past it, the ridged solves cannot beat the hard-case step). The conditioning floor applies only to hard-case candidacy (`min_H_ev < 0`); the interior classification computes its step in the eigenbasis, where such components are resolvable and must not be dropped (using it there sent Paraboloid Diagonal to a spurious minimum, which is how that boundary was found).
- **λ bracket**: iterates confined to `[lambda_lb, lambda_ub]` with the upper bound `‖g‖/delta − min_H_ev` (Geyer's `lambda_up` from the R `trust` vignette); overshoots halve back toward the violated bound, and `lambda_lb` is clamped at zero so λ can no longer go negative for near-PD Hessians.
- **Root-finding tolerance**: default `eps(T)^(2/3)` times the bracket width, reproducing the historical 1e-10 at unit scale in Float64; passing a `Real` still overrides.
- **Honest `reached_solution`**: on the root-finding path it now requires the step to sit on the boundary (residual within `cbrt(eps(T))·delta`), not merely that the λ iterates stopped moving; safeguard stagnation at a bound satisfies the increment test with an infeasible step (that is how a norm-1542 step once reported `reached = true`).
- **`H == 0`** returns the exact linear-model answer (boundary Cauchy point, or the origin for zero gradient) instead of hanging with `s` unassigned.

## Validation (same battery on the pre-change code for comparison)

| Sweep | before | after |
|---|---|---|
| Subproblems I/II + PSD sweeps | 0 fails | 0 fails |
| scaled  (10k matrices) | 3392 fails, 84% reached | **0 fails, 100% reached** |
| scaled, all other 8 (cH, cg) pairs | 0-11 fails | 0-26 fails (hairline, at the sweep's slack) |
| Float32 (10k) | 8 fails, 81% reached | **0 fails, 99.97% reached** |
| near-hard-case, gap 1e-8 / 1e-10 | **27683 / 22230 fails** of 50k | 0 / 0 |
| BigFloat boundary solve | capped at 1e-10 | reached to 1e-65 |

Plus the full NewtonTrustRegion test file (210,310 assertions) including `run_optim_tests`. New tests: zero Hessian (exact linear-model answers), zero gradient with indefinite H (hard-case boundary step, `m = lambda_min*delta^2/2`), scale-invariance of the classification under `H, g -> c*H, c*g`, and Float32 solves that return typed results and can report convergence. The sweep script is committed to the handoff materials as `verify_sweeps_scaled.jl`, companion to the existing `verify_sweeps.jl`.

This PR was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
