### PR TITLE
docs: document accelerated first-order methods

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -54,6 +54,7 @@ makedocs(
                 "Adam and AdaMax" => "algo/adam_adamax.md",
                 "Conjugate Gradient" => "algo/cg.md",
                 "Gradient Descent" => "algo/gradientdescent.md",
+                "Accelerated and Momentum Gradient Descent" => "algo/accelerated_gradient_descent.md",
                 "(L-)BFGS" => "algo/lbfgs.md",
                 "L-BFGS-B (box constrained)" => "algo/lbfgsb.md",
                 "Acceleration" => "algo/ngmres.md",

--- a/docs/src/algo/accelerated_gradient_descent.md
+++ b/docs/src/algo/accelerated_gradient_descent.md
@@ -1,0 +1,10 @@
+# Accelerated and Momentum Gradient Descent
+
+`AcceleratedGradientDescent` and `MomentumGradientDescent` are first-order methods for
+unconstrained objectives with an available gradient. Both use a line search and accept
+the same `alphaguess`, `linesearch`, and `manifold` keyword arguments.
+
+```@docs
+AcceleratedGradientDescent
+MomentumGradientDescent
+```

--- a/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/accelerated_gradient_descent.jl
@@ -14,6 +14,36 @@ end
 
 Base.summary(io::IO, ::AcceleratedGradientDescent) = print(io, "Accelerated Gradient Descent")
 
+"""
+    AcceleratedGradientDescent(; alphaguess = LineSearches.InitialPrevious(),
+        linesearch = LineSearches.HagerZhang(), manifold = Flat())
+
+Construct a first-order optimizer using Nesterov-style accelerated gradient descent.
+The method takes a line-search step from an extrapolated iterate and updates that iterate
+from the current and previous accepted points. Use it with `optimize` on an unconstrained
+objective for which a gradient is available.
+
+# Arguments
+- `alphaguess`: Initial step-length strategy. A `Real` is converted to a static initial
+  step length; otherwise it must be compatible with `LineSearches`.
+- `linesearch`: Line-search method used to choose each step length.
+- `manifold`: Manifold on which iterates are retracted and gradients are projected.
+  The default, `Flat()`, solves an unconstrained Euclidean problem.
+
+# Example
+```julia
+julia> using Optim
+
+julia> f(x) = sum(abs2, x);
+
+julia> g!(storage, x) = (storage .= 2 .* x);
+
+julia> result = optimize(f, g!, [1.0, -1.0], AcceleratedGradientDescent());
+
+julia> Optim.converged(result)
+true
+```
+"""
 function AcceleratedGradientDescent(;
     alphaguess = LineSearches.InitialPrevious(), # TODO: investigate good defaults
     linesearch = LineSearches.HagerZhang(),        # TODO: investigate good defaults

--- a/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
+++ b/src/multivariate/solvers/first_order/momentum_gradient_descent.jl
@@ -10,6 +10,39 @@ end
 
 Base.summary(io::IO, ::MomentumGradientDescent) = print(io, "Momentum Gradient Descent")
 
+"""
+    MomentumGradientDescent(; mu = 0.01,
+        alphaguess = LineSearches.InitialPrevious(),
+        linesearch = LineSearches.HagerZhang(), manifold = Flat())
+
+Construct a first-order optimizer that adds a momentum term to each gradient-descent
+step. The next iterate combines the negative gradient with the displacement between the
+two previous accepted iterates. Use it with `optimize` on an unconstrained objective for
+which a gradient is available.
+
+# Arguments
+- `mu`: Momentum coefficient. `mu = 0` removes the momentum contribution and yields
+  line-search gradient descent.
+- `alphaguess`: Initial step-length strategy. A `Real` is converted to a static initial
+  step length; otherwise it must be compatible with `LineSearches`.
+- `linesearch`: Line-search method used to choose each step length.
+- `manifold`: Manifold on which iterates are retracted and gradients are projected.
+  The default, `Flat()`, solves an unconstrained Euclidean problem.
+
+# Example
+```julia
+julia> using Optim
+
+julia> f(x) = sum(abs2, x);
+
+julia> g!(storage, x) = (storage .= 2 .* x);
+
+julia> result = optimize(f, g!, [1.0, -1.0], MomentumGradientDescent(mu = 0.1));
+
+julia> Optim.converged(result)
+true
+```
+"""
 function MomentumGradientDescent(;
     mu::Real = 0.01,
     alphaguess = LineSearches.InitialPrevious(), # TODO: investigate good defaults

--- a/test/general/api.jl
+++ b/test/general/api.jl
@@ -4,6 +4,14 @@
     @test Optim.minimum !== minimum
     @test Optim.maximum !== maximum
 
+    @testset "first-order optimizer documentation" begin
+        for optimizer in (AcceleratedGradientDescent, MomentumGradientDescent)
+            binding = Base.Docs.Binding(Optim, Symbol(optimizer))
+            @test haskey(Base.Docs.meta(Optim), binding)
+            @test occursin(string(optimizer), sprint(show, Base.Docs.meta(Optim)[binding]))
+        end
+    end
+
     rosenbrock = MultivariateProblems.UnconstrainedProblems.examples["Rosenbrock"]
     f = MVP.objective(rosenbrock)
     g! = MVP.gradient(rosenbrock)


### PR DESCRIPTION
Adds SciMLStyle constructor documentation at the original definitions of `AcceleratedGradientDescent` and `MomentumGradientDescent`, plus a rendered algorithm reference page. The new API test requires both owner doc bindings, so the public doc contract is covered at its source.

Please ignore this PR until reviewed by @ChrisRackauckas.

## Verification

- Before this change, the new binding check fails on `0842dbc7`: `Test Failed at none:1` for `haskey(Base.Docs.meta(Optim), binding)`.
- After this change, the same binding assertions and representative `optimize` calls passed locally.
- `julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` passed: `213571` pass, `88` broken, `213659` total, zero failures.\n- `git diff --check` and `typos` over the changed files passed.\n- `julia --startup-file=no --project=docs docs/make.jl` remains red on generated-notebook links (`ipnewton_basics.md`, `maxlikenlm.md`, and `rasch.md`). The same failure was reproduced on an untouched `master` worktree; this PR adds no docs-build diagnostic.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nhttps://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791