### PR TITLE
Take the line search's alpha = 0 slope from the objective's JVP

### DIFF
--- a/src/utilities/perform_linesearch.jl
+++ b/src/utilities/perform_linesearch.jl
@@ -37,11 +37,12 @@ function reset_search_direction!(state::ConjugateGradientState, ::ConjugateGradi
 end
 
 function perform_linesearch!(state, method, d)
-    # Calculate search direction dphi0
-    dphi_0 = real(dot(state.g_x, state.s))
+    # The line search takes every later slope from `value_jvp!`, so take the one at
+    # alpha = 0 from the objective's JVP too.
+    dphi_0 = real(NLSolversBase.jvp!(d, state.x, state.s))
     # reset the direction if it becomes corrupted
     if dphi_0 >= zero(dphi_0) && reset_search_direction!(state, method)
-        dphi_0 = real(dot(state.g_x, state.s)) # update after direction reset
+        dphi_0 = real(NLSolversBase.jvp!(d, state.x, state.s)) # update after direction reset
     end
     phi_0 = state.f_x
 
@@ -76,7 +77,7 @@ function perform_linesearch!(state, method, d)
 
     # On failure, reset the search direction and retry once
     if !lssuccess && reset_search_direction!(state, method)
-        dphi_0 = real(dot(state.g_x, state.s))
+        dphi_0 = real(NLSolversBase.jvp!(d, state.x, state.s))
         method.alphaguess!(method.linesearch!, state, phi_0, dphi_0, d)
         lssuccess = try
             state.alpha, ϕalpha =

--- a/test/multivariate/linesearch_handoff.jl
+++ b/test/multivariate/linesearch_handoff.jl
@@ -1,3 +1,28 @@
+# `dphi_0` has to be the slope the line search samples itself. `fjvp` here is the gradient
+# version off by one ulp, so the two routes are distinguishable without either being wrong.
+@testset "dphi_0 comes from the objective's JVP" begin
+    fdf(F, G, x) = (G === nothing || (G .= 2 .* x); sum(abs2, x))
+    fjvp(F, JVP, x, v) = (sum(abs2, x), nextfloat(dot(2 .* x, v)))
+
+    x0 = [1.0, -2.0]
+    d = OnceDifferentiable(NLSolversBase.InplaceObjective(; fdf, fjvp), x0)
+
+    calls = Ref(0)
+    linesearch = function (df, x, s, α, x_new, phi_0, dphi_0)
+        calls[] += 1
+        @test dphi_0 == last(LineSearches.make_ϕdϕ(df, x_new, x, s)(zero(α)))
+        @test dphi_0 == NLSolversBase.jvp!(df, x, s)
+        @test dphi_0 != dot(NLSolversBase.gradient!(df, x), s)
+        x_new .= x .+ α .* s
+        return α, phi_0
+    end
+
+    method = BFGS(; linesearch)
+    state = Optim.initial_state(method, Optim.Options(), d, copy(x0))
+    Optim.update_state!(d, state, method)
+    @test calls[] == 1
+end
+
 @testset "Line search hand-off" begin
     # `update_state!` must propose the point the line search vetted, so that `update_fgh!`
     # evaluates where the value is already cached and `accept_step!` checks the finiteness


### PR DESCRIPTION
Fixes #1284.

## The problem

`perform_linesearch!` computed the slope at `alpha = 0` as `dot(state.g_x, state.s)`, but the `ϕdϕ` it hands the line search takes every later slope from `NLSolversBase.value_jvp!`, which dispatches to the objective's own JVP when it has one. For an objective built with both — `OnceDifferentiable(InplaceObjective(; fdf, fjvp), x)` — the two ends of the line search were then on two independent implementations of one directional derivative.

Those diverge in *relative* terms near a stationary point, because `dot(g, s)` cancels across the components where a pushforward does not. Measured on a 16-parameter marginal likelihood under `BFGS(linesearch = HagerZhang(rho = 2.0), initial_stepnorm = 1.0)`, with the unconditional `gradient!!` / `jvp!!` so nothing is a cache hit:

| | |
| --- | --- |
| `jvp!!` twice at the same `x` | identical, 47/47 |
| `gradient!!` twice at the same `x` | identical, 47/47 |
| `dphi_0` vs `dot(gradient!!(obj, x), s)` | identical, 47/47 |
| `dot(gradient!!(obj, x), s)` vs `jvp!!(obj, x, s)` | differs, 47/47 — up to 20.4 % relative |

Each route is reproducible to the bit and the old `dphi_0` matched a forced fresh gradient contraction exactly, so this is not staleness or noise — only the two implementations disagreeing, worst exactly where the line search is most delicate. Far enough into convergence they can differ in sign, which is what broke a bracket invariant in HagerZhang (JuliaNLSolvers/LineSearches.jl#211, fixed in 7.8.1).

## The change

Take `dphi_0` from `NLSolversBase.jvp!`, so the whole line search sits on one derivative implementation.

`jvp!` rather than `value_jvp!`: `value_jvp!` would also compute and store a value we already have in `state.f_x`, and for an `InplaceObjective` both are built from the same `fjvp` closure (`make_jvp` passes `nothing` for the value, `make_fjvp` does not), so `jvp!` is the cheaper of the two on the same route.

Behaviour elsewhere:

- **No JVP of its own.** `jvp!!` falls through to `jacobian!` plus `dot(DF, v)` — the previous expression. `jacobian!` hits the gradient `update_fgh!` already cached whenever `state.x` is the last point evaluated, which is the common path; the exception is the post-failure retry, where the last evaluation was a trial point.
- **`ManifoldObjective`.** Already defines `jvp!` as the projected `dot(g, v)` (`Manifolds.jl:50-55`), with `Flat` forwarding to the inner objective, so non-`Flat` manifolds are unchanged and `Flat` picks up the inner objective's JVP.
- **`BarrierWrapper`.** Defines its own `jvp!` (`fminbox.jl:125`), so `Fminbox` is covered.

The two other `dot(state.g_x, state.s)` sites in the same function (after a direction reset, and on the failure retry) move with it, or they would reintroduce the mismatch on exactly the paths where the line search is already struggling.

## Test

`test/multivariate/linesearch_handoff.jl` gains a testset with an `fjvp` that returns the gradient-route slope off by **one ulp** — what an independent implementation actually looks like, so the two routes are exactly distinguishable without either being wrong, and no convergence behaviour depends on it. A recording line search then checks, on the point it is called with, that `dphi_0`:

- equals `last(LineSearches.make_ϕdϕ(df, x_new, x, s)(0))` — the slope this line search itself samples;
- equals `NLSolversBase.jvp!(df, x, s)`;
- does **not** equal `dot(NLSolversBase.gradient!(df, x), s)`.

The third keeps the testset from passing vacuously if the routes ever coincide. On master all three fail (`-20.0` against `-19.999999999999996`, and the inequality holds as an equality).

---

*This pull request was written with the assistance of generative AI.*
